### PR TITLE
Fix count estimation

### DIFF
--- a/backend/ibutsu_server/controllers/result_controller.py
+++ b/backend/ibutsu_server/controllers/result_controller.py
@@ -107,7 +107,7 @@ def get_result_list(filter_=None, page=1, page_size=25, estimate=False, token_in
                 query = query.filter(filter_clause)
 
     if estimate:
-        total_items = get_count_estimate(query)
+        total_items = get_count_estimate(query, model=Result)
     else:
         total_items = query.count()
 

--- a/backend/ibutsu_server/controllers/run_controller.py
+++ b/backend/ibutsu_server/controllers/run_controller.py
@@ -73,7 +73,7 @@ def get_run_list(filter_=None, page=1, page_size=25, estimate=False, token_info=
                 query = query.filter(filter_clause)
 
     if estimate:
-        total_items = get_count_estimate(query)
+        total_items = get_count_estimate(query, model=Run)
     else:
         total_items = query.count()
 


### PR DESCRIPTION
After the auth PR was merged, count estimation was wildly incorrect because the query with the user filter changed the `EXPLAIN` result significantly. 

The rows it estimated were not from the table but instead from the `Nested Loop` in the first tuple of this list:
```console
(Pdb) print(session.execute(Explain(query)).fetchall())
(Pdb) [('Nested Loop  (cost=0.00..10221.73 rows=56163 width=662)',), ('  ->  Seq Scan on projects  (cost=0.00..9498.80 rows=291 width=0)',), ("        Filter: ((alternatives: SubPlan 1 or hashed SubPlan 2) OR ('2f7c202e-9526-4371-8cde-d16da552ed02'::uuid = owner_id))",), ('        SubPlan 1',), ('          ->  Nested Loop  (cost=0.30..16.35 rows=1 width=0)',), ('                ->  Index Only Scan using users_projects_pkey on users_projects  (cost=0.15..8.17 rows=1 width=16)',), ("                      Index Cond: ((user_id = '2f7c202e-9526-4371-8cde-d16da552ed02'::uuid) AND (project_id = projects.id))",), ('                ->  Index Only Scan using users_pkey on users  (cost=0.15..8.17 rows=1 width=16)',), ("                      Index Cond: (id = '2f7c202e-9526-4371-8cde-d16da552ed02'::uuid)",), ('        SubPlan 2',), ('          ->  Nested Loop  (cost=4.35..22.59 rows=7 width=16)',), ('                ->  Index Only Scan using users_pkey on users users_1  (cost=0.15..8.17 rows=1 width=16)',), ("                      Index Cond: (id = '2f7c202e-9526-4371-8cde-d16da552ed02'::uuid)",), ('                ->  Bitmap Heap Scan on users_projects users_projects_1  (cost=4.21..14.35 rows=7 width=32)',), ("                      Recheck Cond: (user_id = '2f7c202e-9526-4371-8cde-d16da552ed02'::uuid)",), ('                      ->  Bitmap Index Scan on users_projects_pkey  (cost=0.00..4.21 rows=7 width=0)',), ("                            Index Cond: (user_id = '2f7c202e-9526-4371-8cde-d16da552ed02'::uuid)",), ('  ->  Materialize  (cost=0.00..21.38 rows=193 width=662)',), ('        ->  Seq Scan on results  (cost=0.00..20.41 rows=193 width=662)',), ("              Filter: (project_id = 'ebd282fd-5be0-486d-a9ba-a147e4187f51'::uuid)",)]

```
This PR is modifying the count_estimate to look for the tuple that contains the string `Seq Scan on <tablename>` and using the rows from that. 

Note this PR is based on #237, so that one should be merged first.