### PR TITLE
Add a button for deleting a single widget from a dashboard

### DIFF
--- a/frontend/src/components/delete-modal.js
+++ b/frontend/src/components/delete-modal.js
@@ -9,16 +9,18 @@ import {
 } from '@patternfly/react-core';
 
 
-export class DeleteDashboardModal extends React.Component {
+export class DeleteModal extends React.Component {
   static propTypes = {
-    dashboard: PropTypes.object,
+    id: PropTypes.object,
+    title: PropTypes.string,
+    body: PropTypes.string,
     onDelete: PropTypes.func,
     onClose: PropTypes.func,
     isOpen: PropTypes.bool
   };
 
   onDelete = () => {
-    this.props.onDelete(this.props.dashboard);
+    this.props.onDelete(this.props.id);
   }
 
   onClose = () => {
@@ -29,7 +31,7 @@ export class DeleteDashboardModal extends React.Component {
     return (
       <Modal
         variant={ModalVariant.small}
-        title="Delete dashboard"
+        title={this.props.title}
         isOpen={this.props.isOpen}
         onClose={this.onClose}
         actions={[
@@ -37,7 +39,7 @@ export class DeleteDashboardModal extends React.Component {
           <Button key="cancel" variant="link" onClick={this.onClose}>Cancel</Button>
         ]}
       >
-      <Text>Would you like to delete the current dashboard? <strong>ALL WIDGETS</strong> on the dashboard will also be <strong>deleted</strong>.</Text>
+      <Text>{this.props.body}</Text>
       </Modal>
     );
   }

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -1,6 +1,6 @@
 export { ClassificationDropdown, MultiClassificationDropdown } from './classification-dropdown';
 export { ClassifyFailuresTable } from './classify-failures';
-export { DeleteDashboardModal } from './delete-dashboard-modal';
+export { DeleteModal } from './delete-modal';
 export { FileUpload } from './fileupload';
 export { FilterTable } from './filtertable';
 export { ParamDropdown } from './widget-components';

--- a/frontend/src/components/widget-components.js
+++ b/frontend/src/components/widget-components.js
@@ -10,25 +10,34 @@ import {
   Text,
   Tooltip
 } from '@patternfly/react-core';
-import { PficonHistoryIcon } from '@patternfly/react-icons';
+import { PficonHistoryIcon, TimesIcon  } from '@patternfly/react-icons';
 
 
 export class WidgetHeader extends React.Component {
   static propTypes = {
+    id: PropTypes.string,
     getDataFunc: PropTypes.func,
+    onDeleteClick: PropTypes.func,
     title: PropTypes.string,
     actions: PropTypes.array
   }
 
   render () {
-    const { title, getDataFunc, actions } = this.props;
+    const { title, getDataFunc, actions, onDeleteClick } = this.props;
     return (
       <CardHeader data-id="widget-header">
         <Text component="h2" style={{ fontSize: 20 }}>{title}</Text>
         {actions}
+        {getDataFunc &&
         <Button variant="plain" onClick={getDataFunc} title="Refresh" aria-label="Refresh" isInline>
           <PficonHistoryIcon />
         </Button>
+        }
+        {onDeleteClick &&
+         <Button variant="plain" onClick={onDeleteClick} title="Remove from dashboard" aria-label="Delete" isInline>
+          <TimesIcon />
+        </Button>
+        }
       </CardHeader>
     );
   }

--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -23,7 +23,7 @@ import { ArchiveIcon, CubesIcon, PlusCircleIcon, TachometerAltIcon, TimesCircleI
 
 import { KNOWN_WIDGETS } from './constants';
 import { Settings } from './settings';
-import { DeleteDashboardModal, NewDashboardModal, NewWidgetWizard } from './components';
+import { DeleteModal, NewDashboardModal, NewWidgetWizard } from './components';
 import {
   GenericBarWidget,
   JenkinsHeatmapWidget,
@@ -202,6 +202,25 @@ export class Dashboard extends React.Component {
         });
   }
 
+  onDeleteWidget = () => {
+    fetch(Settings.serverUrl + '/widget-config/' + this.state.currentWidgetId, {
+        method: 'DELETE',
+      })
+        .then(response => response.json())
+        .then(() => {
+          this.getWidgets();
+          this.setState({isDeleteWidgetOpen: false});
+        });
+  }
+
+  onDeleteWidgetClick = (id) => {
+    this.setState({isDeleteWidgetOpen: true, currentWidgetId: id});
+  }
+
+  onDeleteWidgetClose = () => {
+    this.setState({isDeleteWidgetOpen: false});
+  }
+
   onAddWidgetClick = () => {
     this.setState({isWidgetWizardOpen: true});
   }
@@ -306,16 +325,36 @@ export class Dashboard extends React.Component {
                 return (
                   <GridItem xl={4} lg={6} md={12} key={widget.id}>
                     {(widget.type === "widget" && widget.widget === "jenkins-heatmap") &&
-                      <JenkinsHeatmapWidget title={widget.title} params={widget.params} includeAnalysisLink={true}/>
+                      <JenkinsHeatmapWidget
+                        title={widget.title}
+                        params={widget.params}
+                        includeAnalysisLink={true}
+                        onDeleteClick={() => this.onDeleteWidgetClick(widget.id)}
+                      />
                     }
                     {(widget.type === "widget" && widget.widget === "run-aggregator") &&
-                      <GenericBarWidget title={widget.title} params={widget.params} horizontal={true} percentData={true} barWidth={20}/>
+                      <GenericBarWidget
+                        title={widget.title}
+                        params={widget.params}
+                        horizontal={true}
+                        percentData={true}
+                        barWidth={20}
+                        onDeleteClick={() => this.onDeleteWidgetClick(widget.id)}
+                      />
                     }
                     {(widget.type === "widget" && widget.widget === "result-summary") &&
-                      <ResultSummaryWidget title={widget.title} params={widget.params}/>
+                      <ResultSummaryWidget
+                        title={widget.title}
+                        params={widget.params}
+                        onDeleteClick={() => this.onDeleteWidgetClick(widget.id)}
+                      />
                     }
                     {(widget.type === "widget" && widget.widget === "result-aggregator") &&
-                      <ResultAggregatorWidget title={widget.title} params={widget.params}/>
+                      <ResultAggregatorWidget
+                        title={widget.title}
+                        params={widget.params}
+                        onDeleteClick={() => this.onDeleteWidgetClick(widget.id)}
+                      />
                     }
                   </GridItem>
                 );
@@ -367,7 +406,20 @@ export class Dashboard extends React.Component {
         </PageSection>
         <NewDashboardModal project={project} isOpen={this.state.isNewDashboardOpen} onSave={this.onNewDashboardSave} onClose={this.onNewDashboardClose} />
         <NewWidgetWizard dashboard={dashboard} isOpen={this.state.isWidgetWizardOpen} onSave={this.onNewWidgetSave} onClose={this.onNewWidgetClose} />
-        <DeleteDashboardModal isOpen={this.state.isDeleteDashboardOpen} onDelete={this.onDeleteDashboard} onClose={this.onDeleteDashboardClose} />
+        <DeleteModal
+          title="Delete dashboard"
+          body={<>Would you like to delete the current dashboard? <strong>ALL WIDGETS</strong> on the dashboard will also be deleted.</>}
+          isOpen={this.state.isDeleteDashboardOpen}
+          onDelete={this.onDeleteDashboard}
+          onClose={this.onDeleteDashboardClose}
+        />
+        <DeleteModal
+          title="Delete widget"
+          body="Would you like to delete the selected widget?"
+          isOpen={this.state.isDeleteWidgetOpen}
+          onDelete={this.onDeleteWidget}
+          onClose={this.onDeleteWidgetClose}
+        />
       </React.Fragment>
     );
   }

--- a/frontend/src/widgets/genericarea.js
+++ b/frontend/src/widgets/genericarea.js
@@ -43,6 +43,7 @@ export class GenericAreaWidget extends React.Component {
     widgetEndpoint: PropTypes.string,
     xLabel: PropTypes.string,
     yLabel: PropTypes.string,
+    onDeleteClick: PropTypes.func,
   }
 
   constructor(props) {
@@ -152,7 +153,7 @@ export class GenericAreaWidget extends React.Component {
     const legendData = this.getLegendData();
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getData}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getData} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="generic-area">
           {this.state.areaChartError &&
             <p>Error fetching data</p>

--- a/frontend/src/widgets/genericbar.js
+++ b/frontend/src/widgets/genericbar.js
@@ -37,6 +37,7 @@ export class GenericBarWidget extends React.Component {
     xLabel: PropTypes.string,
     xLabelTooltip: PropTypes.string,
     yLabel: PropTypes.string,
+    onDeleteClick: PropTypes.func,
   }
 
   constructor(props) {
@@ -199,7 +200,7 @@ export class GenericBarWidget extends React.Component {
   render() {
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getData}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getData} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="recent-runs">
           {this.state.genericBarError &&
             <p>Error fetching data</p>

--- a/frontend/src/widgets/jenkinsheatmap.js
+++ b/frontend/src/widgets/jenkinsheatmap.js
@@ -28,7 +28,8 @@ export class JenkinsHeatmapWidget extends React.Component {
     params: PropTypes.object,
     hideDropdown: PropTypes.bool,
     dropdownItems: PropTypes.array,
-    includeAnalysisLink: PropTypes.bool
+    includeAnalysisLink: PropTypes.bool,
+    onDeleteClick: PropTypes.func
   }
 
   constructor(props) {
@@ -203,7 +204,7 @@ export class JenkinsHeatmapWidget extends React.Component {
     const actions = this.getJenkinsAnalysisLink() || {};
     return (
       <Card>
-        <WidgetHeader title={this.title} actions={actions} getDataFunc={this.getHeatmap}/>
+        <WidgetHeader title={this.title} actions={actions} getDataFunc={this.getHeatmap} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="heatmap" style={{paddingTop: '0.5rem'}}>
           {(!this.state.heatmapError && this.state.isLoading) &&
           <Text component="h2">Loading ...</Text>

--- a/frontend/src/widgets/resultaggregator.js
+++ b/frontend/src/widgets/resultaggregator.js
@@ -25,6 +25,7 @@ export class ResultAggregatorWidget extends React.Component {
     title: PropTypes.string,
     params: PropTypes.object,
     dropdownItems: PropTypes.array,
+    onDeleteClick: PropTypes.func,
   }
 
   constructor(props) {
@@ -109,7 +110,7 @@ export class ResultAggregatorWidget extends React.Component {
     ];
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getResultData}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getResultData} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="recent-result-data">
           {this.state.resultAggregatorError &&
             <p>Error fetching data</p>

--- a/frontend/src/widgets/resultsummary.js
+++ b/frontend/src/widgets/resultsummary.js
@@ -20,6 +20,7 @@ export class ResultSummaryWidget extends React.Component {
   static propTypes = {
     title: PropTypes.string,
     params: PropTypes.object,
+    onDeleteClick: PropTypes.func,
   }
 
   constructor(props) {
@@ -83,7 +84,7 @@ export class ResultSummaryWidget extends React.Component {
                 ];
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getResultSummary}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getResultSummary} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody>
           <div>
             {!this.state.isLoading &&


### PR DESCRIPTION
* Re-name `DeleteDashboardModal` -> `DeleteModal` so it can be used for widgets
* Add a "X" button to the widget header (only appears if `onDeleteClick` prop is passed)
* On widget delete the widgets are reloaded
![Screenshot from 2020-12-10 13-03-24](https://user-images.githubusercontent.com/44065123/101811490-260ad580-3ae8-11eb-9db7-0731ff218c63.png)

![Screenshot from 2020-12-10 13-03-30](https://user-images.githubusercontent.com/44065123/101811510-2905c600-3ae8-11eb-94a9-db62c50d1736.png)
