### PR TITLE
add logging for lock

### DIFF
--- a/backend/ibutsu_server/tasks/__init__.py
+++ b/backend/ibutsu_server/tasks/__init__.py
@@ -123,10 +123,12 @@ def lock(name, timeout=LOCK_EXPIRE, app=None):
     redis_client = Redis.from_url(app.config["CELERY_BROKER_URL"])
     try:
         # Get a lock so that we don't run this task concurrently
+        logging.info(f"Trying to get a lock for {name}")
         with redis_client.lock(name, blocking_timeout=timeout):
             yield
     except LockError:
         # If this task is locked, discard it so that it doesn't clog up the system
+        logging.info(f"Task {name} is already locked, discarding")
         pass
 
 


### PR DESCRIPTION
Example error
```
[2022-04-27 18:28:27,495: INFO/ForkPoolWorker-1] Task ca405c6d-816c-41bf-aba0-cfdff263f62d with args ['cdb2c230-7f45-4490-8d96-49fbfe1359a5'] is not related to a report
[2022-04-27 18:28:27,495: ERROR/ForkPoolWorker-1] Task ibutsu_server.tasks.runs.update_run[ca405c6d-816c-41bf-aba0-cfdff263f62d] raised unexpected: RuntimeError("generator didn't yield")
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.8/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/app/ibutsu_server/tasks/__init__.py", line 31, in __call__
    return super().__call__(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/celery/app/trace.py", line 648, in __protected_call__
    return self.run(*args, **kwargs)
  File "/app/ibutsu_server/tasks/runs.py", line 40, in update_run
    with lock(f"update-run-lock-{run_id}"):
  File "/usr/lib64/python3.8/contextlib.py", line 115, in __enter__
    raise RuntimeError("generator didn't yield") from None
RuntimeError: generator didn't yield
```

I'm not sure what exactly happens inside the 
```
with redis_client.lock(name, blocking_timeout=timeout):
```
statement that prevents it from yielding. It looks like it has to do something with the fact that `the task is not related to a report`.

@rsnyman any suggestion? I just added a bit more logging



