### PR TITLE
Release 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+Version 2.0.3
+=============
+
+* Add an ellipsis to the heatmap labels
+* Move admin creation into environment variables
+* fix ibutsu-pod script
+* Allow to import tests cases without time attr
+
 Version 2.0.2
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.0.2
+  version: 2.0.3
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.0.2"
+VERSION = "2.0.3"
 REQUIRES = [
     "alembic",
     # Pin Celery to be compatible with Kombu

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
* Add an ellipsis to the heatmap labels
* Move admin creation into environment variables
* Fix ibutsu-pod script
* Allow to import tests cases without time attr