### PR TITLE
Add a script to start Ibutsu in a podman pod for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ package-lock.json
 
 # Virtual environment
 .ibutsu-env
+.ibutsu_env
 
 # Frontend
 frontend/public/version.json

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+POD_NAME="ibutsu"
+
+echo 'Creating ibutsu pod...'
+podman pod create -p 8080:8080 -p 3000:3000 --name $POD_NAME
+echo 'Adding postgres to the pod...'
+podman run -dt \
+       --pod $POD_NAME \
+       -e POSTGRES_USER=ibutsu \
+       -e POSTGRES_DB=ibutsu \
+       -e POSTGRES_PASSWORD=ibutsu \
+       --name ibutsu-postgres \
+       --rm \
+       postgres:latest
+echo 'Adding redis to the pod...'
+podman run -dt \
+       --pod $POD_NAME \
+       --name ibutsu-redis \
+       --rm \
+       redis:latest
+echo 'Adding backend to the pod...'
+podman run -dit \
+       --rm \
+       --pod $POD_NAME \
+       --name ibutsu-backend \
+       -w /mnt \
+       -v./backend:/mnt/:Z \
+       python:latest \
+       /bin/bash -c 'python -m venv .ibutsu_env && source .ibutsu_env/bin/activate &&
+                     pip install -U pip setuptools wheel &&
+                     pip install -r requirements.txt &&
+                     python -m ibutsu_server'
+echo "Waiting for backend to respond"
+until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do
+  printf '.'
+  sleep 5
+done
+# Note the COLUMNS=80 env var is for https://github.com/celery/celery/issues/5761
+printf '\nAdding celery worker to the pod...\n'
+podman run -dit \
+       --rm \
+       --pod $POD_NAME \
+       --name ibutsu-worker \
+       -e COLUMNS=80 \
+       -w /mnt \
+       -v./backend:/mnt/:Z \
+       python:latest \
+       /bin/bash -c 'python -m venv .ibutsu_env && source .ibutsu_env/bin/activate &&
+                     pip install -U pip setuptools wheel &&
+                     pip install -r requirements.txt &&
+                     ./celery_worker.sh'
+echo 'Adding frontend to the pod...'
+podman run -dit \
+       --rm \
+       --pod $POD_NAME \
+       --name ibutsu-frontend \
+       -w /mnt \
+       -v./frontend:/mnt/:Z \
+       node:latest \
+       /bin/bash -c 'yarn install &&
+                     yarn run devserver'
+echo "Waiting for frontend to respond"
+until $(curl --output /dev/null --silent --head --fail http://localhost:3000); do
+  printf '.'
+  sleep 5
+done
+printf "\nIbutsu has been deployed into the pod: ${POD_NAME}.\n"
+echo "  Frontend URL: http://localhost:3000"
+echo "  Backend URL: http://localhost:8080"
+echo "Stop the pod by running: 'podman pod rm -f ${POD_NAME}'"


### PR DESCRIPTION
Basically this will:
* Create a podman pod called "ibutsu"
* Deploy redis, postgres containers into the pod
* Mount local files into backend/frontend/worker pods and start each of them
* Note this must be run from the root directory of the repository
Sample output:
```console
(.ibutsu-env) [jdupuy@localhost ibutsu-server]$ ./scripts/ibutsu-pod.sh 
Creating ibutsu pod...
4050405df87c23982bf96d045fb68e1d2dbb3706141c3c80ac71f7ff62fa1033
Adding postgres to the pod...
297fa13d76a85a24730a585e315177c1d888e520838bbcd8824cbe1ca9c9c804
Adding redis to the pod...
1de887ba425e0154073d4db220ebf499fc8414ae7bc95959a8f8823f8b6026ab
Adding backend to the pod...
76f022a72480734c69acd34eb77aa78a45a96c5649b33a8eca603da48a57bf2c
Waiting for backend to respond
..
Adding celery worker to the pod...
d2bcd9a2d6ee0634c5ef5dc8a94608fe72447faaa8b27c9923170634fa0354ac
Adding frontend to the pod...
90883f953321f6c68cd566ac4b6fd999c430a93c951fe343236df2938e36f619
Waiting for frontend to respond
.
Ibutsu has been deployed into the pod: ibutsu.
  Frontend URL: http://localhost:3000
  Backend URL: http://localhost:8080
Stop the pod by running: 'podman pod rm -f ibutsu'
```