### PR TITLE
Output number of collected tests

### DIFF
--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -97,7 +97,9 @@ def run_junit_import(import_):
         import_record.data["run_id"].append(run.id)
         # Import the contents of the XML file
         for testcase in testsuite.iterchildren(tag="testcase"):
-            test_name = testcase.get("name").split(".")[-1]
+            test_name = ""
+            if testcase.get("name"):
+                test_name = testcase.get("name").split(".")[-1]
             backup_fspath = None
             if testcase.get("classname"):
                 test_name = testcase.get("classname").split(".")[-1] + "." + test_name

--- a/backend/ibutsu_server/test/test_tasks.py
+++ b/backend/ibutsu_server/test/test_tasks.py
@@ -7,7 +7,22 @@ from unittest.mock import patch
 from ibutsu_server.test import BaseTestCase
 
 MOCK_RUN_ID = str(uuid.uuid4())
-MOCK_RUN = MagicMock(**{"id": MOCK_RUN_ID, "data": {}})
+MOCK_RUN = MagicMock(
+    **{
+        "id": MOCK_RUN_ID,
+        "duration": 1.532734345,
+        "data": {},
+        "summary": {
+            "collected": 1,
+            "errors": 0,
+            "failures": 0,
+            "skips": 0,
+            "xfailures": 0,
+            "xpasses": 0,
+            "tests": 1,
+        },
+    }
+)
 MOCK_PROJECT = str(uuid.uuid4())
 MOCK_TIME = time.time()
 MOCK_RESULTS = [
@@ -16,7 +31,7 @@ MOCK_RESULTS = [
             "result": "passed",
             "duration": 1.532734345,
             "data": {"component": "login", "env": "qa", "project": MOCK_PROJECT},
-            "starttime": MOCK_TIME,
+            "start_time": MOCK_TIME,
         }
     )
 ]
@@ -25,6 +40,7 @@ UPDATED_RUN = MagicMock(
         "id": MOCK_RUN_ID,
         "duration": 1.532734345,
         "summary": {
+            "collected": 1,
             "errors": 0,
             "failures": 0,
             "skips": 0,
@@ -50,7 +66,7 @@ class TestRunTasks(BaseTestCase):
 
         mocked_lock.return_value.__enter__.return_value = None
         mocked_run.query.get.return_value = MOCK_RUN
-        mocked_result.query.return_value.filter.return_value.all.return_value = MOCK_RESULTS
+        mocked_result.query.return_value.filter.return_value.limit.return_value = MOCK_RESULTS
 
         update_run = update_run._orig_func
         update_run(MOCK_RUN_ID)
@@ -58,6 +74,6 @@ class TestRunTasks(BaseTestCase):
         mocked_lock.assert_called_once()
         mocked_run.query.get.assert_called_once_with(MOCK_RUN_ID)
         mocked_result.query.filter.assert_called_once()
-        mocked_result.query.filter.return_value.order_by.return_value.all.assert_called_once()
+        mocked_result.query.filter.return_value.order_by.return_value.limit.assert_called_once()
         mocked_session.add.assert_called_once()
         mocked_session.commit.assert_called_once()

--- a/frontend/src/run.js
+++ b/frontend/src/run.js
@@ -426,8 +426,9 @@ export class Run extends React.Component {
 
 
   render() {
-    let passed = 0, failed = 0, errors = 0, xfailed = 0, xpassed = 0, skipped = 0;
+    let passed = 0, failed = 0, errors = 0, xfailed = 0, xpassed = 0, skipped = 0, not_run = 0;
     let created = 0;
+    let calculatePasses = true;
     const { run, columns, rows, classificationTable } = this.state;
 
     if (run.start_time) {
@@ -437,28 +438,38 @@ export class Run extends React.Component {
       created = new Date(run.created);
     }
     if (run.summary) {
-      if (run.summary.tests) {
+      if (run.summary.passes) {
+        passed = run.summary.passes;
+        calculatePasses = false;
+      }
+      if (run.summary.tests && calculatePasses) {
         passed = run.summary.tests;
       }
       if (run.summary.failures) {
-        passed -= run.summary.failures;
+        passed -= calculatePasses ? run.summary.failures : 0;
         failed = run.summary.failures;
       }
       if (run.summary.errors) {
-        passed -= run.summary.errors;
+        passed -= calculatePasses ? run.summary.errors : 0;
         errors = run.summary.errors;
       }
       if (run.summary.xfailures) {
-        passed -= run.summary.xfailures;
+        passed -= calculatePasses ? run.summary.xfailures : 0;
         xfailed = run.summary.xfailures;
       }
       if (run.summary.xpasses) {
-        passed -= run.summary.xpasses;
+        passed -= calculatePasses ? run.summary.xpasses : 0;
         xpassed = run.summary.xpasses;
       }
       if (run.summary.skips) {
-        passed -= run.summary.skips;
+        passed -= calculatePasses ? run.summary.skips : 0;
         skipped = run.summary.skips;
+      }
+      if (run.summary.not_run) {
+        not_run = run.summary.not_run;
+      }
+      else if (run.summary.collected) {
+        not_run = run.summary.collected - run.summary.tests;
       }
     }
     const pagination = {
@@ -586,7 +597,7 @@ export class Run extends React.Component {
                                           <DataListItemCells
                                             dataListCells={[
                                               <DataListCell key={1}>Total:</DataListCell>,
-                                              <DataListCell key={2}>{run.summary.tests}</DataListCell>
+                                              <DataListCell key={2}>{run.summary.collected ? run.summary.collected : run.summary.tests}</DataListCell>
                                             ]}
                                           />
                                         </DataListItemRow>
@@ -647,6 +658,16 @@ export class Run extends React.Component {
                                             dataListCells={[
                                               <DataListCell key={1}>Skipped:</DataListCell>,
                                               <DataListCell key={2}>{skipped}</DataListCell>
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </DataListItem>
+                                      <DataListItem aria-labelledby="Not Run">
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>Not Run:</DataListCell>,
+                                              <DataListCell key={2}>{not_run}</DataListCell>
                                             ]}
                                           />
                                         </DataListItemRow>


### PR DESCRIPTION
* Remove some of the duplicated logic in the pytest-plugin
* Use the number of collected tests in the frontend

Requires https://github.com/ibutsu/pytest-ibutsu/pull/17

@rsnyman Will this break the imports? I'm debating whether we can get rid of the loop over the results in the update_run task altogether, all we need is 1 result to copy the metadata/columns over.

Note the pass percentages are still determined from `run.summary.tests`. Meant to address https://github.com/ibutsu/pytest-ibutsu/issues/13

![Screenshot from 2021-02-17 14-49-20](https://user-images.githubusercontent.com/44065123/108259653-58abfc80-712f-11eb-8d62-5b589742f5cf.png)
