### PR TITLE
Allow for updating the metadata of multiple runs at a time and display annotations in heatmap

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -1,5 +1,5 @@
 ALLOWED_TRUE_BOOLEANS = ["y", "t", "1"]
-ARRAY_FIELDS = ["metadata.tags", "metadata.markers"]
+ARRAY_FIELDS = ["metadata.tags", "metadata.markers", "metadata.annotations"]
 NUMERIC_FIELDS = [
     "duration",
     "start_time",

--- a/backend/ibutsu_server/controllers/run_controller.py
+++ b/backend/ibutsu_server/controllers/run_controller.py
@@ -145,7 +145,7 @@ def update_run(id_, run=None):
     return run.to_dict()
 
 
-def update_runs(filter_=None, page_size=25):
+def bulk_update(filter_=None, page_size=1):
     """Updates multiple runs with common metadata
 
     Note: can only be used to update metadata on runs, limited to 25 runs

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -388,10 +388,8 @@ paths:
 
         Example queries:
 
-
-            /result?filter=metadata.run=63fe5
-            /result?filter=test_id~neg
-            /result?filter=result!passed
+            /run?filter=metadata.jenkins.job_name=jenkins_job
+            /run?filter=summary.failures>0
 
       operationId: get_run_list
       parameters:
@@ -445,6 +443,46 @@ paths:
       summary: Create a run
       tags:
       - run
+      x-openapi-router-controller: ibutsu_server.controllers.run_controller
+    put:
+      operationId: update_runs
+      parameters:
+      - description: Fields to filter by
+        explode: true
+        in: query
+        name: filter
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - $ref: '#/components/parameters/PageSize'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRun'
+        description: The metadata to add to the test runs
+        required: true
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunList'
+          description: Updated Run
+        400:
+          description: Bad request, JSON required
+        401:
+          description: Bad request, can only update metadata
+        404:
+          description: Filter(s) returned no Runs
+        405:
+          description: Bad request, cannot update more than 25 runs at a time
+      summary: Update multiple runs with common metadata
+      tags:
+        - run
       x-openapi-router-controller: ibutsu_server.controllers.run_controller
   /run/{id}:
     get:
@@ -1229,10 +1267,15 @@ components:
   schemas:
     Result:
       example:
+        id: f3a9c425-1cf0-4ed3-b5a4-7e43c9d287b0
         duration: 6.027456183070403
         result: passed
+        project_id: 9212ac64-348f-4c1c-90f7-fd0a45bcb47c
         metadata:
-          jenkins_build: 145
+          jenkins:
+            build_number: 123
+            job_name: test-jenkins-job
+          project: 'insights-qe'
           commit_hash: F4BA3E12
         start_time: 2020-05-15T16:18:32.014053
         source: source
@@ -1243,7 +1286,7 @@ components:
       properties:
         id:
           description: Unique ID of the test result
-          example: af3b3ff0c6188c9ba767
+          example: f3a9c425-1cf0-4ed3-b5a4-7e43c9d287b0
           type: string
         test_id:
           description: Unique id
@@ -1266,7 +1309,10 @@ components:
           type: string
         metadata:
           example:
-            jenkins_build: 145
+            jenkins:
+              job_name: test-jenkins-job
+              build_number: 123
+            project: insights-qe
             commit_hash: F4BA3E12
           type: object
         params:
@@ -1279,11 +1325,13 @@ components:
           type: string
     Run:
       example:
-        id: cd7994f77bcf8639011507f1
+        id: 345f14bf-9f90-4246-8413-44b7ad15ecd9
         created: 2020-05-15T16:18:32.014053
         duration: 540.05433
         source: my-tests
         start_time: 2020-05-15T16:18:32.014053
+        component: login
+        env: qa
         summary:
           errors: 1
           failures: 3
@@ -1297,7 +1345,7 @@ components:
       properties:
         id:
           description: Unique ID of the test run
-          example: xBvhD1
+          example: 345f14bf-9f90-4246-8413-44b7ad15ecd9
           type: string
         created:
           description: The time this record was created
@@ -1322,17 +1370,32 @@ components:
           description: Extra data for this run
           type: object
       type: object
+    UpdateRun:
+      example:
+        metadata:
+          annotation:
+            - name: deploymentAnnotation
+              value: Application was deployed at <timestamp>
+              description: Optional description
+            - name: otherAnnotation
+              value: A different type of annotation
+              description: Optional description
+      properties:
+        metadata:
+          description: Extra data for this run
+          type: object
+      type: object
     Artifact:
       example:
         filename: filename
         resultId: resultId
-        id: 507f1f77bcf86cd799439011
+        id: 2a5bf135-e754-472f-8984-85d90d0ef65c
         additionalMetadata:
           key: '{}'
       properties:
         id:
           description: Unique ID of the artifact
-          example: 507f1f77bcf86cd799439011
+          example: 2a5bf135-e754-472f-8984-85d90d0ef65c
           type: string
         resultId:
           description: ID of test result to attach artifact to
@@ -1346,15 +1409,15 @@ components:
       type: object
     Project:
       example:
-        id: 86cd799439011507f1f77bcf
+        id: 32919850-667a-44de-a4f5-0e6a68e5e7e4
         name: my-project
         title: My Project
-        ownerId: 6afedb7a8348eb4ebdbe0c77
-        groupId: 7a8348eb4e6afedb0c77bdbe
+        ownerId: 10485255-76c2-4e2c-a1c1-0723cbca118a
+        groupId: 75be09af-b68b-4029-91e9-34af007eb35c
       properties:
         id:
           description: Unique ID of the project
-          example: 86cd799439011507f1f77bcf
+          example: 32919850-667a-44de-a4f5-0e6a68e5e7e4
           type: string
         name:
           description: The machine name of the project
@@ -1375,12 +1438,12 @@ components:
       type: object
     Group:
       example:
-        id: af3b3ff0c6188c9ba767
+        id: 3e49847a-c775-4bf7-bd9c-91946869634d
         name: Example group
       properties:
         id:
           description: Unique ID of the project
-          example: af3b3ff0c6188c9ba767
+          example: 3e49847a-c775-4bf7-bd9c-91946869634d
           type: string
         name:
           description: The name of the group
@@ -1408,7 +1471,7 @@ components:
       type: object
     Report:
       example:
-        id: c6188b3fa767f0c9baf3
+        id: 4dfa70aa-cf5d-49b6-aa24-b9bd9a85b7cf
         filename: myreport.zip
         mimetype: application/zip
         url: http://ibutsu/reports/download/myreport.zip
@@ -1422,7 +1485,7 @@ components:
       properties:
         id:
           description: Unique ID of the project
-          example: c6188b3fa767f0c9baf3
+          example: 4dfa70aa-cf5d-49b6-aa24-b9bd9a85b7cf
           type: string
         filename:
           description: The filename of the report
@@ -1453,15 +1516,15 @@ components:
       type: object
     Import:
       example:
-        id: 8ebba624448f749dfc5f
+        id: ab9615f4-3f5a-4a09-a638-1e2995a79f64
         status: done
         filename: test-run.xml
         format: JUnit
-        run_id: 97dd93951b96f9bada68
+        run_id: 14693b7c-befa-4051-be1e-0b1ccc091b04
       properties:
         id:
           description: The database ID of the import
-          example: 8ebba624448f749dfc5f
+          example: ab9615f4-3f5a-4a09-a638-1e2995a79f64
           type: string
         status:
           description: The current status of the import, can be one of "pending", "running", "done"
@@ -1477,12 +1540,12 @@ components:
           type: string
         run_id:
           description: The ID of the run from the import
-          example: 97dd93951b96f9bada68
+          example: 14693b7c-befa-4051-be1e-0b1ccc091b04
           type: string
       type: object
     WidgetConfig:
       example:
-        id: d41d8cd98f00b204e980
+        id: 70e505d7-95ba-4416-8f43-b3eacb1a467a
         type: widget
         widget: jenkins-heatmap
         project: my-project
@@ -1496,7 +1559,7 @@ components:
       properties:
         id:
           description: The internal ID of the WidgetConfig
-          example: d41d8cd98f00b204e980
+          example: 70e505d7-95ba-4416-8f43-b3eacb1a467a
           type: string
         type:
           description: The type of widget, one of either "widget" or "view"
@@ -1683,7 +1746,7 @@ components:
     RunList:
       example:
         runs:
-        - id: cd7994f77bcf8639011507f1
+        - id: 0c7a3790-9a71-4351-8567-e98217ee3067
           duration: 540.05433
           summary:
             errors: 1
@@ -1710,7 +1773,7 @@ components:
         artifacts:
         - filename: filename
           resultId: resultId
-          id: 507f1f77bcf86cd799439011
+          id: d207491a-d7f8-40eb-b26c-41c00c985903
           additionalMetadata:
             key: '{}'
         pagination:
@@ -1729,10 +1792,10 @@ components:
     ProjectList:
       example:
         projects:
-        - id: 86cd799439011507f1f77bcf
+        - id: a8d58357-8b9a-4227-92dc-7dd73565ba01
           name: My Project
-          ownerId: 6afedb7a8348eb4ebdbe0c77
-          groupId: 7a8348eb4e6afedb0c77bdbe
+          ownerId: f158795c-c33b-408f-bbbd-791f771299d5
+          groupId: a0c1bdb4-4cd8-48b7-899d-89af68a2e862
         pagination:
           page: 2
           pageSize: 25
@@ -1749,7 +1812,7 @@ components:
     GroupList:
       example:
         groups:
-        - id: af3b3ff0c6188c9ba767
+        - id: 991c8409-f4dc-4e2e-94f8-60eab9c014e8
           name: Example group
         pagination:
           page: 2
@@ -1767,7 +1830,7 @@ components:
     ReportList:
       example:
         reports:
-        - id: c6188b3fa767f0c9baf3
+        - id: 2a690a2c-3a48-4bdc-af60-32955b990dd0
           filename: myreport.zip
           mimetype: application/zip
           url: http://ibutsu/reports/download/myreport.zip
@@ -1791,7 +1854,7 @@ components:
     WidgetConfigList:
       example:
         widgets:
-          - id: d41d8cd98f00b204e980
+          - id: be014e39-c47b-4552-b453-3bbaa02512be
             type: widget
             widget: heatmap
             params:

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -444,8 +444,9 @@ paths:
       tags:
       - run
       x-openapi-router-controller: ibutsu_server.controllers.run_controller
-    put:
-      operationId: update_runs
+  /runs/bulk-update:
+    post:
+      operationId: bulk_update
       parameters:
       - description: Fields to filter by
         explode: true
@@ -1373,7 +1374,7 @@ components:
     UpdateRun:
       example:
         metadata:
-          annotation:
+          annotations:
             - name: deploymentAnnotation
               value: Application was deployed at <timestamp>
               description: Optional description

--- a/backend/ibutsu_server/widgets/jenkins_heatmap.py
+++ b/backend/ibutsu_server/widgets/jenkins_heatmap.py
@@ -98,10 +98,12 @@ def _get_heatmap(job_name, builds, group_field, count_skips, project=None):
     group_field = string_to_column(group_field, Run)
     job_name = string_to_column("metadata.jenkins.job_name", Run)
     build_number = string_to_column("metadata.jenkins.build_number", Run)
+    annotation = string_to_column("metadata.annotation", Run)
 
     # create the base query
     query = session.query(
         Run.id.label("run_id"),
+        annotation.label("annotation"),
         group_field.label("group_field"),
         job_name.label("job_name"),
         build_number.label("build_number"),

--- a/backend/ibutsu_server/widgets/jenkins_heatmap.py
+++ b/backend/ibutsu_server/widgets/jenkins_heatmap.py
@@ -98,12 +98,12 @@ def _get_heatmap(job_name, builds, group_field, count_skips, project=None):
     group_field = string_to_column(group_field, Run)
     job_name = string_to_column("metadata.jenkins.job_name", Run)
     build_number = string_to_column("metadata.jenkins.build_number", Run)
-    annotation = string_to_column("metadata.annotation", Run)
+    annotations = string_to_column("metadata.annotations", Run)
 
     # create the base query
     query = session.query(
         Run.id.label("run_id"),
-        annotation.label("annotation"),
+        annotations.label("annotations"),
         group_field.label("group_field"),
         job_name.label("job_name"),
         build_number.label("build_number"),
@@ -139,6 +139,7 @@ def _get_heatmap(job_name, builds, group_field, count_skips, project=None):
         subquery.c.group_field,
         subquery.c.build_number,
         subquery.c.run_id,
+        subquery.c.annotations,
         (100 * passes / subquery.c.total).label("pass_percent"),
     )
 
@@ -147,7 +148,7 @@ def _get_heatmap(job_name, builds, group_field, count_skips, project=None):
     data = {datum.group_field: [] for datum in query_data}
     for datum in query_data:
         data[datum.group_field].append(
-            [round(datum.pass_percent, 2), datum.run_id, datum.build_number]
+            [round(datum.pass_percent, 2), datum.run_id, datum.annotations, datum.build_number]
         )
     # compute the slope for each component
     data_with_slope = data.copy()
@@ -168,10 +169,10 @@ def _pad_heatmap(heatmap, builds_in_db):
         # skip first item in list which contains slope info
         run_list = heatmap[group][1:]
         padded_run_list = []
-        completed_runs = {run[2]: run for run in run_list}
+        completed_runs = {run[3]: run for run in run_list}
         for build in builds_in_db:
             if build not in completed_runs.keys():
-                padded_run_list.append((NO_PASS_RATE_TEXT, NO_RUN_TEXT, build))
+                padded_run_list.append((NO_PASS_RATE_TEXT, NO_RUN_TEXT, None, build))
             else:
                 padded_run_list.append(completed_runs[build])
         # add the slope info back in

--- a/frontend/src/widgets/jenkinsheatmap.js
+++ b/frontend/src/widgets/jenkinsheatmap.js
@@ -112,12 +112,17 @@ export class JenkinsHeatmapWidget extends React.Component {
       else if (isNaN(value[0])) {
         style.background = 'var(--pf-global--info-color--100)';
       }
+      // handle annotations, add a border for cells with annotations
+      if (value[2]) {
+        style.borderRight = 'solid 5px #01FFFF';
+      }
     }
     return style;
   }
 
   renderCell(value) {
     let contents = '';
+    let style = {marginTop: '-4px'};
     if (!!value && (value[1] === 0)) {
       if (value[0] < 0) {
         contents = <ArrowDownIcon />;
@@ -136,9 +141,20 @@ export class JenkinsHeatmapWidget extends React.Component {
       contents = "n/a"
     }
     else if (value) {
-      contents = <Link to={`/runs/${value[1]}`}>{Math.floor(value[0])}</Link>;
+      if (value[2]) {
+        let title = '';
+        value[2].forEach((item) => {
+          if (!!item.name && !!item.value) {
+            title += item.name + ": " + item.value + "\n";
+          }
+        });
+        contents = <p title={title}><Link to={`/runs/${value[1]}`}>{Math.floor(value[0])}</Link></p>;
+      }
+      else {
+        contents = <Link to={`/runs/${value[1]}`}>{Math.floor(value[0])}</Link>;
+      }
     }
-    return <div style={{marginTop: '-4px'}}>{contents}</div>;
+    return <div style={style}>{contents}</div>;
   }
 
   componentDidMount() {
@@ -175,8 +191,8 @@ export class JenkinsHeatmapWidget extends React.Component {
       yLabels.push(key);
       data.push(values);
       values.forEach((item) => {
-        if (!!item && (item.length > 2) && !!item[2]) {
-          newLabels.push(<Link to={`/results?metadata.jenkins.build_number[eq]=${item[2]}&metadata.jenkins.job_name[eq]=` + this.params['job_name']} key={item[2]}>{item[2]}</Link>);
+        if (!!item && (item.length > 2) && !!item[3]) {
+          newLabels.push(<Link to={`/results?metadata.jenkins.build_number[eq]=${item[3]}&metadata.jenkins.job_name[eq]=` + this.params['job_name']} key={item[3]}>{item[3]}</Link>);
         }
       });
       if (newLabels.length > labels.length) {


### PR DESCRIPTION
* Adding a `/runs/bulk-update` endpoint, which allows you to update multiple runs at a time. It takes filter like the get runs endpoint takes. 
e.g. by passing 
```json,
{
  "metadata": {
    "annotations": [
      {
        "description": "Optional description",
        "name": "deploymentAnnotation",
        "value": "Application was deployed at <timestamp>"
      },
      {
        "description": "Optional description",
        "name": "otherAnnotation",
        "value": "A different type of annotation"
      }
    ]
  }
}
```

Example curl request to update the most recent stage-test-suite run on the foreman_rh_cloud plugin:
```
curl -X POST "<ibutsu-api-url>/api/runs/bulk-update?filter=metadata.jenkins.job_name%3Dstage-test-suite&filter=component%3Dforeman_rh_cloud&pageSize=1" -H "accept: application/json" -H "Content-Type: application/json" -d "{\"metadata\":{\"annotations\":[{\"description\":\"Optional description\",\"name\":\"deploymentAnnotation\",\"value\":\"Application was deployed at <timestamp>\"},{\"description\":\"Optional description\",\"name\":\"otherAnnotation\",\"value\":\"A different type of annotation\"}]}}"
```

* Adding BE/FE updates for handling runs that have annotations in the heatmap. I'd like to get some feedback on how best to signify these -- right now I just have a border on the _right_ of the cell and tooltip on them. 

![Screenshot from 2020-11-18 14-22-29](https://user-images.githubusercontent.com/44065123/99577551-886d2c00-29a9-11eb-92fb-12738df5709c.png)

cc @bsquizz

* Updating some of the examples and ObjectID's in the openapi spec to UUID's