### PR TITLE
Small changes to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.8
-
-RUN apt-get update && apt-get install -y build-essential libmagic-mgc libxml2-dev libxslt-dev python3-dev
-COPY ./backend /app
-COPY ./frontend/build /app/frontend
-COPY ./frontend/build/static /app/static
-
-RUN pip3 install --no-cache-dir -r requirements.txt

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -3,8 +3,6 @@
 README.md
 tox.ini
 git_push.sh
-test-requirements.txt
-setup.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -31,6 +29,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+node_modules/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/backend/docker/Dockerfile.backend
+++ b/backend/docker/Dockerfile.backend
@@ -1,7 +1,15 @@
-FROM tiangolo/uwsgi-nginx:python3.8
+# s2i image from https://github.com/sclorg/s2i-python-container/tree/master/3.8
+FROM registry.access.redhat.com/ubi8/python-38
 
-ENV NGINX_MAX_UPLOAD 100m
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+USER 0
+ADD . /tmp/src
+RUN /usr/bin/fix-permissions /tmp/src
+USER 1001
 
-COPY . /app
-WORKDIR /app
-RUN pip install --no-cache-dir -U pip && pip install --no-cache-dir -r requirements.txt
+# Install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Set the default command for the resulting image
+CMD /usr/libexec/s2i/run

--- a/backend/docker/Dockerfile.flower
+++ b/backend/docker/Dockerfile.flower
@@ -1,9 +1,16 @@
 FROM registry.access.redhat.com/ubi8/python-38
 
-ENV BROKER_URL=redis://localhost
-
+# add application sources with correct perms for OCP
+USER 0
 COPY . /app
 WORKDIR /app
-RUN pip install --no-cache-dir -U pip && pip install --no-cache-dir -r requirements.txt && pip install --no-cache-dir flower
+RUN chown -R 1001:0 ./
 USER 1001
+
+ENV BROKER_URL=redis://localhost
+
+# Install dependencies
+RUN pip install --no-cache-dir -U pip && pip install --no-cache-dir -r requirements.txt && pip install --no-cache-dir flower
+
+# Run application
 CMD celery flower -A ibutsu_server.tasks.queues:app --loglevel=info --broker=$BROKER_URL

--- a/backend/docker/Dockerfile.monitor
+++ b/backend/docker/Dockerfile.monitor
@@ -1,7 +1,13 @@
 FROM registry.access.redhat.com/ubi8/python-38
 
+# add application sources with correct perms for OCP
+USER 0
 COPY . /app
 WORKDIR /app
-RUN pip install --no-cache-dir -U pip && pip install --no-cache-dir -r requirements.txt
+RUN chown -R 1001:0 ./
 USER 1001
+
+# Install deps
+RUN pip install --no-cache-dir -U pip && pip install --no-cache-dir -r requirements.txt
+# Run application
 CMD ["python", "/app/ibutsu_server/tasks/monitor.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,46 +3,65 @@ services:
   frontend:
     environment:
       NODE_ENV: production
-      REACT_APP_SERVER_URL: http://localhost:8081/api
+      REACT_APP_SERVER_URL: http://localhost:8080/api
     build:
       context: ./frontend
       dockerfile: docker/Dockerfile.frontend
     image: ibutsu/frontend
     ports:
-      - "8080:8080"
-    links:
+      - "3000:8080"
+    depends_on:
       - backend
   backend:
     environment:
-      ENV_FOR_DYNACONF: production
-      DYNACONF_CELERY_BROKER_URL: redis://redis:6379
-      DYNACONF_CELERY_RESULT_BACKEND: redis://redis:6379
-      DYNACONF_DATABASE: test_artifacts
+      APP_CONFIG: config.py
+      POSTGRESQL_HOST: postgres
+      POSTGRESQL_DATABASE: ibutsu
+      CELERY_BROKER_URL: 'redis://redis'
+      CELERY_RESULT_BACKEND: 'redis://redis'
     build:
       context: ./backend
       dockerfile: docker/Dockerfile.backend
     image: ibutsu/backend
     ports:
-      - "8081:80"
-    links:
+      - "8080:8080"
+    depends_on:
+      - postgres
       - redis
+  postgres:
+    environment:
+      POSTGRES_USER: ibutsu
+      POSTGRES_PASSWORD: ibutsu
+      POSTGRES_DB: ibutsu
+    image: postgres:latest
   worker:
+    environment:
+      APP_SCRIPT: celery_worker.sh
+      POSTGRESQL_HOST: postgres
+      POSTGRESQL_DATABASE: ibutsu
+      CELERY_BROKER_URL: 'redis://redis'
+      CELERY_RESULT_BACKEND: 'redis://redis'
     build:
       context: ./backend
       dockerfile: docker/Dockerfile.worker
     image: ibutsu/worker
-    links:
-      - mongo
+    depends_on:
+      - backend
+      - postgres
       - redis
-  monitor:
+  scheduler:
     build:
       context: ./backend
-      dockerfile: docker/Dockerfile.monitor
-    image: ibutsu/monitor
-    links:
-      - mongo
+      dockerfile: docker/Dockerfile.scheduler
+    image: ibutsu/scheduler
+    environment:
+      POSTGRESQL_HOST: postgres
+      POSTGRESQL_DATABASE: ibutsu
+      CELERY_BROKER_URL: 'redis://redis'
+      CELERY_RESULT_BACKEND: 'redis://redis'
+    depends_on:
+      - backend
+      - postgres
       - redis
   redis:
-    image: redis
-    ports:
-      - "6379:6379"
+    image: redis:latest

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,71 @@
+.travis.yaml
+.swagger-codegen-ignore
+README.md
+tox.ini
+git_push.sh
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+node_modules/
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+venv/
+.python-version
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+#Ipython Notebook
+.ipynb_checkpoints

--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -1,8 +1,15 @@
-FROM node:14
+# s2i image script from https://github.com/sclorg/s2i-nodejs-container/tree/master/14
+FROM registry.access.redhat.com/ubi8/nodejs-14
 
-EXPOSE 8080
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+USER 0
+ADD . /tmp/src
+RUN chown -R 1001:0 /tmp/src
+USER 1001
 
-COPY . /home/node/app
-WORKDIR /home/node/app
-RUN npm install yarn && yarn install && yarn build
-CMD ["yarn", "start"]
+# Install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Set the default command for the resulting image
+CMD /usr/libexec/s2i/run

--- a/ocp-templates/ibutsu-server-openshift.yaml
+++ b/ocp-templates/ibutsu-server-openshift.yaml
@@ -174,7 +174,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: python:3.6
+          name: python:3.8
           namespace: openshift
         env:
         - name: GIT_SSL_NO_VERIFY


### PR DESCRIPTION
* Update flower/monitor with proper changes for the new image
* Change the frontend and backend container images to the appropriate s2i scripts
  - https://github.com/sclorg/s2i-python-container/tree/master/3.8 for the backend
  - https://github.com/sclorg/s2i-nodejs-container/tree/master/14 for the frontend
* Remove root `Dockerfile` that is no longer used
* Fix/update docker-compose (I am not very familiar with docker-compose but I wasn't able to get it working without `network_mode: host`), anyways, I think https://github.com/ibutsu/ibutsu-server/pull/191 using `podman pods` is a much better strategy

The changes to the dockerfiles for the frontend/backend are meant to mimic the s2i strategy we use in OCP, for more information, see the README's at the `sclorg` links above. 