### PR TITLE
Add ability to create superadmin user on startup

### DIFF
--- a/backend/ibutsu_server/db/util.py
+++ b/backend/ibutsu_server/db/util.py
@@ -1,9 +1,6 @@
 """
 Various utility DB functions
 """
-from base64 import urlsafe_b64encode
-from uuid import uuid4
-
 from ibutsu_server.db.models import User
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.expression import _literal_as_text
@@ -51,7 +48,6 @@ def add_superadmin(session, admin_user):
             password=admin_user["password"],
             is_superadmin=True,
             is_active=True,
-            activation_code=urlsafe_b64encode(str(uuid4()).encode("utf8")).strip(b"=").decode(),
         )
 
     session.add(user)

--- a/ocp-templates/prod/backend.yaml
+++ b/ocp-templates/prod/backend.yaml
@@ -29,9 +29,9 @@ objects:
         containers:
         - env:
           - name: GUNICORN_PROCESSES
-            value: 1
+            value: "1"
           - name: PORT
-            value: 8080
+            value: "8080"
           - name: APP_CONFIG
             value: config.py
           - name: HAS_FRONTEND
@@ -60,6 +60,21 @@ objects:
               secretKeyRef:
                 key: database-password
                 name: redis
+          - name: IBUTSU_SUPERADMIN_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: email
+                name: ibutsu-superadmin
+          - name: IBUTSU_SUPERADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: ibutsu-superadmin
+          - name: IBUTSU_SUPERADMIN_NAME
+            valueFrom:
+              secretKeyRef:
+                key: name
+                name: ibutsu-superadmin
           - name: CELERY_BROKER_URL
             value: redis://:${REDIS_PASSWORD}@redis.${NAMESPACE}.svc
           - name: CELERY_RESULT_BACKEND
@@ -163,6 +178,17 @@ objects:
     tls:
       insecureEdgeTerminationPolicy: Redirect
       termination: edge
+# ------------------------------------------------
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: ibutsu-superadmin
+    namespace: ${NAMESPACE}
+  type: opaque
+  stringData:
+    email: ${IBUTSU_SUPERADMIN_EMAIL}
+    password: ${IBUTSU_SUPERADMIN_PASSWORD}
+    name: ${IBUTSU_SUPERADMIN_NAME}
 # ===============================================
 # Parameters
 # ===============================================
@@ -188,3 +214,17 @@ parameters:
   description: The password for Redis
   generate: expression
   from: '[\w]{16}'
+- name: IBUTSU_SUPERADMIN_EMAIL
+  displayName: Superadmin Email
+  description: The email for the superadmin of Ibutsu
+  generate: expression
+  from: 'admin-[\a\d]{8}@ibutsu.com'
+- name: IBUTSU_SUPERADMIN_PASSWORD
+  displayName: Superadmin Password
+  description: The password for the superadmin of Ibutsu
+  generate: expression
+  from: '[\w]{16}'
+- name: IBUTSU_SUPERADMIN_NAME
+  displayName: Superadmin Name
+  description: The name superadmin of Ibutsu
+  value: Ibutsu Admin

--- a/ocp-templates/stage/backend.yaml
+++ b/ocp-templates/stage/backend.yaml
@@ -31,9 +31,9 @@ objects:
           - name: APP_CONFIG
             value: config.py
           - name: PORT
-            value: 8080
+            value: "8080"
           - name: GUNICORN_PROCESSES
-            value: 1
+            value: "1"
           - name: HAS_FRONTEND
             value: "false"
           - name: POSTGRESQL_HOST
@@ -60,6 +60,21 @@ objects:
               secretKeyRef:
                 key: database-password
                 name: redis
+          - name: IBUTSU_SUPERADMIN_EMAIL
+            valueFrom:
+              secretKeyRef:
+                key: email
+                name: ibutsu-superadmin
+          - name: IBUTSU_SUPERADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: ibutsu-superadmin
+          - name: IBUTSU_SUPERADMIN_NAME
+            valueFrom:
+              secretKeyRef:
+                key: name
+                name: ibutsu-superadmin
           - name: CELERY_BROKER_URL
             value: redis://:${REDIS_PASSWORD}@redis.${NAMESPACE}.svc
           - name: CELERY_RESULT_BACKEND
@@ -163,6 +178,17 @@ objects:
     tls:
       insecureEdgeTerminationPolicy: Redirect
       termination: edge
+# ------------------------------------------------
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: ibutsu-superadmin
+    namespace: ${NAMESPACE}
+  type: opaque
+  stringData:
+    email: ${IBUTSU_SUPERADMIN_EMAIL}
+    password: ${IBUTSU_SUPERADMIN_PASSWORD}
+    name: ${IBUTSU_SUPERADMIN_NAME}
 # ===============================================
 # Parameters
 # ===============================================
@@ -188,3 +214,17 @@ parameters:
   description: The password for Redis
   generate: expression
   from: '[\w]{16}'
+- name: IBUTSU_SUPERADMIN_EMAIL
+  displayName: Superadmin Email
+  description: The email for the superadmin of Ibutsu
+  generate: expression
+  from: 'admin-[\a\d]{8}@ibutsu.com'
+- name: IBUTSU_SUPERADMIN_PASSWORD
+  displayName: Superadmin Password
+  description: The password for the superadmin of Ibutsu
+  generate: expression
+  from: '[\w]{16}'
+- name: IBUTSU_SUPERADMIN_NAME
+  displayName: Superadmin Name
+  description: The name superadmin of Ibutsu
+  value: Ibutsu Admin


### PR DESCRIPTION
Create a super admin given environment variables. 

- [x] Update the template to generate a superadmin

I built this image locally and tagged it as `quay.io/ibutsu/backend:add-superadmin-startup` so we can test it on the staging server.