### PR TITLE
New endpoint filter in frontend to filter the tests

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -54,6 +54,7 @@ export const STRING_RESULT_FIELDS = [
   'metadata.params',
   'metadata.project',
   'metadata.title',
+  'metadata.endpoint',
   'params',
   'result',
   'source',
@@ -74,6 +75,7 @@ export const FILTERABLE_RESULT_FIELDS = [
   'metadata.fspath',
   'metadata.importance',
   'metadata.title',
+  'metadata.endpoint',
   // TODO support object/dict filtering
   // https://github.com/ibutsu/ibutsu-server/issues/229
   //'metadata.params',


### PR DESCRIPTION
New `metadata.endpoint` filter in Ibutsu Frontend to filter the tests based on API, UI and CLI endpoints on any product.