### PR TITLE
Implement MetaFilter with separate field and value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,8 +60,11 @@ docs/_build/
 # PyBuilder
 target/
 
-#Ipython Notebook
+# Ipython Notebook
 .ipynb_checkpoints
+
+# Editors
+.vscode
 
 # NodeJS stuff
 node_modules
@@ -70,6 +73,7 @@ package-lock.json
 # Virtual environment
 .ibutsu-env
 .ibutsu_env
+.ibutsu
 
 # Frontend
 frontend/public/version.json

--- a/frontend/src/components/filtertable.js
+++ b/frontend/src/components/filtertable.js
@@ -9,13 +9,20 @@ import {
   Flex,
   FlexItem,
   Pagination,
-  PaginationVariant
+  PaginationVariant,
+  Select,
+  SelectOption,
+  SelectVariant,
 } from '@patternfly/react-core';
 import {
   Table,
   TableBody,
   TableHeader
 } from '@patternfly/react-table';
+
+import { Settings } from '../settings';
+import { HttpClient } from '../services/http';
+import { toAPIFilter } from '../utilities';
 
 import { TableEmptyState, TableErrorState } from './tablestates';
 
@@ -158,5 +165,140 @@ export class FilterTable extends React.Component {
         />
       </React.Fragment>
     );
+  }
+}
+
+
+export class MetaFilter extends React.Component {
+  // TODO Extend this to contain the filter handling functions, and better integrate filter state with FilterTable
+  // https://github.com/ibutsu/ibutsu-server/issues/230
+  static propTypes = {
+    fieldOptions: PropTypes.array,  // could reference constants directly
+    runId: PropTypes.string,  // make optional?
+    setFilter: PropTypes.func,
+    customFilters: PropTypes.array, // more advanced handling of filter objects? the results-aggregator endpoint takes a string filter
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      fieldSelection: null,
+      isFieldOpen: false,
+      isValueOpen: false,
+      valueOptions: [],
+      valueSelections: [],
+    };
+  }
+
+  onFieldToggle = isExpanded => {
+    this.setState({isFieldOpen: isExpanded})
+  };
+
+  onValueToggle = isExpanded => {
+    this.setState({isValueOpen: isExpanded})
+  };
+
+  onFieldSelect = (event, selection) => {
+    this.setState(
+      // clear value state too, otherwise the old selection remains selected but is no longer visible
+      {fieldSelection: selection, isFieldOpen: false, valueSelections: [], valueOptions: [], isValueOpen: false},
+      this.updateValueOptions
+    )
+
+  };
+
+  onValueSelect = (event, selection) => {
+    // update state and call setFilter
+    const valueSelections = this.state.valueSelections;
+    let updated_values = (valueSelections.includes(selection))
+      ? valueSelections.filter(item => item !== selection)
+      : [...valueSelections, selection]
+
+    this.setState(
+      {valueSelections: updated_values},
+      () => this.props.setFilter(this.state.fieldSelection, this.state.valueSelections.join(';'))
+    )
+  };
+
+  onFieldClear = () => {
+    this.setState(
+      {fieldSelection: null, valueSelections: [], isFieldOpen: false, isValueOpen: false},
+    )
+  };
+
+  onValueClear = () => {
+    this.setState(
+      {valueSelections: [], isValueOpen: false},
+      () => this.props.setFilter(this.state.fieldSelection, this.state.valueSelections)
+    )
+  }
+
+  updateValueOptions = () => {
+    const {fieldSelection} = this.state
+    const {customFilters} = this.props
+
+    console.log('CUSTOMFILTER: '+customFilters)
+    if (fieldSelection !== null) {
+      let api_filter = toAPIFilter(customFilters).join()
+      console.log('APIFILTER: '+customFilters)
+
+      HttpClient.get(
+        [Settings.serverUrl, 'widget', 'result-aggregator'],
+        {
+          group_field: fieldSelection,
+          run_id: this.props.runId,
+          additional_filters: api_filter,
+        }
+      )
+      .then(response => HttpClient.handleResponse(response))
+      .then(data => {
+        this.setState({valueOptions: data})
+      })
+    }
+  }
+
+  render () {
+    const {isFieldOpen, fieldSelection, isValueOpen, valueOptions, valueSelections} = this.state;
+    let field_selected = this.state.fieldSelection !== null;
+    let values_available = valueOptions.length > 0;
+    let value_placeholder = "Select a field first" ; // default instead of an else block
+    if (field_selected && values_available){ value_placeholder = "Select value(s)";}
+    else if (field_selected && !values_available) { value_placeholder = "No values for selected field";}
+    return (
+      <React.Fragment>
+        <Select key="metafield_select"
+          aria-label="metadata-field-filter"
+          placeholderText="Select metadata field"
+          variant={SelectVariant.single}
+          isOpen={isFieldOpen}
+          selections={fieldSelection}
+          maxHeight={"1140%"}
+          onToggle={this.onFieldToggle}
+          onSelect={this.onFieldSelect}
+          onClear={this.onFieldClear}
+        >
+          {this.props.fieldOptions.map((option, index) => (
+            <SelectOption key={index} value={option}/>
+          ))}
+        </Select>
+        <Select key="metavalue_select"
+          typeAheadAriaLabel={value_placeholder}
+          placeholderText={value_placeholder}
+          variant={SelectVariant.typeaheadMulti}
+          isOpen={isValueOpen}
+          selections={valueSelections}
+          maxHeight={"1140%"}
+          isDisabled={!field_selected || (field_selected && !values_available) }
+          onToggle={this.onValueToggle}
+          onSelect={this.onValueSelect}
+          onClear={this.onValueClear}
+        >
+          {valueOptions.map((option, index) => (
+            <SelectOption key={index} value={option._id} description={option.count + ' results'}/>
+          ))}
+        </Select>
+      </React.Fragment>
+
+    )
   }
 }

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -4,7 +4,7 @@ export { AddTokenModal } from './add-token-modal';
 export { DeleteModal } from './delete-modal';
 export { EmptyObject } from './empty-object';
 export { FileUpload } from './fileupload';
