### PR TITLE
Pin SqlAlchemy to 1.3.23

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -23,7 +23,7 @@ REQUIRES = [
     "PyYAML",
     "redis",
     "setuptools >= 21.0.0",
-    "sqlalchemy",
+    "sqlalchemy==1.3.23",
     "sqlalchemy-json",
     "swagger-ui-bundle==0.0.2",
     # Pin this for now, once other libraries are updated, drop this pin


### PR DESCRIPTION
SqlAlchemy 1.4.3 breaks `ibutsu-server`.

We will have to be careful with this upgrade. In particular, this import is no longer available:
```
from sqlalchemy.sql.expression import _literal_as_text
```

