### PR TITLE
Add custom filters for some widgets

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -39,6 +39,12 @@ WIDGET_TYPES = {
                 "description": "Count skips against the pass rate",
                 "type": "boolean",
             },
+            {
+                "name": "additional_filters",
+                "description": "Comma-separated list of additional filters, e.g. "
+                "'metadata.tags=platform-experience,metadata.assignee=username'",
+                "type": "string",
+            },
         ],
         "type": "widget",
     },
@@ -62,6 +68,12 @@ WIDGET_TYPES = {
                 "description": "Type of chart with which to display results, e.g. 'bar' or 'line'",
                 "type": "string",
             },
+            {
+                "name": "additional_filters",
+                "description": "Comma-separated list of additional filters, e.g. "
+                "'metadata.tags=platform-experience,metadata.assignee=username'",
+                "type": "string",
+            },
         ],
         "type": "widget",
     },
@@ -81,6 +93,12 @@ WIDGET_TYPES = {
                 "type": "string",
             },
             {"name": "job_name", "description": "Filter by Jenkins job name", "type": "string"},
+            {
+                "name": "additional_filters",
+                "description": "Comma-separated list of additional filters, e.g. "
+                "'metadata.tags=platform-experience,metadata.assignee=username'",
+                "type": "string",
+            },
         ],
         "type": "widget",
     },
@@ -102,6 +120,12 @@ WIDGET_TYPES = {
             {
                 "name": "chart_type",
                 "description": "Type of chart with which to display results, e.g. 'pie' or 'bar'",
+                "type": "string",
+            },
+            {
+                "name": "additional_filters",
+                "description": "Comma-separated list of additional filters, e.g. "
+                "'metadata.tags=platform-experience,metadata.assignee=username'",
                 "type": "string",
             },
         ],

--- a/backend/ibutsu_server/widgets/result_aggregator.py
+++ b/backend/ibutsu_server/widgets/result_aggregator.py
@@ -17,15 +17,16 @@ def _get_min_count(days):
         return days ** 5
 
 
-def _get_recent_result_data(days, group_field, project=None):
-    """ Count occurrences of distinct fields within results.
-    """
+def _get_recent_result_data(days, group_field, project=None, additional_filters=None):
+    """Count occurrences of distinct fields within results."""
     delta = timedelta(days=days).total_seconds()
     current_time = time.time()
     time_period_in_sec = current_time - delta
 
     # create filters for the start time and that the group_field exists
     filters = [f"start_time>{datetime.utcfromtimestamp(time_period_in_sec)}", f"{group_field}@y"]
+    if additional_filters:
+        filters.extend(additional_filters.split(","))
     if project:
         filters.append(f"project_id={project}")
 
@@ -48,6 +49,8 @@ def _get_recent_result_data(days, group_field, project=None):
     return data
 
 
-def get_recent_result_data(days, group_field, project=None, chart_type="pie"):
-    data = _get_recent_result_data(days, group_field, project)
+def get_recent_result_data(
+    days, group_field, project=None, chart_type="pie", additional_filters=None
+):
+    data = _get_recent_result_data(days, group_field, project, additional_filters)
     return data

--- a/backend/ibutsu_server/widgets/result_summary.py
+++ b/backend/ibutsu_server/widgets/result_summary.py
@@ -7,7 +7,7 @@ from sqlalchemy import func
 PAGE_SIZE = 250
 
 
-def get_result_summary(source=None, env=None, job_name=None, project=None):
+def get_result_summary(source=None, env=None, job_name=None, project=None, additional_filters=None):
     """Get a summary of results"""
     summary = {
         "error": 0,
@@ -37,6 +37,8 @@ def get_result_summary(source=None, env=None, job_name=None, project=None):
         filters.append(f"metadata.jenkins.job_name={job_name}")
     if project:
         filters.append(f"project_id={project}")
+    if additional_filters:
+        filters.extend(additional_filters.split(","))
 
     # TODO: implement some page size here?
     if filters:

--- a/backend/ibutsu_server/widgets/run_aggregator.py
+++ b/backend/ibutsu_server/widgets/run_aggregator.py
@@ -10,7 +10,7 @@ from ibutsu_server.filters import string_to_column
 from sqlalchemy import func
 
 
-def _get_recent_run_data(weeks, group_field, project=None):
+def _get_recent_run_data(weeks, group_field, project=None, additional_filters=None):
     """Get all the data from the time period and aggregate the results"""
     data = {"passed": {}, "skipped": {}, "error": {}, "failed": {}, "xfailed": {}, "xpassed": {}}
     delta = timedelta(weeks=weeks).total_seconds()
@@ -19,6 +19,8 @@ def _get_recent_run_data(weeks, group_field, project=None):
 
     # create filters for start time and that the group_field exists
     filters = [f"start_time>{datetime.utcfromtimestamp(time_period_in_sec)}", f"{group_field}@y"]
+    if additional_filters:
+        filters.extend(additional_filters.split(","))
     if project:
         filters.append(f"project_id={project}")
 
@@ -63,7 +65,9 @@ def _get_recent_run_data(weeks, group_field, project=None):
     return data
 
 
-def get_recent_run_data(weeks, group_field, project=None, chart_type="bar"):
+def get_recent_run_data(
+    weeks, group_field, project=None, chart_type="bar", additional_filters=None
+):
     # TODO: Implement line chart by splitting weeks of data into distinct blocks of time
-    data = _get_recent_run_data(weeks, group_field, project)
+    data = _get_recent_run_data(weeks, group_field, project, additional_filters)
     return data


### PR DESCRIPTION
This PR allows users to specify custom filters for a few widgets, so that they can filter on specific metadata. 

e.g. filtering by `platform-experience` tag
![Screenshot from 2020-12-04 13-42-09](https://user-images.githubusercontent.com/44065123/101201961-8c01e380-3636-11eb-8523-1f23e2c2f86e.png)

