### PR TITLE
Make links open in new tab

### DIFF
--- a/frontend/src/components/decorators.js
+++ b/frontend/src/components/decorators.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// decorator for making Linkify links open in a new tab
+export const linkifyDecorator = (href, text, key) => (
+  <a href={href} key={key} target="_blank" rel="noopener noreferrer">
+      {text}
+  </a>
+);

--- a/frontend/src/components/result.js
+++ b/frontend/src/components/result.js
@@ -24,6 +24,7 @@ import ReactJson from 'react-json-view';
 import Editor from '@monaco-editor/react';
 
 import { ClassificationDropdown } from './classification-dropdown';
+import { linkifyDecorator } from './decorators'
 import { Settings } from '../settings';
 import { buildUrl, getIconForResult, round } from '../utilities';
 import { TabTitle } from './tabs';
@@ -227,7 +228,7 @@ export class ResultView extends React.Component {
                       <DataListItemCells
                         dataListCells={[
                           <DataListCell key="skip-reason-label" width={2}><strong>Reason skipped:</strong></DataListCell>,
-                          <DataListCell key="skip-reason-data" width={4}><Linkify>{testResult.metadata.skip_reason}</Linkify></DataListCell>
+                          <DataListCell key="skip-reason-data" width={4}><Linkify componentDecorator={linkifyDecorator}>{testResult.metadata.skip_reason}</Linkify></DataListCell>
                         ]}
                       />
                     </DataListItemRow>

--- a/frontend/src/views/jenkinsjob.js
+++ b/frontend/src/views/jenkinsjob.js
@@ -32,7 +32,7 @@ function jobToRow(job, analysisViewId) {
   return {
     cells: [
       analysisViewId ? {title: <Link to={`/view/${analysisViewId}?job_name=${job.job_name}`}>{job.job_name}</Link>} : job.job_name,
-      {title: <a href={job.build_url}>{job.build_number}</a>},
+      {title: <a href={job.build_url} target="_blank" rel="noreferrer">{job.build_number}</a>},
       {title: <RunSummary summary={job.summary} />},
       job.source,
       job.env,


### PR DESCRIPTION
Making the `build_number` and JIRA links open in a new tab. 

For linkify, I followed https://github.com/tasti/react-linkify/pull/51#issuecomment-585207861