### PR TITLE
Use apply_async and countdown=5 when updating run

### DIFF
--- a/backend/ibutsu_server/controllers/run_controller.py
+++ b/backend/ibutsu_server/controllers/run_controller.py
@@ -132,7 +132,7 @@ def update_run(id_, run=None):
     existing_run = mongo.runs.find_one({"_id": ObjectId(id_)})
     merge_dicts(existing_run, run)
     mongo.runs.replace_one({"_id": ObjectId(id_)}, run)
-    update_run_task.delay(id_)
+    update_run_task.apply_async((id_,), countdown=5)
     return serialize(run)
 
 

--- a/backend/ibutsu_server/test/test_run_controller.py
+++ b/backend/ibutsu_server/test/test_run_controller.py
@@ -117,5 +117,5 @@ class TestRunController(BaseTestCase):
             data=json.dumps(run),
             content_type="application/json",
         )
-        self.mock_update_run_task.delay.assert_called_once_with(MOCK_ID)
+        self.mock_update_run_task.apply_async.assert_called_once_with((MOCK_ID,), countdown=5)
         self.assert_200(response, "Response body is : " + response.data.decode("utf-8"))


### PR DESCRIPTION
This should fix https://issues.redhat.com/browse/IBUTSU-28. 

Since results are updated [asynchronously](https://github.com/ibutsu/pytest-ibutsu/blob/master/pytest_ibutsu.py#L489), occasionally I think that a result will update AFTER the run has been updated for the last time. This can cause the pass,fail,etc. values for the run to be inaccurate. 

Waiting 5 s before updating the run should give time for all the results to update before updating the run. 