### PR TITLE
Allow to import tests cases without time attr

### DIFF
--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -258,7 +258,7 @@ def run_junit_import(import_):
             result_dict = {
                 "test_id": test_name,
                 "start_time": run_dict["start_time"],
-                "duration": float(testcase.get("time")),
+                "duration": float(testcase.get("time") or 0),
                 "run_id": run.id,
                 "metadata": {
                     "run": run.id,

--- a/backend/ibutsu_server/test/res/collection.xml
+++ b/backend/ibutsu_server/test/res/collection.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuites>
+    <testsuite name="pytest" tests="1" errors="0" failures="0" skipped="0" time="2335.183"
+               timestamp="2022-03-07T21:20:16.602815">
+        <testcase name="action-plugin-docs" classname="sanity"/>
+    </testsuite>
+</testsuites>

--- a/backend/ibutsu_server/test/test_importers.py
+++ b/backend/ibutsu_server/test/test_importers.py
@@ -8,6 +8,7 @@ from ibutsu_server.test import BaseTestCase
 
 XML_FILE = Path(__file__).parent / "res" / "empty-testsuite.xml"
 XML_FILE_COMBINED = Path(__file__).parent / "res" / "combined.xml"
+XML_FILE_COLLECTION = Path(__file__).parent / "res" / "collection.xml"
 
 
 class TestImporterTasks(BaseTestCase):
@@ -78,3 +79,26 @@ class TestImporterTasks(BaseTestCase):
         ]
         MockImportFile.query.filter.assert_called_once()
         MockImportFile.query.filter.return_value.first.assert_called_once()
+
+    @patch("ibutsu_server.tasks.importers.ImportFile")
+    @patch("ibutsu_server.tasks.importers.Import")
+    @patch("ibutsu_server.tasks.importers._update_import_status")
+    @patch("ibutsu_server.tasks.importers.session")
+    def test_junit_import_testcase_without_time(
+        self, mocked_session, mocked_update, MockImport, MockImportFile
+    ):
+        """Test the junit importer"""
+        mocked_import = {"id": "12345"}
+        mocked_record = MagicMock(data={"metadata": {"job_name": "foo"}})
+        MockImport.query.get.return_value = mocked_record
+        mocked_file = MagicMock(content=XML_FILE_COLLECTION.open().read().encode("utf8"))
+        MockImportFile.query.filter.return_value.first.return_value = mocked_file
+
+        from ibutsu_server.tasks.importers import run_junit_import
+
+        # We mocked out the @task decorator, use the _orig_func attr to get the original function
+        run_junit_import = run_junit_import._orig_func
+        run_junit_import(mocked_import)
+
+        MockImport.query.get.assert_called_once_with("12345")
+        mocked_session.add.call_args[0][0].summary["tests"] == 1


### PR DESCRIPTION
Sometimes test cases in the junit report do not have the "time" attribute. In that case, the import will fail to convert None to float. This PR fixes this issue by defaulting the time attribute to 0. 