### PR TITLE
Release 1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+Version 1.13.3
+==============
+
+* Add a script to build a settings file at container runtime
+* Small changes to dockerfiles
+* Add a script to start ibutsu in a podman pod
+* Sync aborted runs from the last 3 hrs
+* Small bugs fixes
+* Also fix possibility that duration is None is update_run task
+* Handle 'None' results in the task controller
+* Change the user when copying over the application
+* Use Ubi8 images
+* Build worker, schedule too
+* Add a build image stage in tests.yaml
+* remove travis.yml
+* Change from travis to gh action
+
 Version 1.13.2
 ==============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 1.13.2
+  version: 1.13.3
 servers:
 - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "1.13.2"
+VERSION = "1.13.3"
 REQUIRES = [
     "alembic",
     # Pin Celery to be compatible with Kombu

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "private": true,
   "dependencies": {
     "@babel/helper-call-delegate": "^7.8.7",


### PR DESCRIPTION
* Release 1.13.3
* Add a script to build a settings file at container runtime
* Small changes to dockerfiles
* Add a script to start ibutsu in a podman pod
* Sync aborted runs from the last 3 hrs
* Small bugs fixes
* Also fix possibility that duration is None is update_run task
* Handle 'None' results in the task controller
* Change the user when copying over the application
* Use Ubi8 images
* Build worker, schedule too
* Add a build image stage in tests.yaml
* remove travis.yml
* Change from travis to gh action

This release has a few bug fixes, but it's mostly just deployment/ci related things. I'd like to use this release to test out the build triggers in https://quay.io/organization/ibutsu