### PR TITLE
Just use "ls" rather than "ls -ltr"

### DIFF
--- a/ibutsu-server-openshift.yaml
+++ b/ibutsu-server-openshift.yaml
@@ -1102,7 +1102,7 @@ objects:
                   - >
                     trap "echo Backup failed; exit 0" ERR;
                     FILENAME=backup-${PGDATABASE}-`date +%Y-%m-%d`.dump;
-                    time (find /database-backup -type f -name "backup-${PGDATABASE}-*" -exec ls -ltr "{}" + | head -n -${BACKUP_KEEP} | xargs rm -fr;
+                    time (find /database-backup -type f -name "backup-${PGDATABASE}-*" -exec ls "{}" + | head -n -${BACKUP_KEEP} | xargs rm -fr;
                     pg_dump --format=custom --compress=9 --jobs=1 --no-owner --exclude-schema=$BACKUP_EXCLUDE --file=$FILENAME;
                     echo "";
                     echo -n "Backup successful: "; du -h /database-backup/$FILENAME;


### PR DESCRIPTION
Backups were failing to be removed due to some invalid arguments being piped to `rm` through `xargs`. 

This issue didn't show up until we had enough backups in order for this to trigger. We just want the file name to pipe to `rm` through `xargs` not the permissions, etc. of the file. 

