### PR TITLE
Convert result aggregator widget to postgres

### DIFF
--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -72,6 +72,11 @@ def convert_filter(filter_string, model):
         return column.in_(value)
     if oper == "~":
         return column.op("~")(value)
+    if oper == "@":
+        if value:
+            return column != None  # noqa
+        else:
+            return column == None  # noqa
     return None
 
 

--- a/backend/ibutsu_server/widgets/result_aggregator.py
+++ b/backend/ibutsu_server/widgets/result_aggregator.py
@@ -1,7 +1,11 @@
 import time
 from datetime import timedelta
 
-from ibutsu_server.mongo import mongo
+from ibutsu_server.db.base import session
+from ibutsu_server.db.models import Result
+from ibutsu_server.filters import convert_filter
+from sqlalchemy import desc
+from sqlalchemy import func
 
 
 def _get_min_count(days):
@@ -17,24 +21,35 @@ def _get_recent_result_data(days, group_field, project=None):
     delta = timedelta(days=days).total_seconds()
     current_time = time.time()
     time_period_in_sec = current_time - delta
-    # now do the aggregation based on the 'group_field'
-    # just count the number of tests for each entry of 'group_field'
-    pipeline = [
-        {
-            "$match": {
-                "start_time": {"$gte": time_period_in_sec},
-                f"{group_field}": {"$exists": "true", "$ne": "null"},
-            }
-        },
-        {"$unwind": f"${group_field}"},
-        {"$group": {"_id": f"${group_field}", "count": {"$sum": 1}}},
-        # so that too many results with minimal counts are not displayed,
-        {"$match": {"count": {"$gte": _get_min_count(days)}}},
-        {"$sort": {"count": -1}},
-    ]
+
+    # create filters for the start time and that the group_field exists
+    filters = [f"start_time>{time_period_in_sec}", f"{group_field}@y"]
     if project:
-        pipeline[0]["$match"]["metadata.project"] = {"$eq": project}
-    return list(mongo.results.aggregate(pipeline))
+        filters.append(f"metadata.project={project}")
+
+    # generate the group field
+    group_fields = group_field.split(".")
+    group_field = Result.data
+    for group in group_fields:
+        group_field = group_field[group]
+
+    # create the query
+    query = (
+        session.query(group_field, func.count(Result.id).label("count"))
+        .group_by(group_field)
+        .order_by(desc("count"))
+    )
+
+    # add filters to the query
+    for filter_string in filters:
+        filter_clause = convert_filter(filter_string, Result)
+        if filter_clause is not None:
+            query = query.filter(filter_clause)
+
+    query_data = query.all()
+    # parse the data for the frontend
+    data = [{"_id": _id, "count": count} for _id, count in query_data]
+    return data
 
 
 def get_recent_result_data(days, group_field, project=None, chart_type="pie"):


### PR DESCRIPTION
```
curl -X GET "http://localhost:8080/api/widget/result-aggregator?days=10&group_field=result" -H "accept: application/json"
```
Output:
```json
[
  {
    "_id": "passed",
    "count": 161
  },
  {
    "_id": "skipped",
    "count": 20
  },
  {
    "_id": "failed",
    "count": 10
  },
  {
    "_id": "error",
    "count": 7
  },
  {
    "_id": "xfailed",
    "count": 1
  }
]
```

Note that I didn't make use of `_get_min_count`, if this widget gets used, we can enable it then. 