### PR TITLE
Frontend env vars at container runtime

### DIFF
--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -5,6 +5,9 @@ FROM registry.access.redhat.com/ubi8/nodejs-14
 # and set permissions so that the container runs without root access
 USER 0
 ADD . /tmp/src
+COPY ./docker/start-frontend.sh /usr/bin/start-frontend.sh
+RUN chmod +x /usr/bin/start-frontend.sh
+RUN chown 1001:0 /usr/bin/start-frontend.sh
 RUN chown -R 1001:0 /tmp/src
 USER 1001
 
@@ -12,4 +15,4 @@ USER 1001
 RUN /usr/libexec/s2i/assemble
 
 # Set the default command for the resulting image
-CMD /usr/libexec/s2i/run
+ENTRYPOINT [ "start-frontend.sh" ]

--- a/frontend/docker/start-frontend.sh
+++ b/frontend/docker/start-frontend.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# For the frontend container we follow a similar approach to option 4 in:
+# https://levelup.gitconnected.com/handling-multiple-environments-in-react-with-docker-543762989783
+# We do this so that we can have runtime env vars for our REACT application.
+# Build the public/settings.js file with ENV variables
+echo "window.settings = {};" > build/settings.js
+if [[ ! -z "${REACT_APP_SERVER_URL}" ]]; then
+  echo "window.settings.serverUrl='${REACT_APP_SERVER_URL}';" >> build/settings.js
+else
+  echo "window.settings.serverUrl='http://localhost:8080/api}';}" >> build/settings.js
+fi
+if [[ ! -z "${NODE_ENV}" ]]; then
+  echo "window.settings.environment='${NODE_ENV}';" >> build/settings.js
+else
+  echo "window.settings.environment='development';" >> build/settings.js
+fi
+
+/usr/libexec/s2i/run

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <!-- config.js provides common environment variables -->
+    <script src="%PUBLIC_URL%/settings.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <!--

--- a/frontend/public/settings.js
+++ b/frontend/public/settings.js
@@ -1,0 +1,6 @@
+// Public settings for the application. If running in a container, this file will be overwritten
+// at container runtime with ENV variables.
+window.settings = {
+  serverUrl: 'http://localhost:8080/api',
+  environment: 'development'
+}

--- a/frontend/src/settings.js
+++ b/frontend/src/settings.js
@@ -1,15 +1,14 @@
-const environ = process.env.NODE_ENV || 'development';
-const serverUrl = process.env.REACT_APP_SERVER_URL || null;
+/*
+Set some settings from public/settings.js. The reason we set settings in this way is so
+that we can set them via environment variables at container runtime.
 
-export class Settings {
-}
+cf.
+https://levelup.gitconnected.com/handling-multiple-environments-in-react-with-docker-543762989783
+*/
+export var Settings;
 
-if (serverUrl) {
-  Settings.serverUrl = serverUrl;
-}
-else if (environ === 'production') {
-  Settings.serverUrl = '/api';
-}
-else {
-  Settings.serverUrl = 'http://localhost:8080/api';
-}
+// If no settings are defined in the window (i.e. in the tests), use defaults
+Settings = window.settings ? window.settings : {
+  serverUrl: 'http://localhost:8080/api',
+  environment: 'development'
+};


### PR DESCRIPTION
Address https://github.com/ibutsu/ibutsu-server/issues/192 by:
- creating a `public/settings.js` file that is loaded before react
- adding a `start-frontend.js` that overwrites the `public/settings.js` file at container runtime
- changing `src/settings.js` to be assigned to window.settings

Depends on #188 