-export { FilterTable } from './filtertable';
+export { FilterTable, MetaFilter } from './filtertable';
 export { ParamDropdown } from './widget-components';
 export { MultiValueInput } from './multivalueinput';
 export { NewDashboardModal } from './new-dashboard-modal';

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -60,6 +60,26 @@ export const STRING_RESULT_FIELDS = [
   'start_time',  // TODO: handle this with a calendar widget?
   'test_id'
 ];
+export const FILTERABLE_RESULT_FIELDS = [
+  'env',
+  'component',
+  'metadata.assignee',
+  // TODO support array filtering
+  // https://github.com/ibutsu/ibutsu-server/issues/228
+  //'metadata.statuses.call',
+  //'metadata.statuses.setup',
+  //'metadata.statuses.teardown',
+  'metadata.caseautomation',
+  'metadata.exception_name',
+  'metadata.fspath',
+  'metadata.importance',
+  'metadata.title',
+  // TODO support object/dict filtering
+  // https://github.com/ibutsu/ibutsu-server/issues/229
+  //'metadata.params',
+  //'metadata.markers',
+
+]
 export const RESULT_FIELDS = [...NUMERIC_RESULT_FIELDS, ...STRING_RESULT_FIELDS, ...ARRAY_RESULT_FIELDS];
 export const ARRAY_RUN_FIELDS = [
   'metadata.tags',

--- a/frontend/src/utilities.js
+++ b/frontend/src/utilities.js
@@ -101,6 +101,37 @@ export function buildParams(filters) {
   return getParams;
 }
 
+export function buildUrl(url, params) {
+  // shorthand
+  const esc = encodeURIComponent;
+  let query = [];
+  for (const key of Object.keys(params)) {
+    const value = params[key];
+    if (value instanceof Array) {
+      value.forEach(element => {
+        query.push(esc(key) + '=' + esc(element));
+      });
+    }
+    else {
+      query.push(esc(key) + '=' + esc(value));
+    }
+  }
+  return url + '?' + query.join('&');
+}
+
+export function toAPIFilter(filters) {
+  // Take UI style filter object with field/op/val keys and generate an array of filter strings for the API
+  let filter_strings = []
+  for (const key in filters) {
+    if (Object.prototype.hasOwnProperty.call(filters, key) && !!filters[key]) {
+      const val = filters[key]['val'];
+      const op = OPERATIONS[filters[key]['op']];
+      filter_strings.push(key + op + val);
+    }
+  }
+  return filter_strings
+}
+
 export function round(number) {
   let rounded = Math.round(number * 10);
   return rounded / 10;


### PR DESCRIPTION
Alternative to #221 that is more generic. Similar to the filters used on
the run/results page, and could be an abstract replacement for their
current filters.


## TODO
- [x] complete functions for field/value clear
- [x] complete function for value select
- [x] add checkbox to apply `not` operator (`eq` and `in` will be inferred)  #230 
- [x] handling of null value metadata (key only) :: Specific list of metadata fields that can be filtered has been added. Outside of this PR scope to further abstract this.
- [x] handling of non-string metadata, dates, etc. :: Specific list of metadata fields that can be filtered has been added. Outside of this PR scope to further abstract this.
- [ ] Rebase to account for Auth

## Preview
### Nothing selected
![image](https://user-images.githubusercontent.com/21315076/137390824-ea46bd2a-eb55-49e9-9f00-4303b8350105.png)

### Field selected with no values available
![image](https://user-images.githubusercontent.com/21315076/137390905-d9f0ea4a-9502-4d28-9893-a74d8b700697.png)

### Field selected with values available/selected
![image](https://user-images.githubusercontent.com/21315076/137390972-8cb95ad0-c59f-48c8-a7be-feaeffeae7a0.png)

