### PR TITLE
Estimate counts in large tables by using rows returned from Explain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: reorder-python-imports
     language_version: python3
 - repo: https://github.com/ambv/black
-  rev: 19.10b0
+  rev: 20.8b1
   hooks:
   - id: black
     args: [--safe, --quiet, --line-length, "100"]
@@ -23,11 +23,11 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.8.4
   hooks:
   - id: flake8
     language_version: python3
-    args: [--max-line-length, "100", --ignore, "E203"]
+    args: [--max-line-length, "100", --ignore, "E203, W503"]
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.6.1
   hooks:

--- a/backend/ibutsu_server/db/util.py
+++ b/backend/ibutsu_server/db/util.py
@@ -1,0 +1,31 @@
+"""
+Various utility DB functions
+"""
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.expression import _literal_as_text
+from sqlalchemy.sql.expression import ClauseElement
+from sqlalchemy.sql.expression import Executable
+
+
+class Explain(Executable, ClauseElement):
+    """
+    EXPLAIN a SQLAlchemy query (only for PSQL)
+    e.g.
+        query = Run.query
+        session.execute(Explain(query)).fetchall()
+
+    cf. http://www.wmmi.net/documents/SQLAlchemy.pdf for more info
+    """
+
+    def __init__(self, stmt, analyze=False):
+        self.statement = _literal_as_text(stmt)
+        self.analyze = analyze
+
+
+@compiles(Explain, "postgresql")
+def pg_explain(element, compiler, **kw):
+    text = "EXPLAIN "
+    if element.analyze:
+        text += "ANALYZE "
+    text += compiler.process(element.statement)
+    return text

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -72,9 +72,9 @@ paths:
             type: string
           type: array
         style: form
-      - description: Use a max to limit documents returned
+      - description: Return an estimated count
         in: query
-        name: apply_max
+        name: estimate
         required: false
         schema:
           type: boolean
@@ -404,6 +404,13 @@ paths:
           items:
             type: string
           type: array
+        style: form
+      - description: Return an estimated count
+        in: query
+        name: estimate
+        required: false
+        schema:
+          type: boolean
         style: form
       - $ref: '#/components/parameters/Page'
       - $ref: '#/components/parameters/PageSize'

--- a/backend/ibutsu_server/util/count.py
+++ b/backend/ibutsu_server/util/count.py
@@ -1,0 +1,40 @@
+""" Utility functions for counting rows in large tables"""
+from contextlib import contextmanager
+
+from ibutsu_server.constants import COUNT_TIMEOUT
+from ibutsu_server.db.base import session
+from ibutsu_server.db.util import Explain
+
+
+def _get_count_from_explain(query):
+    explain_result = session.execute(Explain(query)).fetchall()[0][0]
+    rows = int(explain_result.split("rows")[-1].split("=")[1].split(" ")[0])
+    return rows
+
+
+def get_count_estimate(query, no_filter=False, **kwargs):
+    """
+    Given tablename, return an estimated count of the number of rows in the table.
+
+    Only valid when NO filters are applied
+    """
+    if no_filter:
+        tablename = kwargs.get("tablename")
+        sql = f"SELECT reltuples as approx_count FROM pg_class WHERE relname='{tablename}'"
+        return int(session.execute(sql).fetchall()[0][0])
+    else:
+        return _get_count_from_explain(query)
+
+
+@contextmanager
+def time_limited_db_operation(timeout=None):
+    """
+    Context manager for performing some time limited DB operation.
+
+    timeout: timeout for the operation in 's'
+    """
+    timeout = int(timeout * 1000) if timeout else int(COUNT_TIMEOUT * 1000)
+
+    session.execute(f"SET statement_timeout TO {timeout}; commit;")
+    yield
+    session.execute("SET statement_timeout TO 0; commit;")

--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -346,9 +346,7 @@ export class ResultList extends React.Component {
     else if (Object.prototype.hasOwnProperty.call(filters, 'project_id')) {
       delete filters['project_id']
     }
-    if (filters) {
-      params['apply_max'] = true;  // if filters are applied limit the documents returned
-    }
+    params['estimate'] = true;  // use a count estimate for this page
     params['pageSize'] = this.state.pageSize;
     params['page'] = this.state.page;
     // Convert UI filters to API filters
@@ -531,8 +529,8 @@ export class ResultList extends React.Component {
             </CardBody>
             <CardFooter>
               <Text className="disclaimer" component="h4">
-                * Note: due to the number of results, when filters are applied, the results returned are limited to a max value.
-                Use the API if you need an accurate count.
+                * Note: for performance reasons, the total number of items is an approximation.
+                Use the API with &lsquo;estimate=false&rsquo; if you need an accurate count.
               </Text>
             </CardFooter>
           </Card>

--- a/frontend/src/run-list.js
+++ b/frontend/src/run-list.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   Card,
   CardBody,
+  CardFooter,
   PageSection,
   PageSectionVariants,
   Select,
@@ -328,6 +329,7 @@ export class RunList extends React.Component {
     else if (Object.prototype.hasOwnProperty.call(filters, 'project_id')) {
       delete filters['project_id']
     }
+    params['estimate'] = true;
     params['pageSize'] = this.state.pageSize;
     params['page'] = this.state.page;
     // Convert UI filters to API filters
@@ -475,6 +477,12 @@ export class RunList extends React.Component {
                 onSetPageSize={this.setPageSize}
               />
             </CardBody>
+            <CardFooter>
+              <Text className="disclaimer" component="h4">
+                * Note: for performance reasons, the total number of items is an approximation.
+                Use the API with &lsquo;estimate=false&rsquo; if you need an accurate count.
+              </Text>
+            </CardFooter>
           </Card>
         </PageSection>
       </React.Fragment>


### PR DESCRIPTION
Various utility functions to aid in counting large tables.
 
This makes use of (a variant on) the count estimate function described here: 
https://wiki.postgresql.org/wiki/Count_estimate

Via implementing an `Explain` that can be used to `Explain` general SQLAlchemy queries, described here: http://www.wmmi.net/documents/SQLAlchemy.pdf