### PR TITLE
Add superadmin user after upgrading db

### DIFF
--- a/backend/ibutsu_server/__init__.py
+++ b/backend/ibutsu_server/__init__.py
@@ -82,6 +82,7 @@ def get_app(**extra_config):
 
     with app.app.app_context():
         db.create_all()
+        upgrade_db(session, upgrades)
         # add a superadmin user
         if config.get("IBUTSU_SUPERADMIN_EMAIL") and config.get("IBUTSU_SUPERADMIN_PASSWORD"):
             add_superadmin(
@@ -92,7 +93,6 @@ def get_app(**extra_config):
                     "name": config.get("IBUTSU_SUPERADMIN_NAME"),
                 },
             )
-        upgrade_db(session, upgrades)
 
     @app.route("/")
     def index():


### PR DESCRIPTION
Follow up from #248, in the stage env I tried to start the backend with a DB replicated from the prod DB. The container fails to startup with an error in the `add_superadmin` script. 

This is because the database has not yet been updated to include the columns for Users table. We need to upgrade before trying to add the superadmin. 