### PR TITLE
Hotfix for jenkins heatmap issue

### DIFF
--- a/backend/ibutsu_server/widgets/jenkins_heatmap.py
+++ b/backend/ibutsu_server/widgets/jenkins_heatmap.py
@@ -78,7 +78,7 @@ def _get_heatmap(job_name, builds, group_field, count_skips, project=None):
 
     cursor = mongo.results.aggregate(aggregation)
 
-    runs = [run for run in cursor]
+    runs = [run for run in cursor if ObjectId.is_valid(str(run["_id"]))]
     run_to_build = {str(run["_id"]): run["build_number"] for run in runs}
     # Figure out the pass rates for each run
     fail_fields = ["$summary.errors", "$summary.failures"]

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -24,6 +24,7 @@ REQUIRES = [
     "swagger-ui-bundle==0.0.2",
     # Pin this for now, once other libraries are updated, drop this pin
     "werkzeug==0.16.1",
+    "vine<5.0.0a1",
 ]
 
 setup(


### PR DESCRIPTION
There are some UUID's populating the `metadata.run` field of some results in production ibutsu. 