### PR TITLE
Limit the number of results we can display in the results table.

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -1,5 +1,7 @@
 ALLOWED_TRUE_BOOLEANS = ["y", "t", "1"]
 HEATMAP_MAX_BUILDS = 40  # max for number of builds that are possible to display in heatmap
+COUNT_TIMEOUT = 0.5  # timeout for counting the number of documents [s]
+MAX_DOCUMENTS = 100000  # max documents for pagination, when apply_max=True
 WIDGET_TYPES = {
     "jenkins-heatmap": {
         "id": "jenkins-heatmap",

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -72,6 +72,13 @@ paths:
             type: string
           type: array
         style: form
+      - description: Use a max to limit documents returned
+        in: query
+        name: apply_max
+        required: false
+        schema:
+          type: boolean
+        style: form
       - $ref: '#/components/parameters/Page'
       - $ref: '#/components/parameters/PageSize'
       responses:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -12,6 +12,7 @@ REQUIRES = [
     "connexion",
     "dynaconf",
     "flask_cors",
+    "func-timeout",
     "gunicorn",
     "lxml",
     "pymongo",

--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   Card,
   CardBody,
+  CardFooter,
   PageSection,
   PageSectionVariants,
   Select,
@@ -336,6 +337,9 @@ export class ResultList extends React.Component {
     else if (Object.prototype.hasOwnProperty.call(filters, 'metadata.project')) {
       delete filters['metadata.project']
     }
+    if (filters) {
+      params['apply_max'] = true;  // if filters are applied limit the documents returned
+    }
     params['pageSize'] = this.state.pageSize;
     params['page'] = this.state.page;
     // Convert UI filters to API filters
@@ -524,6 +528,12 @@ export class ResultList extends React.Component {
                 onSetPageSize={this.setPageSize}
               />
             </CardBody>
+            <CardFooter>
+              <Text className="disclaimer" component="h4">
+                * Note: due to the number of results, when filters are applied, the results returned are limited to a max value.
+                Use the API if you need an accurate count.
+              </Text>
+            </CardFooter>
           </Card>
         </PageSection>
       </React.Fragment>

--- a/frontend/src/run-list.js
+++ b/frontend/src/run-list.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  Badge,
   Card,
   CardBody,
   PageSection,
@@ -95,7 +94,7 @@ function runToRow(run, filterFunc) {
   }
   badges.push(badge);
   badges.push(' ');
-  
+
   if (run.metadata && run.metadata.env) {
     let badge;
     if (filterFunc) {
@@ -290,7 +289,7 @@ export class RunList extends React.Component {
       });
     });
   }
-  
+
 
   removeFilter = id => {
     this.updateFilters(id, null, null, () => {


### PR DESCRIPTION
This is attempting to address #6. 

This PR does the following: 
* Adds a timeout for the `mongo.results.count` query
* Adds a parameter `apply_max` (default: `False`), that limits the documents that are returned to a constant `MAX_DOCUMENTS` if `mongo.results.count` times out
* Sets `apply_max=True` in the FE when a filter is applied on the Results table

An unfortunate side effect of this approach is that sometimes the `count` takes a long time BUT there are actually _less_ documents than `MAX_DOCUMENTS`.

For example, say you are filtering by a component when you also have a project applied, the count will take a long time, but there might only be a few thousand records that match your filter. In the approach followed in this PR, query will return a `total_items` of `MAX_DOCUMENTS`. Of course this is inaccurate, since there are actually many less documents.

As the run collection grows, something similar might have to be done there as well.

**Note:** to test this locally, you will need to have a lot of results in your DB, I recommend restoring from a `prod` backup.