### PR TITLE
Add a way to disable basic auth for non-superadmins

### DIFF
--- a/backend/ibutsu_server/test/__init__.py
+++ b/backend/ibutsu_server/test/__init__.py
@@ -198,13 +198,7 @@ class MockRun(MockModel):
 
 
 class MockUser(MockModel):
-    COLUMNS = [
-        "id",
-        "email",
-        "password",
-        "name",
-        "group_id",
-    ]
+    COLUMNS = ["id", "email", "password", "name", "group_id", "is_superadmin"]
 
     def check_password(self, plain):
         self._test_password = plain

--- a/backend/ibutsu_server/test/test_login_controller.py
+++ b/backend/ibutsu_server/test/test_login_controller.py
@@ -11,7 +11,9 @@ from ibutsu_server.util.jwt import generate_token
 MOCK_ID = "6f7c2d52-54dc-4309-8e2e-c74515d39455"
 MOCK_EMAIL = "test@example.com"
 MOCK_PASSWORD = "my super secret password"
-MOCK_USER = MockUser(id=MOCK_ID, email=MOCK_EMAIL, password=MOCK_PASSWORD, name="Test User")
+MOCK_USER = MockUser(
+    id=MOCK_ID, email=MOCK_EMAIL, password=MOCK_PASSWORD, name="Test User", is_superadmin=False
+)
 
 
 class TestLoginController(BaseTestCase):

--- a/frontend/src/login.js
+++ b/frontend/src/login.js
@@ -121,7 +121,8 @@ export class Login extends React.Component {
             this.setState({
               alert: {message: AuthService.loginError.message, status: 'danger'},
               isValidEmail: false,
-              isValidPassword: false
+              isValidPassword: false,
+              isLoggingIn: false
             });
           }
         })
@@ -129,7 +130,8 @@ export class Login extends React.Component {
           this.setState({
             alert: {message: error, status: 'danger'},
             isValidEmail: false,
-            isValidPassword: false
+            isValidPassword: false,
+            isLoggingIn: false
           });
         });
     }
@@ -162,7 +164,9 @@ export class Login extends React.Component {
 
   onKeycloakLogin = () => {
     const { server_url, realm, client_id } = this.state.externalLogins.keycloak;
-    KeycloakService.login(server_url, realm, client_id);
+    this.setState({isLoggingIn: true}, () => {
+      KeycloakService.login(server_url, realm, client_id);
+    });
   }
 
   onFacebookLogin = (response) => {


### PR DESCRIPTION
- Add a config option for disabling basic auth - `USER_LOGIN_ENABLED`
- Minor UX enhancement for showing the spinner when keycloak is used
- Stopping the spinner when we get back a 401 from the backend. 

![Screenshot from 2021-12-21 09-11-58](https://user-images.githubusercontent.com/44065123/146970965-917b9cb2-194a-4e38-8f71-1bc5352edd7f.png)
