### PR TITLE
Add in tasks to prune old runs and results from the DB

### DIFF
--- a/backend/ibutsu_server/tasks/__init__.py
+++ b/backend/ibutsu_server/tasks/__init__.py
@@ -62,7 +62,17 @@ def create_celery_app(_app=None):
             "task": "ibutsu_server.tasks.db.prune_old_files",
             "schedule": crontab(minute=0, hour=4, day_of_week=6),  # 4 am on Saturday, after DB dump
             "args": (3,),  # delete any artifact file older than 3 months
-        }
+        },
+        "prune-old-results": {
+            "task": "ibutsu_server.tasks.db.prune_old_results",
+            "schedule": crontab(minute=0, hour=5, day_of_week=6),  # 5 am on Saturday
+            "args": (5,),  # delete any results older than 5 months
+        },
+        "prune-old-runs": {
+            "task": "ibutsu_server.tasks.db.prune_old_runs",
+            "schedule": crontab(minute=0, hour=6, day_of_week=6),  # 6 am on Saturday
+            "args": (12,),  # delete any runs older than 12 months
+        },
     }
 
     @signals.task_failure.connect

--- a/backend/ibutsu_server/tasks/db.py
+++ b/backend/ibutsu_server/tasks/db.py
@@ -4,23 +4,79 @@ from datetime import timedelta
 
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Artifact
+from ibutsu_server.db.models import Result
+from ibutsu_server.db.models import Run
 from ibutsu_server.tasks import task
+
+DAYS_IN_MONTH = 30
 
 
 @task
 def prune_old_files(months=5):
-    """ Delete artifact files older than specified months (here defined as 4 weeks). """
+    """ Delete artifact files older than specified months (here defined as 30 days). """
     try:
         if isinstance(months, str):
             months = int(months)
 
         if months < 2:
-            # we don't want to remove files more recent than 3 months
+            # we don't want to remove files more recent than 2 months
             return
 
-        max_date = datetime.utcnow() - timedelta(days=months * 4)
+        max_date = datetime.utcnow() - timedelta(days=months * DAYS_IN_MONTH)
         # delete artifact files older than max_date
         delete_statement = Artifact.__table__.delete().where(Artifact.upload_date < max_date)
+        session.execute(delete_statement)
+        session.commit()
+    except Exception:
+        # we don't want to continually retry this task
+        return
+
+
+@task
+def prune_old_results(months=6):
+    """
+    Remove results older than specified months (here defined as 30 days).
+
+    IMPORTANT NOTE: to avoid primary key errors, 'months' must be greater than what is used
+                    in 'prune_old_files'
+    """
+    try:
+        if isinstance(months, str):
+            months = int(months)
+
+        if months < 4:
+            # we don't want to remove files more recent than 4 months
+            return
+
+        max_date = datetime.utcnow() - timedelta(days=months * DAYS_IN_MONTH)
+        # delete artifact files older than max_date
+        delete_statement = Result.__table__.delete().where(Result.start_time < max_date)
+        session.execute(delete_statement)
+        session.commit()
+    except Exception:
+        # we don't want to continually retry this task
+        return
+
+
+@task
+def prune_old_runs(months=12):
+    """
+    Remove runs older than specified months (here defined as 30 days).
+
+    IMPORTANT NOTE: to avoid primary key errors, 'months' must be greater than what is used
+                    in 'prune_old_results'
+    """
+    try:
+        if isinstance(months, str):
+            months = int(months)
+
+        if months < 10:
+            # we don't want to remove files more recent than 10 months
+            return
+
+        max_date = datetime.utcnow() - timedelta(days=months * DAYS_IN_MONTH)
+        # delete artifact files older than max_date
+        delete_statement = Run.__table__.delete().where(Run.start_time < max_date)
         session.execute(delete_statement)
         session.commit()
     except Exception:


### PR DESCRIPTION
* Prune runs, results on weekly basis
* Runs older than 12 months will be removed 
* Results older than 6 months will be removed
* Fixing a bug that was deleting artifact files prematurely
