### PR TITLE
Only filter on env if an env is not null

### DIFF
--- a/frontend/src/components/test-history.js
+++ b/frontend/src/components/test-history.js
@@ -65,11 +65,14 @@ export class TestHistoryTable extends React.Component {
       filters: Object.assign({
         'result': {op: 'in', val: "passed;skipped;failed;error;xpassed;xfailed"},
         'test_id': {op: 'eq', val: props.testResult.test_id},
-        'env': {op: 'eq', val: props.testResult.env},
         // default to filter only from 1 weeks ago to the most test's start_time.
         'start_time': {op: 'gt', val: new Date(new Date(props.testResult.start_time).getTime() - (0.25 * 30 * 86400 * 1000)).toISOString()}
         }, props.filters),
     };
+    // filter on env by default
+    if (props.testResult.env) {
+      this.state.filters["env"] = {op: 'eq', val: props.testResult.env};
+    }
     this.refreshResults = this.refreshResults.bind(this);
     this.onCollapse = this.onCollapse.bind(this);
   }


### PR DESCRIPTION
For many projects (e.g. SatQE), `env` will be null as it's kind of an IQE specific thing. 
On the test history page we shouldn't default to filtering on a `null` field. 