### PR TITLE
Small bug fixes

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,6 @@
 import os
 
-workers = int(os.environ.get("GUNICORN_PROCESSES", "3"))
+workers = int(os.environ.get("GUNICORN_PROCESSES", "1"))
 threads = int(os.environ.get("GUNICORN_THREADS", "1"))
 
 forwarded_allow_ips = "*"

--- a/backend/ibutsu_server/controllers/run_controller.py
+++ b/backend/ibutsu_server/controllers/run_controller.py
@@ -176,7 +176,7 @@ def bulk_update(filter_=None, page_size=1):
     if run_dict.get("metadata", {}).get("project"):
         run_dict["project_id"] = get_project_id(run_dict["metadata"]["project"])
 
-    runs = get_run_list(filter_, page_size=page_size, estimate=True).get("runs")
+    runs = get_run_list(filter_=filter_, page_size=page_size, estimate=True).get("runs")
 
     if not runs:
         return f"No runs found with {filter_}", 404

--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -374,7 +374,7 @@ export class ResultList extends React.Component {
   }
 
   getRuns() {
-    fetch(buildUrl(Settings.serverUrl + '/run', {pageSize: 1000, estimate: true}))
+    fetch(buildUrl(Settings.serverUrl + '/run', {pageSize: 500, estimate: true}))
       .then(response => response.json())
       .then(data => {
         const runs = data.runs.map((run) => run.id);


### PR DESCRIPTION
* fix the `bulk_update` endpoint, this was broken by `query` task
* make it so that the fe doesn't request a number of runs > 500
* change the number of gunicorn workers in the backend pod to 1, this way we can let OCP handle the auto-scaling