### PR TITLE
Group by component not metadata.component by default

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -9,6 +9,7 @@ NUMERIC_FIELDS = [
     "summary.skips",
 ]
 HEATMAP_MAX_BUILDS = 40  # max for number of builds that are possible to display in heatmap
+BARCHART_MAX_BUILDS = 150  # max for number of builds possible to display in bar chart
 COUNT_TIMEOUT = 0.5  # timeout for counting the number of documents [s]
 MAX_DOCUMENTS = 100000  # max documents for pagination, when apply_max=True
 JJV_RUN_LIMIT = 8000  # max runs from which to aggregate Jenkins Jobs

--- a/backend/ibutsu_server/widgets/jenkins_job_analysis.py
+++ b/backend/ibutsu_server/widgets/jenkins_job_analysis.py
@@ -1,11 +1,14 @@
+from ibutsu_server.constants import BARCHART_MAX_BUILDS
 from ibutsu_server.constants import HEATMAP_MAX_BUILDS
+from ibutsu_server.constants import JJV_RUN_LIMIT
 from ibutsu_server.widgets.jenkins_job_view import get_jenkins_job_view
 
 
 def get_jenkins_line_chart(job_name, builds, group_field="build_number", project=None):
     data = {"duration": {}}
+    run_limit = int((JJV_RUN_LIMIT / BARCHART_MAX_BUILDS) * builds)
     jobs = get_jenkins_job_view(
-        filter_=f"job_name={job_name}", page_size=builds, project=project
+        filter_=f"job_name={job_name}", page_size=builds, project=project, run_limit=run_limit
     ).get("jobs")
     # first determine duration differs from total_execution_time
     run_had_multiple_components = any(
@@ -27,8 +30,9 @@ def get_jenkins_line_chart(job_name, builds, group_field="build_number", project
 
 def get_jenkins_bar_chart(job_name, builds, group_field="build_number", project=None):
     data = {"passed": {}, "skipped": {}, "error": {}, "failed": {}}
+    run_limit = int((JJV_RUN_LIMIT / BARCHART_MAX_BUILDS) * builds)
     jobs = get_jenkins_job_view(
-        filter_=f"job_name={job_name}", page_size=builds, project=project
+        filter_=f"job_name={job_name}", page_size=builds, project=project, run_limit=run_limit
     ).get("jobs")
     for job in jobs:
         data_id = job.get(group_field)

--- a/backend/ibutsu_server/widgets/jenkins_job_analysis.py
+++ b/backend/ibutsu_server/widgets/jenkins_job_analysis.py
@@ -39,7 +39,7 @@ def get_jenkins_bar_chart(job_name, builds, group_field="build_number", project=
     return data
 
 
-def get_jenkins_analysis_data(job_name, builds, group_field="metadata.component", project=None):
+def get_jenkins_analysis_data(job_name, builds, group_field="component", project=None):
     heatmap_params = {
         "job_name": job_name,
         "builds": min(builds, HEATMAP_MAX_BUILDS),


### PR DESCRIPTION
I added this param manually on prod, so the issue is fixed there, but best to keep the default value correct as well. 

On the analysis page, this was causing a bunch of n/a columns to show up. 

Also adding a row limit for fetching the bar/line charts on the Jenkins Job analysis page