### PR TITLE
Update pre-commit; add in task for syncing aborted runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ backend/settings.yaml
 # pytest-ibutsu stuff
 *.tar.gz
 .last*
+
+# celery beat
+celerybeat*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 exclude: iqe/data/plugin_skel
 repos:
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.3.0
+  rev: v2.5.0
   hooks:
   - id: reorder-python-imports
     language_version: python3
 - repo: https://github.com/ambv/black
-  rev: 20.8b1
+  rev: 21.5b1
   hooks:
   - id: black
     args: [--safe, --quiet, --line-length, "100"]
     language_version: python3
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.1.0
+  rev: v4.0.1
   hooks:
   - id: trailing-whitespace
     language_version: python3
@@ -23,18 +23,18 @@ repos:
   - id: debug-statements
     language_version: python3
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+  rev: 3.9.2
   hooks:
   - id: flake8
     language_version: python3
     args: [--max-line-length, "100", --ignore, "E203, W503"]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.6.1
+  rev: v2.16.0
   hooks:
   - id: pyupgrade
     language_version: python3
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v7.3.1
+  rev: v7.26.0
   hooks:
   - id: eslint
     additional_dependencies:

--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -18,6 +18,7 @@ COUNT_ESTIMATE_LIMIT = 1000  # if count estimate < COUNT_ESTIMATE_LIMIT, actuall
 MAX_DOCUMENTS = 100000  # max documents for pagination, when apply_max=True
 JJV_RUN_LIMIT = 8000  # max runs from which to aggregate Jenkins Jobs
 HEATMAP_RUN_LIMIT = 3000  # max runs from which to determine recent Jenkins builds
+SYNC_RUN_TIME = 15 * 60  # time for searching through aborted runs [s]
 _ADDITIONAL_FILTERS_PARAM = {
     "name": "additional_filters",
     "description": "Comma-separated list of additional filters, cf. "

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -38,7 +38,7 @@ def string_to_column(field, model):
 
 
 def apply_filters(query, filter_list, model):
-    """ Given a list of filters and a query object, applies the filters to the query."""
+    """Given a list of filters and a query object, applies the filters to the query."""
     for filter_string in filter_list:
         filter_clause = convert_filter(filter_string, model)
         if filter_clause is not None:

--- a/backend/ibutsu_server/tasks/__init__.py
+++ b/backend/ibutsu_server/tasks/__init__.py
@@ -6,6 +6,7 @@ from celery import signals
 from celery import Task
 from celery.schedules import crontab
 from flask import current_app
+from ibutsu_server.constants import SYNC_RUN_TIME
 from ibutsu_server.db.base import session
 from redis import Redis
 from redis.exceptions import LockError
@@ -72,6 +73,10 @@ def create_celery_app(_app=None):
             "task": "ibutsu_server.tasks.db.prune_old_runs",
             "schedule": crontab(minute=0, hour=6, day_of_week=6),  # 6 am on Saturday
             "args": (12,),  # delete any runs older than 12 months
+        },
+        "sync-aborted-runs": {
+            "task": "ibutsu_server.tasks.runs.sync_aborted_runs",
+            "schedule": SYNC_RUN_TIME,
         },
     }
 

--- a/backend/ibutsu_server/tasks/db.py
+++ b/backend/ibutsu_server/tasks/db.py
@@ -13,7 +13,7 @@ DAYS_IN_MONTH = 30
 
 @task
 def prune_old_files(months=5):
-    """ Delete artifact files older than specified months (here defined as 30 days). """
+    """Delete artifact files older than specified months (here defined as 30 days)."""
     try:
         if isinstance(months, str):
             months = int(months)

--- a/backend/ibutsu_server/tasks/reports.py
+++ b/backend/ibutsu_server/tasks/reports.py
@@ -126,7 +126,7 @@ def _build_query(report):
 
 
 def _get_results(report):
-    """ Limit the number of documents to REPORT_MAX_DOCUMENTS so as not to crash the server."""
+    """Limit the number of documents to REPORT_MAX_DOCUMENTS so as not to crash the server."""
     query = _build_query(report)
     try:
         session.execute(f"SET statement_timeout TO {int(REPORT_COUNT_TIMEOUT * 1000)}; commit;")

