### PR TITLE
Default to 3 retries for tasks, fix some small report bugs

### DIFF
--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -33,7 +33,7 @@ def _create_result(tar, run_id, result, artifacts):
     return old_id
 
 
-@task()
+@task
 def run_junit_import(import_):
     """Import a test run from a JUnit file"""
     # Update the status of the import
@@ -127,7 +127,7 @@ def run_junit_import(import_):
     mongo.imports.replace_one({"_id": ObjectId(import_["id"])}, import_)
 
 
-@task()
+@task
 def run_archive_import(import_):
     """Import a test run from an Ibutsu archive file"""
     # Update the status of the import

--- a/backend/ibutsu_server/tasks/queues.py
+++ b/backend/ibutsu_server/tasks/queues.py
@@ -8,9 +8,19 @@ from dynaconf import settings
 
 
 class IbutsuTask(Task):
-    # Globally override the maximum retries.
-    # This means the task will run for about 41 days and 22 hours
-    max_retries = 1000
+    """
+    Leave this class empty for now, may add global overrides in the future.
+
+    By default tasks will retry 3 times, if a task should retry more than 3 times
+    specify it at the task level.
+
+
+    @task(max_retries=<integer>)
+    def my_task():
+        pass
+    """
+
+    pass
 
 
 app = Celery(

--- a/backend/ibutsu_server/tasks/reports.py
+++ b/backend/ibutsu_server/tasks/reports.py
@@ -101,7 +101,8 @@ def _build_filters(report):
     filters = {}
     if report["parameters"].get("filter"):
         for f in report["parameters"]["filter"].split(","):
-            filters.update(generate_filter_object(f.strip()))
+            if f:
+                filters.update(generate_filter_object(f.strip()))
     if report["parameters"]["source"]:
         filters["source"] = {"$eq": report["parameters"]["source"]}
     if report["parameters"].get("project"):
@@ -206,7 +207,10 @@ def _make_dict(results):
     for result in results:
         result_path = _make_result_path(result)
         if result.get("duration") and result.get("start_time"):
-            finish_time = result["start_time"] + result["duration"]
+            try:
+                finish_time = float(result["start_time"]) + float(result["duration"])
+            except ValueError:
+                finish_time = None
         else:
             finish_time = None
         result_id = result.get("id") or str(result["_id"])

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -19,9 +19,9 @@ def _copy_result_metadata(result, metadata, key):
         metadata[key] = result["metadata"][key]
 
 
-@task
+@task(max_retries=1000)
 def update_run(run_id):
-    """Update the run summary from the results"""
+    """Update the run summary from the results, this task will retry 1000 times"""
     redis_client = Redis.from_url(settings["CELERY_BROKER_URL"])
     try:
         # Get a lock so that we don't run this task concurrently


### PR DESCRIPTION
We've been having issues with `html` reports failing and retrying indefinitely. This PR fixes up a couple of the exceptions that we've been seeing with those tasks. 

In addition, this PR changes the default `max_retries` for the task to 3 (which is celery's [default](https://docs.celeryproject.org/en/stable/userguide/tasks.html#Task.max_retries)). 

Going forward, I think we should specify tasks that should retry more than 3 times specifically (e.g. for the `update_run` task, I set `max_retries` to 1000). I can't think of a good reason why we should retry reports and the other tasks more than 3 times. @rsnyman is there a historical reason why we've defaulted to 1000 retries for all tasks? 