### PR TITLE
Fix metadata reading during test import

### DIFF
--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -161,7 +161,7 @@ def _populate_result_metadata(run_dict, result_dict, import_record, has_metadata
     """To reduce cognitive complexity"""
     # Extend the result metadata with import metadata, and add env and component
     if has_metadata:
-        result_dict["metadata"].update(run_dict["data"])
+        result_dict["metadata"].update(run_dict["metadata"])
         result_dict["env"] = run_dict.get("env")
         result_dict["component"] = run_dict.get("component")
     if import_record.data.get("project_id"):

--- a/backend/ibutsu_server/test/res/combined.xml
+++ b/backend/ibutsu_server/test/res/combined.xml
@@ -1,0 +1,295 @@
+<testsuites>
+        <testsuite errors="0" failures="0" name="pytest" skipped="29" tests="164" time="3911.311" timestamp="2022-02-22T23:02:03.200802">
+            <testcase classname="tests.api.test_fact_cache.TestFactCache" name="test_consume_facts_with_custom_ansible_module" time="0.129">
+                <skipped message="Skipping due to unresolved github issues:&#10;https://github.com/ansible/awx/issues/11560 [open] AWX believes facts are modified even when gather_facts=false" type="pytest.skip">
+                    /home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/pytest_github/plugin.py:307: Skipping
+                    due to unresolved github issues:
+                    https://github.com/ansible/awx/issues/11560 [open] AWX believes facts are modified even when
+                    gather_facts=false
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.test_custom_virtualenv.TestCustomVirtualenv" name="test_venv_pip_works" time="0.392">
+                <skipped message="test requires tower version maximum of 3.8.99, found tower version 4.2.0" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/markers/markers.py:97: test requires tower
+                    version maximum of 3.8.99, found tower version 4.2.0
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.test_activity_stream.TestActivityStream" name="test_deleted_uj_logged_as_deleted_user[job]" time="110.002" />
+            <testcase classname="tests.api.test_fact_cache.TestFactCache" name="test_use_fact_cache_for_host_with_large_hostvars" time="129.768" />
+            <testcase classname="tests.api.test_hub.TestHub" name="test_hub_token" time="23.911" />
+            <testcase classname="tests.api.test_hub.TestHub" name="test_hub_create_namespace" time="0.171" />
+            <testcase classname="tests.api.test_named_urls.TestNamedURLs" name="test_named_url_formats" time="25.142" />
+            <testcase classname="tests.api.test_hub.TestHub" name="test_hub_namespace_create_rbac" time="1.028" />
+            <testcase classname="tests.api.test_task_manager.Test_Sequential_Jobs" name="test_inventory_update" time="115.457" />
+            <testcase classname="tests.api.auth.test_basic_auth.TestBasicAuth" name="test_basic_auth" time="2.545" />
+            <testcase classname="tests.api.test_hub.TestHubTowerIntegration" name="test_hub_tower_integration" time="90.724" />
+            <testcase classname="tests.api.auth.test_basic_auth.TestBasicAuth" name="test_basic_auth_user_in_mutliple_orgs_with_teams" time="10.656" />
+            <testcase classname="tests.api.test_ad_hoc_commands.Test_Ad_Hoc_Commands_Main" name="test_launch_with_ask_credential_and_passwords_in_payload[sudo]" time="69.720" />
+            <testcase classname="tests.api.cluster.test_hop_instances.TestHopInstances" name="test_hop_health_check" time="0.200">
+                <skipped message="This test can only run on installation that have hop-type nodes" type="pytest.skip">
+                    /home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:168: This test can only run on installation
+                    that have hop-type nodes
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.cluster.test_hop_instances.TestHopInstances" name="test_hop_modified_by_api" time="0.133">
+                <skipped message="Skipping due to unresolved github issues:&#10;https://github.com/ansible/awx/issues/11622 [open] Hop nodes instances can be modified" type="pytest.skip">
+                    /home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/pytest_github/plugin.py:307: Skipping
+                    due to unresolved github issues:
+                    https://github.com/ansible/awx/issues/11622 [open] Hop nodes instances can be modified
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.cluster.test_hop_instances.TestHopInstances" name="test_hop_association_to_instance_group" time="0.156">
+                <skipped message="This test can only run on installation that have hop-type nodes" type="pytest.skip">
+                    /home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:168: This test can only run on installation
+                    that have hop-type nodes
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.cluster.test_instances.TestInstances" name="test_control_plane_instances_last_seen_equals_ping_heartbeat" time="1.118" />
+            <testcase classname="tests.api.cluster.test_instances.TestInstances" name="test_execution_instances_last_seen_equals_ping_heartbeat" time="0.318" />
+            <testcase classname="tests.api.copy.test_copy_credential.Test_Copy_Credential" name="test_check_copied_secret_input" time="72.007" />
+            <testcase classname="tests.api.test_channels.TestJobChannels" name="test_job_events_subscribe" time="77.854" />
+            <testcase classname="tests.api.test_ad_hoc_commands.Test_Ad_Hoc_Commands_Main" name="test_launch_with_ask_credential_and_passwords_in_payload[su]" time="18.247" />
+            <testcase classname="tests.api.test_prompts.TestPrompts" name="test_created_schedule_from_wfj_with_ask_jt" time="45.677" />
+            <testcase classname="tests.api.test_ad_hoc_commands.Test_Ad_Hoc_Commands_Main" name="test_launch_with_ask_credential_and_passwords_in_payload[pbrun]" time="10.006" />
+            <testcase classname="tests.api.test_labels.Test_Labels" name="test_reference_delete_with_job_template_disassociation[regular_tower_instance]" time="97.959" />
+            <testcase classname="tests.api.test_labels.Test_Labels" name="test_reference_delete_with_job_template_disassociation[isolated_node]" time="0.003">
+                <skipped message="Isolated node support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:126: Isolated node
+                    support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.test_labels.Test_Labels" name="test_reference_delete_with_job_template_disassociation[container_group]" time="0.003">
+                <skipped message="Only running container group tests from standalone instances to not overwhelm our k8s cluster nightly." type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:136: Only running
+                    container group tests from standalone instances to not overwhelm our k8s cluster nightly.
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.copy.test_copy_workflow_job_template.Test_Copy_Workflow_Job_Template" name="test_copy_wfjt_nodes" time="95.010" />
+            <testcase classname="tests.api.test_ad_hoc_commands.Test_Ad_Hoc_Commands_Main" name="test_launch_with_ask_credential_and_passwords_in_payload[pfexec]" time="16.639" />
+            <testcase classname="tests.api.test_activity_stream.TestActivityStream" name="test_deleted_uj_logged_as_deleted_user[workflow job]" time="9.319" />
+            <testcase classname="tests.api.cluster.test_execution_nodes.TestExecutionNodes" name="test_execution_nodes_type" time="1.680" />
+            <testcase classname="tests.api.cluster.test_execution_nodes.TestExecutionNodes" name="test_execution_node_default_membership" time="0.889" />
+            <testcase classname="tests.api.cluster.test_execution_nodes.TestExecutionNodes" name="test_cleanup_private_data_dir" time="42.939" />
+            <testcase classname="tests.api.test_ad_hoc_commands.Test_Ad_Hoc_Commands_Main" name="test_launch_with_ask_credential_and_passwords_in_payload[dzdo]" time="13.688" />
+            <testcase classname="tests.api.test_task_manager.Test_Autospawned_Jobs" name="test_inventory_multiple" time="94.097" />
+            <testcase classname="tests.api.test_activity_stream.TestActivityStream" name="test_deleted_uj_logged_as_deleted_user[ad hoc command]" time="19.328" />
+            <testcase classname="tests.api.test_prompts.TestPrompts" name="test_launch_credentials_override_default_wfjn_credentials" time="64.011" />
+            <testcase classname="tests.api.copy.test_copy_credential.Test_Copy_Credential" name="test_check_copied_input_sources" time="66.349" />
+            <testcase classname="tests.api.auth.test_application_tokens.TestTokenAuthentication" name="test_access_token_revocation" time="7.431" />
+            <testcase classname="tests.api.test_ad_hoc_commands.Test_Ad_Hoc_Commands_Main" name="test_command_page_update" time="28.894" />
+            <testcase classname="tests.api.test_activity_stream.TestActivityStream" name="test_deleted_uj_logged_as_deleted_user[project_update]" time="35.172" />
+            <testcase classname="tests.api.auth.test_application_tokens.TestDjangoOAuthToolkitTokenManagement" name="test_refresh_token[read]" time="6.640" />
+            <testcase classname="tests.api.auth.test_application_tokens.TestDjangoOAuthToolkitTokenManagement" name="test_refresh_token[write]" time="2.367" />
+            <testcase classname="tests.api.inventories.test_inventory_update.TestInventoryUpdate" name="test_update_with_overwrite_vars_group" time="62.370" />
+            <testcase classname="tests.api.execution_environments.test_ee_models_basic.TestEEModelsBasic" name="test_create_ee_with_success" time="1.801" />
+            <testcase classname="tests.api.execution_environments.test_ee_models_basic.TestEEModelsBasic" name="test_create_ee_name_unique" time="1.966" />
+            <testcase classname="tests.api.execution_environments.test_ee_models_basic.TestEEModelsBasic" name="test_create_ee_name_blank" time="0.521" />
+            <testcase classname="tests.api.execution_environments.test_ee_models_basic.TestEEModelsBasic" name="test_create_ee_image_can_be_duplicated" time="4.916" />
+            <testcase classname="tests.api.cluster.test_execution_nodes.TestExecutionNodes" name="test_cleanup_after_receptor_cancel" time="0.145">
+                <skipped message="Skipping due to unresolved github issues:&#10;https://github.com/ansible/awx/issues/11110 [open] Execution node jobs canceled (via receptor) while in progress show as running forever" type="pytest.skip">
+                    /home/ec2-user/venvs/test-controller/lib64/python3.9/site-packages/pytest_github/plugin.py:307: Skipping
+                    due to unresolved github issues:
+                    https://github.com/ansible/awx/issues/11110 [open] Execution node jobs canceled (via receptor) while in
+                    progress show as running forever
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.execution_environments.test_ee_models_basic.TestEEModelsBasic" name="test_create_ee_image_blank" time="1.588" />
+            <testcase classname="tests.api.execution_environments.test_ee_models_basic.TestEEModelsBasic" name="test_create_ee_image_with_invalid_format" time="1.899" />
+            <testcase classname="tests.api.inventories.test_smart_inventory.TestSmartInventory" name="test_launch_ahc_with_smart_inventory" time="26.728" />
+            <testcase classname="tests.api.test_activity_stream.TestActivityStream" name="test_deleted_uj_logged_as_deleted_user[inventory_update]" time="38.289" />
+            <testcase classname="tests.api.copy.test_copy_job_template.Test_Copy_Job_Template" name="test_copy_jt_survey_spec" time="33.282" />
+            <testcase classname="tests.api.inventories.test_group.TestGroup" name="test_reassociate_with_non_root_group[non_root_variation0]" time="33.121" />
+            <testcase classname="tests.api.copy.test_copy_project.Test_Copy_Project" name="test_copy_project_with_non_default_values" time="16.719" />
+            <testcase classname="tests.api.credentials.test_credential_search.TestCredentialSearchLegacy" name="test_search_by_modifier" time="0.001">
+                <skipped message="test requires tower version maximum of 3.8.99, found tower version 4.2.0" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/markers/markers.py:97: test requires tower
+                    version maximum of 3.8.99, found tower version 4.2.0
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.credentials.test_credential_search.TestCredentialSearchLegacy" name="test_search_by_sourcing_workflow_job_template_node_and_workflow_job_node" time="0.000">
+                <skipped message="test requires tower version maximum of 3.8.99, found tower version 4.2.0" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/markers/markers.py:97: test requires tower
+                    version maximum of 3.8.99, found tower version 4.2.0
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.credentials.test_credential_search.TestCredentialSearch" name="test_search_by_modifier" time="5.493" />
+            <testcase classname="tests.api.inventories.test_smart_inventory.TestSmartInventory" name="test_launch_job_template_with_smart_inventory" time="47.292" />
+            <testcase classname="tests.api.credentials.test_credential_search.TestCredentialSearch" name="test_search_by_sourcing_workflow_job_template_node_and_workflow_job_node" time="48.548" />
+            <testcase classname="tests.api.inventories.test_host_filter.TestHostFilter" name="test_nested_list_password_search" time="2.694" />
+            <testcase classname="tests.api.inventories.test_host_filter.TestHostFilter" name="test_unicode_search" time="7.771" />
+            <testcase classname="tests.api.inventories.test_inventory_update.TestInventoryUpdate" name="test_update_with_stdout_injection" time="43.699" />
+            <testcase classname="tests.api.cluster.test_control_nodes.TestControlNodes" name="test_ha_config" time="0.667" />
+            <testcase classname="tests.api.test_activity_stream.TestActivityStream" name="test_deleted_uj_logged_as_deleted_user[system job]" time="10.708" />
+            <testcase classname="tests.api.inventories.test_group.TestGroup" name="test_reassociate_with_non_root_group[non_root_variation1]" time="31.040" />
+            <testcase classname="tests.api.credentials.test_custom_credentials.TestCustomCredentials" name="test_file_injector_path_from_variable[extra_var]" time="40.014" />
+            <testcase classname="tests.api.test_activity_stream.TestActivityStream" name="test_fish_for_sensitive_content" time="0.919" />
+            <testcase classname="tests.api.job_templates.test_job_template_credentials.TestJobTemplateLaunchCredentials" name="test_launch_with_multiple_credentials" time="57.534" />
+            <testcase classname="tests.api.job_templates.test_job_template_extra_vars.TestJobTemplateExtraVars" name="test_launch_with_variables_needed_to_start_and_extra_vars_at_launch[job_template_with_json_vars-json_launch_time_vars]" time="37.231" />
+            <testcase classname="tests.api.inventories.test_group.TestGroup" name="test_reassociate_with_non_root_group[non_root_variation2]" time="35.865" />
+            <testcase classname="tests.api.cluster.test_control_nodes.TestControlNodes" name="test_control_nodes_cannot_change_ig_membership" time="1.316" />
+            <testcase classname="tests.api.cluster.test_control_nodes.TestControlNodes" name="test_control_nodes_cannot_be_deleted_from_controlplane_group" time="0.652" />
+            <testcase classname="tests.api.cluster.test_control_nodes.TestControlNodes" name="test_control_plane_node_type" time="0.235" />
+            <testcase classname="tests.api.inventories.test_tower_manage_import.TestTowerManageInventoryImport" name="test_import_by_name" time="25.470" />
+            <testcase classname="tests.api.credentials.test_custom_credentials.TestCustomCredentials" name="test_file_injector_path_from_variable[env_var]" time="36.012" />
+            <testcase classname="tests.api.inventories.test_scm_inventory_source.TestSCMInventorySource" name="test_inventory_update_using_update_on_project_update_without_scm_change" time="55.982" />
+            <testcase classname="tests.api.job_templates.test_extravars.TestExtraVarsStoreRetreiveJsonYaml" name="test_job_templates_extra_var_attr_yaml_post" time="27.099" />
+            <testcase classname="tests.api.job_templates.test_job_template_surveys.TestJobTemplateSurveys" name="test_launch_with_optional_survey_spec" time="47.999" />
+            <testcase classname="tests.api.job_templates.test_job_template_credentials.TestJobTemplateLaunchCredentials" name="test_provide_additional_vault_credential_on_launch" time="45.339" />
+            <testcase classname="tests.api.job_templates.test_job_template_extra_vars.TestJobTemplateExtraVars" name="test_launch_with_variables_needed_to_start_and_extra_vars_at_launch[job_template_with_json_vars-yaml_launch_time_vars]" time="40.785" />
+            <testcase classname="tests.api.inventories.test_group.TestGroup" name="test_reassociate_with_non_root_group[non_root_variation3]" time="32.120" />
+            <testcase classname="tests.api.credentials.test_custom_credentials.TestCustomCredentials" name="test_credential_creation_and_usage_dont_leak_fields_into_activity_stream" time="54.422" />
+            <testcase classname="tests.api.job_templates.test_extravars.TestExtraVarsStoreRetreiveJsonYaml" name="test_job_templates_extra_var_attr_json_post" time="21.935" />
+            <testcase classname="tests.api.job_templates.test_job_template_surveys.TestJobTemplateSurveys" name="test_confirm_survey_secret_extra_vars_not_in_activity_stream" time="61.991" />
+            <testcase classname="tests.api.job_templates.test_job_template_slicing.TestJobTemplateSlicing" name="test_job_template_slice_workflow_job_relaunch" time="45.590" />
+            <testcase classname="tests.api.job_templates.test_job_template_callbacks.TestJobTemplateCallbacks" name="test_provision_with_provided_variables_needed_to_start" time="60.475" />
+            <testcase classname="tests.api.inventories.test_scm_inventory_source.TestSCMInventorySource" name="test_scm_inv_source_with_update_on_launch_is_synced_on_job_launch" time="76.462" />
+            <testcase classname="tests.api.jobs.test_jobs.Test_Job" name="test_relaunch_uses_extra_vars_from_job[job_template_with_json_vars]" time="49.431" />
+            <testcase classname="tests.api.job_templates.test_job_template_credentials.TestJobTemplateVaultCredentials" name="test_decrypt_vaulted_playbook_with_multiple_ask_on_launch_vault_credentials" time="45.362" />
+            <testcase classname="tests.api.job_templates.test_job_template_extra_vars.TestJobTemplateExtraVars" name="test_launch_with_variables_needed_to_start_and_extra_vars_at_launch[job_template_with_yaml_vars-json_launch_time_vars]" time="40.445" />
+            <testcase classname="tests.api.jobs.test_system_job_templates.Test_System_Job_Template" name="test_launch_with_extra_vars[cleanup_jobs]" time="7.167" />
+            <testcase classname="tests.api.jobs.test_system_job_templates.Test_System_Job_Template" name="test_launch_with_extra_vars[cleanup_activitystream]" time="6.668" />
+            <testcase classname="tests.api.job_templates.test_job_template_callbacks.TestJobTemplateCallbacks" name="test_provision_job_template_with_limit[regular_tower_instance]" time="48.974" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_related_counts[job_template_plain]" time="29.690" />
+            <testcase classname="tests.api.job_templates.test_job_template_extra_vars.TestJobTemplateExtraVars" name="test_launch_with_variables_needed_to_start_and_extra_vars_at_launch[job_template_with_yaml_vars-yaml_launch_time_vars]" time="49.551" />
+            <testcase classname="tests.api.rbac.test_organizations_rbac.Test_Organization_RBAC" name="test_auditor_role" time="10.966" />
+            <testcase classname="tests.api.smoke.test_me.Test_Me" name="test_get" time="17.689" />
+            <testcase classname="tests.api.jobs.test_jobs.Test_Job" name="test_relaunch_uses_extra_vars_from_job[job_template_with_yaml_vars]" time="52.820" />
+            <testcase classname="tests.api.rbac.test_workflow_job_template_rbac.Test_Workflow_Job_Template_RBAC" name="test_user_capabilities[admin]" time="5.219" />
+            <testcase classname="tests.api.job_templates.test_job_template_callbacks.TestJobTemplateCallbacks" name="test_provision_job_template_with_limit[isolated_node]" time="0.003">
+                <skipped message="Isolated node support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:126: Isolated node
+                    support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.job_templates.test_job_template_callbacks.TestJobTemplateCallbacks" name="test_provision_job_template_with_limit[container_group]" time="0.002">
+                <skipped message="Only running container group tests from standalone instances to not overwhelm our k8s cluster nightly." type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:136: Only running
+                    container group tests from standalone instances to not overwhelm our k8s cluster nightly.
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.job_templates.test_job_template_callbacks.TestJobTemplateCallbacks" name="test_job_triggered_by_callback_sources_venv" time="1.541">
+                <skipped message="Cannot run on a cluster install" type="pytest.skip">
+                    /home/ec2-user/tower-qa/tests/lib/fixtures/utils.py:505: Cannot run on a cluster install
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.rbac.test_workflow_job_template_rbac.Test_Workflow_Job_Template_RBAC" name="test_user_capabilities[execute]" time="3.806" />
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_limit_in_payload[regular_tower_instance]" time="41.961" />
+            <testcase classname="tests.api.rbac.test_workflow_job_template_rbac.Test_Workflow_Job_Template_RBAC" name="test_user_capabilities[read]" time="3.769" />
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[organization]" time="25.961" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_related_counts[check_job_template_plain]" time="23.759" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_related_counts[org_user]" time="4.909" />
+            <testcase classname="tests.api.rbac.test_users_rbac.Test_User_RBAC" name="test_org_admin_can_only_edit_users_from_own_organization" time="14.353" />
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_limit_in_payload[isolated_node]" time="0.002">
+                <skipped message="Isolated node support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:126: Isolated node
+                    support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_limit_in_payload[container_group]" time="0.005">
+                <skipped message="Only running container group tests from standalone instances to not overwhelm our k8s cluster nightly." type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:136: Only running
+                    container group tests from standalone instances to not overwhelm our k8s cluster nightly.
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.jobs.test_jobs.Test_Job" name="test_job_host_summary_status_are_accurate" time="29.461" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_related_counts[team]" time="3.506" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_related_counts[org_admin]" time="3.101" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_related_counts[inventory]" time="3.493" />
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[team]" time="7.497" />
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_tags_in_payload[regular_tower_instance-job_tags]" time="34.490" />
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[project]" time="20.213" />
+            <testcase classname="tests.api.schedules.test_schedules.TestSchedules" name="test_schedule_basic_integrity[inventory_source]" time="20.101" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_related_counts[project]" time="15.465" />
+            <testcase classname="tests.api.rbac.test_organizations.Test_Organizations" name="test_organization_host_limits_allow_same_host_multiple_inventories" time="11.840" />
+            <testcase classname="tests.api.smoke.test_tower_prepopulation.Test_Tower_Prepopulation" name="test_success" time="18.043" />
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[inventory]" time="8.585" />
+            <testcase classname="tests.api.schedules.test_schedules.TestSchedules" name="test_schedule_basic_integrity[job_template]" time="16.303" />
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_tags_in_payload[regular_tower_instance-skip_tags]" time="32.639" />
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[inventory_script]" time="0.002">
+                <skipped message="Custom inventory scripts are removed in this version" type="pytest.skip">
+                    /home/ec2-user/tower-qa/tests/api/rbac/test_main_rbac.py:24: Custom inventory scripts are removed in
+                    this version
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[credential]" time="5.223" />
+            <testcase classname="tests.api.workflows.test_combined_workflow_features.TestCombinedWorkflowFeatures" name="test_dense_workflow" time="158.535" />
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[job_template]" time="19.487" />
+            <testcase classname="tests.api.schedules.test_schedules.TestSchedules" name="test_schedule_basic_integrity[project]" time="13.212" />
+            <testcase classname="tests.api.schedules.test_schedules.TestSchedules" name="test_schedule_basic_integrity[workflow_job_template]" time="1.755" />
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_tags_in_payload[isolated_node-job_tags]" time="0.002">
+                <skipped message="Isolated node support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:126: Isolated node
+                    support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_tags_in_payload[isolated_node-skip_tags]" time="0.002">
+                <skipped message="Isolated node support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:126: Isolated node
+                    support was dropped in Tower 4.0.0 https://github.com/ansible/tower/issues/4857
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_tags_in_payload[container_group-job_tags]" time="0.002">
+                <skipped message="Only running container group tests from standalone instances to not overwhelm our k8s cluster nightly." type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:136: Only running
+                    container group tests from standalone instances to not overwhelm our k8s cluster nightly.
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_tags_in_payload[container_group-skip_tags]" time="0.001">
+                <skipped message="Only running container group tests from standalone instances to not overwhelm our k8s cluster nightly." type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/instance.py:136: Only running
+                    container group tests from standalone instances to not overwhelm our k8s cluster nightly.
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_diff_mode_in_payload[True]" time="20.787" />
+            <testcase classname="tests.api.rbac.test_main_rbac.Test_Main_RBAC" name="test_role_association_and_disassociation_as_resource_nonadmin[workflow_job_template]" time="4.922" />
+            <testcase classname="tests.api.job_templates.test_job_templates.TestJobTemplates" name="test_launch_with_diff_mode_in_payload[False]" time="31.420" />
+            <testcase classname="tests.api.workflows.test_workflow_jobs.Test_Workflow_Jobs" name="test_workflow_launched_by_workflow" time="7.399" />
+            <testcase classname="tests.api.test_hub.TestHubTowerIntegration" name="test_discover_hub_collection_via_playbook" time="31.899" />
+            <testcase classname="tests.api.auth.test_basic_auth.TestBasicAuth" name="test_basic_auth_disabled" time="1.700" />
+            <testcase classname="tests.api.cluster.test_instance_groups.TestInstanceGroups" name="test_instance_group_capacity_should_update_for_added_instances" time="1.811" />
+            <testcase classname="tests.api.cluster.test_instance_groups.TestInstanceGroups" name="test_verify_tower_instance_group_is_a_partially_protected_group" time="0.464" />
+            <testcase classname="tests.api.cluster.test_instances.TestInstances" name="test_disabiling_instance_should_not_impact_currently_running_jobs" time="52.158" />
+            <testcase classname="tests.api.cluster.test_instances.TestInstances" name="test_disabiling_instance_should_set_capacity_to_zero" time="0.405" />
+            <testcase classname="tests.api.jobs.test_isolated_paths.Test_Isolated_Paths" name="test_write_and_read_file_isolated_path" time="30.513" />
+            <testcase classname="tests.api.jobs.test_isolated_paths.Test_Isolated_Paths" name="test_read_existing_file_isolated_path[/etc/cron.d/0hourly-# Run the hourly jobs]" time="25.884" />
+            <testcase classname="tests.api.jobs.test_isolated_paths.Test_Isolated_Paths" name="test_read_existing_file_isolated_path[/etc/default/useradd-# useradd defaults file]" time="25.894" />
+            <testcase classname="tests.api.jobs.test_isolated_paths.Test_Isolated_Paths" name="test_read_existing_file_isolated_path[/etc/pki/ca-trust/README-This directory /etc/pki/ca-trust]" time="25.865" />
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[sysadmin]" time="26.120" />
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[org_admin]" time="25.946" />
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[wf_admin]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[org_wf_admin]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[org_approve]" time="20.875" />
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[wf_approve]" time="15.871" />
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[org_executor]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[wf_executor]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[org_read]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[wf_read]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[system_auditor]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[user_in_org]" time="0.001">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.workflows.test_workflow_approval_nodes.TestWorkflowApprovalNodes" name="test_approval_node_happy_path[random_user]" time="0.538">
+                <skipped message="Skipped" type="pytest.skip">/home/ec2-user/tower-qa/tests/lib/fixtures/api/users.py:191:
+                    Skipped
+                </skipped>
+            </testcase>
+            <testcase classname="tests.api.cluster.test_control_nodes.TestControlNodes" name="test_project_update_in_execution_group" time="19.337" />
+        </testsuite>
+    </testsuites>

--- a/backend/ibutsu_server/test/test_importers.py
+++ b/backend/ibutsu_server/test/test_importers.py
@@ -7,6 +7,7 @@ from ibutsu_server.test import BaseTestCase
 
 
 XML_FILE = Path(__file__).parent / "res" / "empty-testsuite.xml"
+XML_FILE_COMBINED = Path(__file__).parent / "res" / "combined.xml"
 
 
 class TestImporterTasks(BaseTestCase):
@@ -34,6 +35,34 @@ class TestImporterTasks(BaseTestCase):
         mocked_record = MagicMock(data={})
         MockImport.query.get.return_value = mocked_record
         mocked_file = MagicMock(content=XML_FILE.open().read().encode("utf8"))
+        MockImportFile.query.filter.return_value.first.return_value = mocked_file
+
+        from ibutsu_server.tasks.importers import run_junit_import
+
+        # We mocked out the @task decorator, use the _orig_func attr to get the original function
+        run_junit_import = run_junit_import._orig_func
+        run_junit_import(mocked_import)
+
+        MockImport.query.get.assert_called_once_with("12345")
+        assert mocked_update.call_args_list == [
+            call(mocked_record, "running"),
+            call(mocked_record, "done"),
+        ]
+        MockImportFile.query.filter.assert_called_once()
+        MockImportFile.query.filter.return_value.first.assert_called_once()
+
+    @patch("ibutsu_server.tasks.importers.ImportFile")
+    @patch("ibutsu_server.tasks.importers.Import")
+    @patch("ibutsu_server.tasks.importers._update_import_status")
+    @patch("ibutsu_server.tasks.importers.session")
+    def test_junit_import_non_empty(
+        self, mocked_session, mocked_update, MockImport, MockImportFile
+    ):
+        """Test the junit importer"""
+        mocked_import = {"id": "12345"}
+        mocked_record = MagicMock(data={"metadata": {"job_name": "foo"}})
+        MockImport.query.get.return_value = mocked_record
+        mocked_file = MagicMock(content=XML_FILE_COMBINED.open().read().encode("utf8"))
         MockImportFile.query.filter.return_value.first.return_value = mocked_file
 
         from ibutsu_server.tasks.importers import run_junit_import


### PR DESCRIPTION
Looks like the run dict exposes the "metadata" property instead of data. Fixing that to properly import tests results. 

Fixes: https://github.com/ibutsu/ibutsu-server/issues/291