### PR TITLE
Release 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+Version 1.13.0
+==============
+
+* Fix bugs in the OpenAPI specification, and make sure to drop the 'data' attribute before sending it out (#153)
+* Use 'id' rather than 'name'
+* Use 'in' rather than dict.get()
+* updated importer to work with older style junit xml
+* Use the number of collected tests
+* Add a note on how to generate the changelog (#148)
+* Actually count when we are filtering on very small subset of rows
+* oc create -f will just create the template, we need to process it
+* Add cronjob/job for nightly vacuuming of database
+
 Version 1.12.2
 ==============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 1.12.2
+  version: 1.13.0
 servers:
 - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "1.12.2"
+VERSION = "1.13.0"
 REQUIRES = [
     "alembic",
     # Pin Celery to be compatible with Kombu

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "private": true,
   "dependencies": {
     "@babel/helper-call-delegate": "^7.8.7",

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -88,7 +88,7 @@ if [[ "$CAN_COMMIT" = true ]]; then
     if [[ $GENERATE_CHANGELOG = true ]]; then
         COMMIT_MSG="$COMMIT_MSG\n\n$CHANGELOG"
     fi
-    git commit -q -m $COMMIT_MSG
+    git commit -q -m "$COMMIT_MSG"
     echo "done, new branch created: $BRANCH_NAME"
     if [[ "$CAN_PUSH" = true ]]; then
         echo -n "Pushing up to origin/$BRANCH_NAME..."


### PR DESCRIPTION
* Fix bugs in the OpenAPI specification (#153)
* Drop the 'data' attribute before sending it out (#153)
* Use 'id' rather than 'name'
* Use 'in' rather than dict.get()
* Updated importer to work with older style junit xml
* Use the number of collected tests
* Add a note on how to generate the changelog (#148)
* Actually count when we are filtering on very small subset of rows
* oc create -f will just create the template, we need to process it
* Add cronjob/job for nightly vacuuming of database