### PR TITLE
Fix filters on reports

### DIFF
--- a/backend/ibutsu_server/tasks/reports.py
+++ b/backend/ibutsu_server/tasks/reports.py
@@ -10,7 +10,7 @@ from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Report
 from ibutsu_server.db.models import ReportFile
 from ibutsu_server.db.models import Result
-from ibutsu_server.filters import convert_filter
+from ibutsu_server.filters import apply_filters
 from ibutsu_server.tasks import task
 from ibutsu_server.templating import render_template
 from ibutsu_server.util.projects import get_project_id
@@ -115,11 +115,9 @@ def _build_query(report):
     """Build the filters from a report object"""
     query = Result.query
     if report["params"].get("filter"):
-        for report_filter in report["params"]["filter"].split(","):
-            if report_filter:
-                filter_clause = convert_filter(Result, report_filter.strip())
-                if filter_clause is not None:
-                    query = query.filter(filter_clause)
+        filters = report["params"]["filter"].split(",")
+        if filters:
+            query = apply_filters(query, filters, Result)
     if report["params"]["source"]:
         query = query.filter(Result.source == report["params"]["source"])
     if report["params"].get("project"):


### PR DESCRIPTION
Thanks @mshriver for reporting the issue! 

Fixes this exception that shows up whenever reports are filtered:
```
  File "/app/ibutsu_server/tasks/reports.py", line 132, in _get_results
    query = _build_query(report)
  File "/app/ibutsu_server/tasks/reports.py", line 120, in _build_query
    filter_clause = convert_filter(Result, report_filter.strip())
  File "/app/ibutsu_server/filters.py", line 50, in convert_filter
    match = FILTER_RE.match(filter_string)
TypeError: expected string or bytes-like object
```