--- a/backend/ibutsu_server/tasks/results.py
+++ b/backend/ibutsu_server/tasks/results.py
@@ -7,7 +7,7 @@ from ibutsu_server.tasks import task
 
 @task
 def add_result_start_time(run_id):
-    """ Update all results in a run to add the 'start_time' field to a result"""
+    """Update all results in a run to add the 'start_time' field to a result"""
     with lock(f"update-run-lock-{run_id}"):
         run = Run.query.get(run_id)
         if not run:

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+from datetime import timedelta
+
+from ibutsu_server.constants import SYNC_RUN_TIME
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Result
 from ibutsu_server.db.models import Run
@@ -19,6 +23,17 @@ def _copy_column(result, run, key):
         setattr(run, key, getattr(result, key, None))
 
 
+def _status_to_summary(status):
+    return {
+        "failed": "failures",
+        "error": "errors",
+        "skipped": "skips",
+        "xfailed": "xfailures",
+        "xpassed": "xpasses",
+        "tests": "tests",
+    }.get(status)
+
+
 @task(max_retries=1000)
 def update_run(run_id):
     """Update the run summary from the results, this task will retry 1000 times"""
@@ -26,19 +41,41 @@ def update_run(run_id):
         run = Run.query.get(run_id)
         if not run:
             return
-        # sort according to start_time to get the most recent starting time of the run
-        results = (
-            Result.query.filter(Result.run_id == run_id).order_by(Result.start_time.asc()).limit(1)
-        )
+
+        # initialize some necessary variables
         summary = {
-            "errors": run.summary.get("errors", 0),
-            "failures": run.summary.get("failures", 0),
-            "skips": run.summary.get("skips", 0),
-            "tests": run.summary.get("tests", 0),
-            "xpasses": run.summary.get("xpasses", 0),
-            "xfailures": run.summary.get("xfailures", 0),
+            "errors": 0,
+            "failures": 0,
+            "skips": 0,
+            "tests": 0,
+            "xpasses": 0,
+            "xfailures": 0,
             "collected": run.summary.get("collected", 0),
         }
