### PR TITLE
Add a switch to change overall health bar chart to area chart

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -2,6 +2,7 @@ ALLOWED_TRUE_BOOLEANS = ["y", "t", "1"]
 HEATMAP_MAX_BUILDS = 40  # max for number of builds that are possible to display in heatmap
 COUNT_TIMEOUT = 0.5  # timeout for counting the number of documents [s]
 MAX_DOCUMENTS = 100000  # max documents for pagination, when apply_max=True
+JJV_RUN_LIMIT = 8000  # max runs from which to aggregate Jenkins Jobs
 WIDGET_TYPES = {
     "jenkins-heatmap": {
         "id": "jenkins-heatmap",
@@ -98,6 +99,11 @@ WIDGET_TYPES = {
             {
                 "name": "page_size",
                 "description": "Number of builds on each page",
+                "type": "integer",
+            },
+            {
+                "name": "run_limit",
+                "description": "Limit on runs from which to aggregate jenkins jobs",
                 "type": "integer",
             },
         ],


### PR DESCRIPTION
Adding a switch to change the "Overall Health" chart from bar chart to area line chart. 

I couldn't get the tooltips to work, I think because of this bug: 
https://github.com/FormidableLabs/victory/issues/1608

So I added a prop to hide them. I don't know why they work in the duration chart but not this one. @rsnyman can you help with the styling of that switch? 

This PR also makes the widget load on tab select rather than loading them all at once.  

Screenshot:
![Screenshot from 2020-07-21 11-30-05](https://user-images.githubusercontent.com/44065123/88074546-8dc68100-cb45-11ea-9f26-6ec909417970.png)


**Note** this depends on #17, so we should review/merge that one before this one. 