### PR TITLE
Updates to support xfail in Ibutsu

### DIFF
--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -23,7 +23,13 @@ def _copy_column(result, run, key):
 def update_run(run_id):
     """Update the run summary from the results, this task will retry 1000 times"""
     with lock(f"update-run-lock-{run_id}"):
-        key_map = {"failed": "failures", "error": "errors", "skipped": "skips"}
+        key_map = {
+            "failed": "failures",
+            "error": "errors",
+            "skipped": "skips",
+            "xpassed": "xpasses",
+            "xfailed": "xfailures",
+        }
         run = Run.query.get(run_id)
         if not run:
             return
@@ -31,7 +37,7 @@ def update_run(run_id):
         results = (
             Result.query.filter(Result.run_id == run_id).order_by(Result.start_time.asc()).all()
         )
-        summary = {"errors": 0, "failures": 0, "skips": 0, "tests": 0}
+        summary = {"errors": 0, "failures": 0, "skips": 0, "tests": 0, "xpasses": 0, "xfailures": 0}
         run_duration = 0.0
         metadata = run.data or {}
         for counter, result in enumerate(results):

--- a/frontend/src/components/result.js
+++ b/frontend/src/components/result.js
@@ -249,6 +249,18 @@ export class ResultView extends React.Component {
                     </DataListItemRow>
                   </DataListItem>
                   }
+                  {testResult.result === 'xfailed' && testResult.metadata && testResult.metadata.xfail_reason &&
+                  <DataListItem aria-labelledby="xfail-reason-label">
+                    <DataListItemRow>
+                      <DataListItemCells
+                        dataListCells={[
+                          <DataListCell key="xfail-reason-label" width={2}><strong>Reason xfailed:</strong></DataListCell>,
+                          <DataListCell key="xfail-reason-data" width={4}><Linkify componentDecorator={linkifyDecorator}>{testResult.metadata.xfail_reason}</Linkify></DataListCell>
+                        ]}
+                      />
+                    </DataListItemRow>
+                  </DataListItem>
+                  }
                   {(testResult.result === 'failed' || testResult.result === 'error' || testResult.result === 'skipped') &&
                   <DataListItem aria-labelledby="classification-label">
                     <DataListItemRow>


### PR DESCRIPTION
@jjaquish's xfail/xpass work was mostly ported over in the migration, but there were some small things that needed to be remedied in order for it to work properly. 

Note:
* widgets need to consider xpass/xfail in percentage calculations
* the results tree also needs to consider xpass/xfail in the pass percentage calculation

When used with Parthvi's iqe-core updates: 
![Screenshot from 2020-10-22 15-27-07](https://user-images.githubusercontent.com/44065123/96920368-10c7e200-147b-11eb-9dcc-7ec092feeea3.png)