+        run.duration = 0.0
+        metadata = run.data or {}
+
+        # Fetch all the results for the runs and calculate the summary
+        results = (
+            Result.query.filter(Result.run_id == run_id).order_by(Result.start_time.asc()).all()
+        )
+
+        for i, result in enumerate(results):
+            if i == 0:
+                # on the first result, copy over some metadata
+                for column in COLUMNS_TO_COPY:
+                    _copy_column(result, run, column)
+
+                for key in METADATA_TO_COPY:
+                    _copy_result_metadata(result, metadata, key)
+
+            key = _status_to_summary(result.result)
+            if key in summary:
+                summary[key] += 1
+            # update the number of tests that actually ran
+            summary["tests"] += 1
+            run.duration += result.duration
+
         # determine the number of passes
         summary["passes"] = summary["tests"] - (
             summary["errors"]
@@ -50,15 +87,27 @@ def update_run(run_id):
         # determine the number of tests that didn't run
         summary["not_run"] = max(summary["collected"] - summary["tests"], 0)
 
-        # copy over some metadata from the results
-        metadata = run.data or {}
-        for result in results:
-            for column in COLUMNS_TO_COPY:
-                _copy_column(result, run, column)
-
-            for key in METADATA_TO_COPY:
-                _copy_result_metadata(result, metadata, key)
-
         run.update({"summary": summary, "data": metadata})
         session.add(run)
         session.commit()
+
+
+@task(max_retries=1)
+def sync_aborted_runs():
+    """
+    When test runs are prematurely aborted, e.g. due to a connection failure or outage, the number
+    of tests that are stored in summary.tests on a Run will not match the number of results for that
+    Run in the database.
+
+    This periodic task will search through recent runs and compare 'summary.tests' to the actual
+    number of results. If there is a mismatch, it will run the 'update_run' task on the Run.id.
+    """
+    # fetch recent runs
+    runs = Run.query.filter(Run.start_time > (datetime.utcnow() - timedelta(seconds=SYNC_RUN_TIME)))
+
+    # for each run, check if the result count matches 'summary.tests'
+    # if it doesn't, run the update_run task
+    for run in runs:
+        result_count = Result.query.filter(Result.run_id == run.id).count()
+        if run.summary["tests"] != result_count:
+            update_run.apply_async((run.id,), countdown=5)

--- a/backend/ibutsu_server/test/test_artifact_controller.py
+++ b/backend/ibutsu_server/test/test_artifact_controller.py
@@ -67,7 +67,9 @@ class TestArtifactController(BaseTestCase):
         """
         headers = {"Accept": "application/octet-stream"}
         response = self.client.open(
-            "/api/artifact/{id}/download".format(id=MOCK_ID), method="GET", headers=headers,
+            "/api/artifact/{id}/download".format(id=MOCK_ID),
+            method="GET",
+            headers=headers,
         )
         self.mock_artifact.query.get.assert_called_once_with(MOCK_ID)
         self.assert_200(response, "Response body is : " + response.data.decode("utf-8"))
@@ -79,7 +81,9 @@ class TestArtifactController(BaseTestCase):
         """
         headers = {"Accept": "application/json"}
         response = self.client.open(
-            "/api/artifact/{id}".format(id=MOCK_ID), method="GET", headers=headers,
+            "/api/artifact/{id}".format(id=MOCK_ID),
+            method="GET",
+            headers=headers,
         )
         self.mock_artifact.query.get.assert_called_once_with(MOCK_ID)
         self.assert_200(response, "Response body is : " + response.data.decode("utf-8"))

--- a/backend/ibutsu_server/test/test_tasks.py
+++ b/backend/ibutsu_server/test/test_tasks.py
@@ -66,7 +66,7 @@ class TestRunTasks(BaseTestCase):
 
         mocked_lock.return_value.__enter__.return_value = None
         mocked_run.query.get.return_value = MOCK_RUN
-        mocked_result.query.return_value.filter.return_value.limit.return_value = MOCK_RESULTS
+        mocked_result.query.return_value.filter.return_value.all.return_value = MOCK_RESULTS
 
         update_run = update_run._orig_func
         update_run(MOCK_RUN_ID)
@@ -74,6 +74,6 @@ class TestRunTasks(BaseTestCase):
         mocked_lock.assert_called_once()
         mocked_run.query.get.assert_called_once_with(MOCK_RUN_ID)
         mocked_result.query.filter.assert_called_once()
-        mocked_result.query.filter.return_value.order_by.return_value.limit.assert_called_once()
+        mocked_result.query.filter.return_value.order_by.return_value.all.assert_called_once()
         mocked_session.add.assert_called_once()
         mocked_session.commit.assert_called_once()

--- a/backend/ibutsu_server/widgets/jenkins_heatmap.py
+++ b/backend/ibutsu_server/widgets/jenkins_heatmap.py
@@ -80,7 +80,7 @@ def _get_builds(job_name, builds, project=None, additional_filters=None):
 
 
 def _get_heatmap(job_name, builds, group_field, count_skips, project=None, additional_filters=None):
-    """ Get Jenkins Heatmap Data. """
+    """Get Jenkins Heatmap Data."""
 
     # Get the distinct builds that exist in the DB
     min_start_time, builds = _get_builds(job_name, builds, project, additional_filters)

--- a/backend/ibutsu_server/widgets/jenkins_job_view.py
+++ b/backend/ibutsu_server/widgets/jenkins_job_view.py
@@ -10,7 +10,7 @@ from sqlalchemy import func
 
 
 def _get_jenkins_aggregation(filters=None, project=None, page=1, page_size=25, run_limit=None):
-    """ Get a list of Jenkins jobs"""
+    """Get a list of Jenkins jobs"""
     offset = (page * page_size) - page_size
 
     # first create the filters


### PR DESCRIPTION
Address #167

* Update pre-commit
* Add in a periodic task (runs every 15 minutes) to look at recent runs and sync `summary.tests` with the actual number of results

Change the way the `update_run` task works (basically reverting some of the changes made in #147), although this has redundancy with the pytest-ibutsu plugin (summary is being computed again), this is the cleanest way to make sure the runs are synced with the results.