### PR TITLE
Version 1.10.0

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 1.9.0
+  version: 1.10.0
 servers:
 - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "1.9.0"
+VERSION = "1.10.0"
 REQUIRES = [
     # Pin Celery to be compatible with Kombu
     "celery==4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "dependencies": {
     "@babel/helper-call-delegate": "^7.8.7",


### PR DESCRIPTION
```
* Add a switch to change from overall health from bar to area chart
* Show active filters and make exception name clickable in failure classification table
* Apply a limit to the amount of runs from which we create the JJV
* Make failure classification table expandable, to aid in debugging
* Add a tooltip to the generic area chart
* Fix warnings for links, limit reports to 1e6 documents
* Make links open in a new tab
* Add link to submit upstream issue, make links open in new tab
* Limit documents returned by reports to a reasonable number
* Add trademark and file retention policy to About modal
* Add a link to the docs on the about modal
* Limit the number of results we can display in the results table.
* Made run-list component and env pills clickable for filtering
* Update the rtd conf file location
* Fix the master_doc for Sphinx
* Make the docs requirements file match the config file
* Add readthedocs config
* Change Travis config to support both Python and JS
* Initial import
```