### PR TITLE
Limit documents for reports

### DIFF
--- a/frontend/src/report-builder.js
+++ b/frontend/src/report-builder.js
@@ -6,6 +6,7 @@ import {
   Button,
   Card,
   CardBody,
+  CardFooter,
   ExpandableSection,
   Form,
   FormGroup,
@@ -262,6 +263,11 @@ export class ReportBuilder extends React.Component {
                 </ActionGroup>
               </Form>
             </CardBody>
+            <CardFooter>
+              <Text className="disclaimer" component="h4">
+                * Note: Reports can only show a maximum of 1,000,000 results.
+              </Text>
+            </CardFooter>
           </Card>
         </PageSection>
         <PageSection>


### PR DESCRIPTION
Reports will sometimes run endlessly because they are not filtered. The server tries to poll ALL the result objects, meaning that the mongo container will run out of memory and crash. 

To avoid this, we should implement an upper limit on the amount of documents returned by reports, which I've set to 1 million in this PR (1e5 might be more reasonable though, thoughts @rsnyman?). 

