### PR TITLE
Version 1.10.1

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 1.10.0
+  version: 1.10.1
 servers:
 - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "1.10.0"
+VERSION = "1.10.1"
 REQUIRES = [
     # Pin Celery to be compatible with Kombu
     "celery==4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "dependencies": {
     "@babel/helper-call-delegate": "^7.8.7",


### PR DESCRIPTION
* Fix styling of count skips on Jenkins Job Analysis page (#29)
* [Heatmap] Sort builds by start_time, not the string build_number
* [Heatmap] Use an aggregation to get the correct number of jobs that exist in the DB
* [Heatmap] Don't show columns in which all the plugins failed
* Add link to JIRA issues.redhat.com
* Convert failure classification table into its own component
* Expose the count_skips parameter in the UI (#24)
* Check to make sure "start_time" exists
