### PR TITLE
Fix warnings for links, limit reports to 1e6 documents

### DIFF
--- a/backend/ibutsu_server/tasks/reports.py
+++ b/backend/ibutsu_server/tasks/reports.py
@@ -31,7 +31,7 @@ FAILURE_PERC_WARN = 0.2  # % of tests failing to be warning level
 FAILURE_PERC_DANGER = 0.4
 
 REPORT_COUNT_TIMEOUT = 2.0  # timeout for counting documents in report
-REPORT_MAX_DOCUMENTS = 1000000  # max documents for reports
+REPORT_MAX_DOCUMENTS = 100000  # max documents for reports
 
 
 def _generate_report_name(report_parameters):

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -338,11 +338,11 @@ class App extends React.Component {
                 <TextListItem component="dt">Version</TextListItem>
                 <TextListItem component="dd">{this.version}</TextListItem>
                 <TextListItem component="dt">Source code</TextListItem>
-                <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server" target="_blank" rel="noreferrer">github.com/ibutsu/ibutsu-server</a></TextListItem>
+                <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server" target="_blank" rel="noopener noreferrer">github.com/ibutsu/ibutsu-server</a></TextListItem>
                 <TextListItem component="dt">Documentation</TextListItem>
-                <TextListItem component="dd"><a href="https://docs.ibutsu-project.org/" target="_blank" rel="noreferrer">docs.ibutsu-project.org</a></TextListItem>
+                <TextListItem component="dd"><a href="https://docs.ibutsu-project.org/" target="_blank" rel="noopener noreferrer">docs.ibutsu-project.org</a></TextListItem>
                 <TextListItem component="dt">Report bugs</TextListItem>
-                <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server/issues/new" target="_blank" rel="noreferrer">Submit an upstream issue</a></TextListItem>
+                <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server/issues/new" target="_blank" rel="noopener noreferrer">Submit an upstream issue</a></TextListItem>
               </TextList>
             </TextContent>
             <p style={{marginTop: 260}}>* Note: artifact files (screenshots, logs) are retained for 3 months</p>

--- a/frontend/src/report-builder.js
+++ b/frontend/src/report-builder.js
@@ -265,7 +265,7 @@ export class ReportBuilder extends React.Component {
             </CardBody>
             <CardFooter>
               <Text className="disclaimer" component="h4">
-                * Note: Reports can only show a maximum of 1,000,000 results.
+                * Note: reports can only show a maximum of 100,000 results.
               </Text>
             </CardFooter>
           </Card>

--- a/frontend/src/views/jenkinsjob.js
+++ b/frontend/src/views/jenkinsjob.js
@@ -32,7 +32,7 @@ function jobToRow(job, analysisViewId) {
   return {
     cells: [
       analysisViewId ? {title: <Link to={`/view/${analysisViewId}?job_name=${job.job_name}`}>{job.job_name}</Link>} : job.job_name,
-      {title: <a href={job.build_url} target="_blank" rel="noreferrer">{job.build_number}</a>},
+      {title: <a href={job.build_url} target="_blank" rel="noopener noreferrer">{job.build_number}</a>},
       {title: <RunSummary summary={job.summary} />},
       job.source,
       job.env,


### PR DESCRIPTION
* Fixing a compilation warning for not having `noopener` in the `rel` for links. 
* Limiting reports to 1e5 documents

The latter comes from some investigation locally, running (unfiltered) `html` reports with different values for the max documents. I limited my local mongo container to 1 GiB of memory and 1 CPU. 

| REPORT_MAX_DOCUMENTS | Runtime (s) | Approx File Size of Report | Report type |
| ------------- | ------------- | ------------- | ------------- |
| 100,000  | 80 | 250 MB | HTML |
| 200,000  | 200 | 500 MB | HTML |
| 1,000,000 | 800 | 2.5 GB | HTML |
| 100,000 | 20 | 21 MB | TEXT |
| 1,000,000 | 80 | 107 MB | TEXT |

Clearly 1e6 is too high for a realistic report. 1e5 seems okay but even then the file size is pretty high. We will need to start doing cleanup of report files if people start actually using them. @rsnyman do you think we should limit it to something even lower (5e4 ?)

Clearly, the file size is dependent on the type of report that is run (i.e. text reports will be much smaller than html reports). Therefore, we should place report-type specific limits on the MAX_DOCUMENTS. However, we need more data (extend the table presented here for more report types) to decide on these limits. For now, I think it's OK to apply a global limit.