### PR TITLE
Release 1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Version 1.13.2
+==============
+
+* Fix division by 0 in the jenkins heatmap
+* Change 204 to 206
+* Add an API endpoint to check the status of a task
+* Small changes to OCP templates
+* Update pre-commit; add in task for syncing aborted runs
+* Update the Python dependencies (#169)
+
 Version 1.13.1
 ==============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 1.13.1
+  version: 1.13.2
 servers:
 - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "1.13.1"
+VERSION = "1.13.2"
 REQUIRES = [
     "alembic",
     # Pin Celery to be compatible with Kombu

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": true,
   "dependencies": {
     "@babel/helper-call-delegate": "^7.8.7",


### PR DESCRIPTION
* Change 204 to 206
* Add an API endpoint to check the status of a task
* Small changes to OCP templates
* Update pre-commit; add in task for syncing aborted runs
* Update the Python dependencies (#169)
* Fix division by 0 in the jenkins heatmap