### PR TITLE
Small improvements test history

### DIFF
--- a/frontend/src/components/classify-failures.js
+++ b/frontend/src/components/classify-failures.js
@@ -78,12 +78,14 @@ export class ClassifyFailuresTable extends React.Component {
       let result = rows[rowIndex].result;
       let hideSummary=true;
       let hideTestObject=true;
+      let defaultTab="test-history";
       if (result.result === "skipped") {
         hideSummary=false;
         hideTestObject=false;
+        defaultTab="summary";
       }
       rows[rowIndex + 1].cells = [{
-        title: <ResultView hideTestHistory={false} hideSummary={hideSummary} hideTestObject={hideTestObject} testResult={rows[rowIndex].result}/>
+        title: <ResultView defaultTab={defaultTab} hideTestHistory={false} hideSummary={hideSummary} hideTestObject={hideTestObject} testResult={rows[rowIndex].result}/>
       }]
     }
     rows[rowIndex].isOpen = isOpen;

--- a/frontend/src/components/result.js
+++ b/frontend/src/components/result.js
@@ -59,6 +59,7 @@ export class ResultView extends React.Component {
   static propTypes = {
     testResult: PropTypes.object,
     resultId: PropTypes.string,
+    defaultTab: PropTypes.string,
     hideSummary: PropTypes.bool,
     hideTestObject: PropTypes.bool,
     hideTestHistory: PropTypes.bool,
@@ -85,7 +86,10 @@ export class ResultView extends React.Component {
   }
 
   getDefaultTab() {
-    if (!this.props.hideSummary) {
+    if (this.props.defaultTab) {
+      return this.props.defaultTab;
+    }
+    else if (!this.props.hideSummary) {
       return 'summary';
     }
     else if (!!this.state && this.state.artifactTabs.length > 0) {
@@ -205,6 +209,9 @@ export class ResultView extends React.Component {
 
   componentDidMount() {
     this.getResult();
+    if (this.state.activeTab === "test-history") {
+      this.getTestHistoryTable();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
- Move the summary down where table filters would be
- Add a link to the most recent passed result
- Default to open the "test-history" tab on the classify-failures page
- Load the summary before the table

New look:
![Screenshot from 2022-01-14 13-25-22](https://user-images.githubusercontent.com/44065123/149587274-00850edb-9aa2-409d-89a4-046172117692.png)
