### PR TITLE
Handle 'None' result in the task controller

### DIFF
--- a/backend/ibutsu_server/controllers/task_controller.py
+++ b/backend/ibutsu_server/controllers/task_controller.py
@@ -19,7 +19,9 @@ def get_task(id_):
 
     if async_result.state == "SUCCESS":
         response["message"] = "Task has succeeded"
-        response.update(async_result.get())
+        result = async_result.get()
+        if result:
+            response.update(async_result.get())
     elif async_result.state == "PENDING":
         response["message"] = "Task not yet started or invalid, check back later"
     elif async_result.state == "STARTED":

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -74,7 +74,8 @@ def update_run(run_id):
                 summary[key] += 1
             # update the number of tests that actually ran
             summary["tests"] += 1
-            run.duration += result.duration
+            if result.duration:
+                run.duration += result.duration
 
         # determine the number of passes
         summary["passes"] = summary["tests"] - (


### PR DESCRIPTION
* Tasks which had no `return` statement are hitting an error at that `response.update` line
* Also check that `result.duration` is not `None` before adding it to `run.duration` in the update_run task
This will fix the error:
```
  File "/app/ibutsu_server/tasks/runs.py", line 77, in update_run
    run.duration += result.duration
TypeError: unsupported operand type(s) for +=: 'float' and 'NoneType'
```