### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+Version 2.0.1
+=============
+
+* Clear projects and dashboards when logging out. Fixes #295
+* fix metadata reading during test import
+* Bump url-parse from 1.5.3 to 1.5.10 in /frontend
+* Bump follow-redirects from 1.14.7 to 1.14.8 in /frontend
+* newbie fixes
+* Bump nanoid from 3.1.23 to 3.2.0 in /frontend
+* Only filter on env if an env is not null
+* Add some logging and a URL check (#284)
+* Bump follow-redirects from 1.14.1 to 1.14.7 in /frontend
+* Add JWT secret to template files
+
 Version 2.0.0
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.0.0
+  version: 2.0.1
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 REQUIRES = [
     "alembic",
     # Pin Celery to be compatible with Kombu

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
* Clear projects and dashboards when logging out. Fixes #295
* fix metadata reading during test import
* Bump url-parse from 1.5.3 to 1.5.10 in /frontend
* Bump follow-redirects from 1.14.7 to 1.14.8 in /frontend
* newbie fixes
* Bump nanoid from 3.1.23 to 3.2.0 in /frontend
* Only filter on env if an env is not null
* Add some logging and a URL check (#284)
* Bump follow-redirects from 1.14.1 to 1.14.7 in /frontend
* Add JWT secret to template files