### PR TITLE
fix AttributeError: 'NoneType' object has no attribute 'project'

### DIFF
--- a/backend/ibutsu_server/controllers/result_controller.py
+++ b/backend/ibutsu_server/controllers/result_controller.py
@@ -167,10 +167,10 @@ def update_result(id_, result=None, token_info=None, user=None):
         merge_dicts(user_properties, result_dict["metadata"])
 
     result = Result.query.get(id_)
-    if not project_has_user(result.project, user):
-        return "Forbidden", 403
     if not result:
         return "Result not found", 404
+    if not project_has_user(result.project, user):
+        return "Forbidden", 403
     result.update(result_dict)
     result.env = result.data.get("env") if result.data else None
     result.component = result.data.get("component") if result.data else None


### PR DESCRIPTION
This error is found in logs
```
[2022-04-13 10:47:30,359] ERROR in app: Exception on /api/result/f06312d1-43f7-480c-b84d-892103eb6803 [PUT]
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 2077, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 1525, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/app-root/lib64/python3.8/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/app-root/lib64/python3.8/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/decorators/decorator.py", line 68, in wrapper
    response = function(request)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/security/security_handler_factory.py", line 388, in wrapper
    return function(request)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/decorators/uri_parsing.py", line 149, in wrapper
    response = function(request)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/decorators/validation.py", line 196, in wrapper
    response = function(request)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/decorators/validation.py", line 399, in wrapper
    return function(request)
  File "/opt/app-root/lib64/python3.8/site-packages/connexion/decorators/parameter.py", line 116, in wrapper
    return function(**kwargs)
  File "/opt/app-root/src/ibutsu_server/controllers/result_controller.py", line 170, in update_result
    if not project_has_user(result.project, user):
AttributeError: 'NoneType' object has no attribute 'project'
```

I think switching the conditions checks should fix it. That way the function immediately returns when there's no result and doesn't try to access `result.project`.