### PR TITLE
Adding project setup fixes to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,15 @@ which is browseable from `/api/ui/`
 
 ## Requirements
 
-To run the server locally for development, you can use `podman` by running:
+To run the server locally for development, you can use `podman` by first running:
+```console
+ln -s backend/default.settings.yaml backend/settings.yaml
+```
+from the root of the repository, then:
 ```console
 ./scripts/ibutsu-pod.sh
 ```
-from the root of the repository.
+to start the project.
 
 Otherwise the following must be installed:
 

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -65,7 +65,8 @@ podman run -dit \
        -w /mnt \
        -v./frontend:/mnt/:Z \
        node:latest \
-       /bin/bash -c 'yarn install &&
+       /bin/bash -c 'export NODE_OPTIONS=--openssl-legacy-provider &&
+       		     yarn install &&
                      yarn run devserver' > /dev/null
 echo "done."
 echo -n "Waiting for frontend to respond..."
@@ -87,6 +88,6 @@ echo ""
 echo "Ibutsu has been deployed into the pod: ${POD_NAME}."
 echo "  Frontend URL: http://localhost:3000"
 echo "  Backend URL: http://localhost:8080"
-echo "  Admin user: admin@example / admin12345"
+echo "  Admin user: admin@example.com / admin12345"
 echo "  Project ID: ${PROJECT_ID}"
 echo "Stop the pod by running: 'podman pod rm -f ${POD_NAME}'"


### PR DESCRIPTION
I was unable to start the project without the settings.yaml symlink in `backend/`. I'm adding that step to setup and also adding .com to the login credentials for clarity.