### PR TITLE
[Heatmap] Follow up to #27

### DIFF
--- a/backend/ibutsu_server/widgets/jenkins_heatmap.py
+++ b/backend/ibutsu_server/widgets/jenkins_heatmap.py
@@ -40,14 +40,19 @@ def _get_builds(job_name, builds, project=None):
         },
         {"$sort": {"start_time": DESCENDING}},
         {"$limit": HEATMAP_RUN_LIMIT},
-        {"$group": {"_id": "$metadata.jenkins.build_number"}},
-        {"$sort": {"_id": DESCENDING}},
+        {
+            "$group": {
+                "_id": "$metadata.jenkins.build_number",
+                "start_time": {"$min": "$start_time"},
+            }
+        },
+        {"$sort": {"start_time": DESCENDING}},
         {"$limit": builds},
     ]
     if project:
         aggregation[0]["$match"].update({"metadata.project": project})
     builds = list(mongo.runs.aggregate(aggregation))
-    return [str(build["_id"]) for build in builds]
+    return [build["_id"] for build in builds]
 
 
 def _get_heatmap(job_name, builds, group_field, count_skips, project=None):


### PR DESCRIPTION
This is a follow up PR to #27 to make it so that the heatmap only shows builds which actually exist in the DB. It uses an aggregation similar to the one used in the JJV to pull the most recent `x` builds from the DB. In so doing it removes the need for the `build_number` arg. 

Now the heatmap should always show the number of builds specified in `Set builds to:` parameter. @rsnyman can you do a bit of local testing here to make sure I didn't break anything?

Showing a similar image to the one shown in #27, you can see that the builds go all the way back to `284` now:
<img src="https://user-images.githubusercontent.com/44065123/89531637-8e564d00-d7be-11ea-9786-db66313b57ac.png" width="300">

