### PR TITLE
Add Compare Runs view

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -56,6 +56,20 @@ _ADDITIONAL_FILTERS_PARAM = {
     "required": False,
 }
 WIDGET_TYPES = {
+    "compare-runs-view": {
+        "id": "compare-runs-view",
+        "title": "Compare Runs",
+        "description": "A summary of multiple ran test results filtered",
+        "params": [
+            {
+                "name": "filters",
+                "description": "List of filters used for comparison",
+                "type": "list",
+                "required": True,
+            }
+        ],
+        "type": "view",
+    },
     "jenkins-heatmap": {
         "id": "jenkins-heatmap",
         "title": "Jenkins Pipeline Heatmap",

--- a/backend/ibutsu_server/controllers/widget_config_controller.py
+++ b/backend/ibutsu_server/controllers/widget_config_controller.py
@@ -33,9 +33,9 @@ def add_widget_config(widget_config=None, token_info=None, user=None):
             return "Forbidden", 403
         data["project_id"] = project.id
     # default to make views navigable
-    if data.get("navigable"):
+    if data.get("navigable") and isinstance(data["navigable"], str):
         data["navigable"] = data["navigable"][0] in ALLOWED_TRUE_BOOLEANS
-    if data.get("type") == "view" and data.get("navigable") is not None:
+    if data.get("type") == "view" and data.get("navigable") is None:
         data["navigable"] = True
     widget_config = WidgetConfig.from_dict(**data)
     session.add(widget_config)
@@ -121,10 +121,10 @@ def update_widget_config(id_, token_info=None, user=None):
     if not widget_config.weight:
         widget_config.weight = 10
     # default to make views navigable
-    if data.get("navigable"):
+    if data.get("navigable") and isinstance(data["navigable"], str):
         data["navigable"] = data["navigable"][0] in ALLOWED_TRUE_BOOLEANS
-    if data.get("type") and data["type"] == "view" and data.get("navigable") is not None:
-        data.navigable = True
+    if data.get("type") and data["type"] == "view" and data.get("navigable") is None:
+        data["navigable"] = True
     widget_config.update(data)
     session.add(widget_config)
     session.commit()

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -29,6 +29,7 @@ OPER_COMPARE = {
 }
 FILTER_RE = re.compile(r"([a-zA-Z\._]+)([" + "".join(OPERATORS.keys()) + "])(.*)")
 FLOAT_RE = re.compile(r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?")
+VERSION_RE = re.compile("([0-9].*[0-9])")
 
 
 def _to_int_or_float(value):
@@ -100,6 +101,7 @@ def convert_filter(filter_string, model):
     field = match.group(1)
     oper = match.group(2)
     value = match.group(3).strip('"')
+    is_version = True if VERSION_RE.match(value) is not None else False
     column = string_to_column(field, model)
     # determine if the field is an array field, if so it requires some additional care
     is_array_field = field in ARRAY_FIELDS
@@ -108,10 +110,9 @@ def convert_filter(filter_string, model):
         return _null_compare(column, value)
     elif oper == "*":
         value = value.split(";")
-    elif "build_number" not in field:
+    elif not is_version and "build_number" not in field:
         # This is a horrible hack, because Jenkins build numbers are strings :-(
         value = _to_int_or_float(value)
-
     if is_array_field:
         return _array_compare(oper, column, value)
     else:

--- a/backend/ibutsu_server/test/test_widget_controller.py
+++ b/backend/ibutsu_server/test/test_widget_controller.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from ibutsu_server.test import BaseTestCase
+from ibutsu_server.test import MockProject
+from ibutsu_server.test import MockResult
+
+MOCK_ID_1 = "99fba7d2-4d32-4b9b-b07f-4200c9717661"
+MOCK_ID_2 = "99fba7d2-4d32-4b9b-b07f-4200c9717662"
+MOCK_RUN_ID_1 = "8395c072-4724-4dae-9f4a-1407b25a2d5b"
+MOCK_RUN_ID_2 = "8395c072-4724-4dae-9f4a-1407b25a2d5c"
+MOCK_PROJECT = MockProject()
+START_TIME = datetime.utcnow()
+MOCK_RESULTS = [
+    MockResult(
+        id=MOCK_ID_1,
+        duration=6.027456183070403,
+        result="passed",
+        component="fake-component",
+        data={
+            "jenkins_build": 145,
+            "commit_hash": "F4BA3E12",
+            "assignee": "jdoe",
+            "component": "fake-component",
+            "fspath": "fake_component.py",
+        },
+        start_time=str(START_TIME),
+        source="source",
+        params={"provider": "vmware", "ip_stack": "ipv4"},
+        test_id="test_id",
+        project=MOCK_PROJECT,
+    ),
+    MockResult(
+        id=MOCK_ID_2,
+        duration=10.457123453030907,
+        result="failed",
+        component="fake-component",
+        data={
+            "jenkins_build": 146,
+            "commit_hash": "A11BEF06",
+            "assignee": "jdoe",
+            "component": "fake-component",
+            "fspath": "fake_component.py",
+        },
+        start_time=str(START_TIME),
+        source="source",
+        params={"provider": "vmware", "ip_stack": "ipv4"},
+        test_id="test_id",
+        project=MOCK_PROJECT,
+    ),
+]
+
+MOCK_RESULTS_DICT = [result.to_dict() for result in MOCK_RESULTS]
+
+
+class TestWidgetController(BaseTestCase):
+    """WidgetController integration test stubs"""
+
+    @patch("ibutsu_server.widgets.compare_runs_view.Result.query")
+    def test_get_comparison_result_list(self, mocked_query):
+        """Test case for compare_runs_view.py::get_comparison_data
+
+        Get the list of comparison results.
+        """
+        MOCK_RUN_IDS = [MOCK_RUN_ID_1, MOCK_RUN_ID_2]
+        MOCKED_RESULTS = [[mocked_result] for mocked_result in MOCK_RESULTS]
+        mocked_query = mocked_query.filter.return_value
+        mocked_query.with_entities.return_value.order_by.return_value.first.side_effect = (
+            MOCK_RUN_IDS
+        )
+        mocked_query.filter.return_value.order_by.return_value.all.side_effect = MOCKED_RESULTS
+        query_string = {
+            "filters": ["metadata.component=frontend", "metadata.component=frontend"],
+        }
+        headers = {"Accept": "application/json", "Authorization": f"Bearer {self.jwt_token}"}
+        response = self.client.open(
+            "/api/widget/compare-runs-view",
+            method="GET",
+            headers=headers,
+            query_string=query_string,
+        )
+        self.assert_200(response, "Response body is : " + response.data.decode("utf-8"))
+        expected_response = {
+            "pagination": {"totalItems": 1},
+            "results": [MOCK_RESULTS_DICT],
+        }
+        assert response.json == expected_response

--- a/backend/ibutsu_server/widgets/compare_runs_view.py
+++ b/backend/ibutsu_server/widgets/compare_runs_view.py
@@ -1,0 +1,55 @@
+from ibutsu_server.db.models import Result
+from ibutsu_server.filters import convert_filter
+
+
+def _get_comparison_data(filters):
+    """Count occurrences of distinct fields within results."""
+    queries = []
+    for _ in filters:
+        queries.append(Result.query)
+
+    # Create DB ready filter strings
+    if filters:
+        for i, filter in enumerate(filters):
+            filters = filter.split(",")
+            for filter_string in filters:
+                filter_clause = convert_filter(filter_string, Result)
+                if filter_clause is not None:
+                    queries[i] = queries[i].filter(filter_clause)
+
+    # Find run IDs for each filter
+    run_id_1 = queries[0].with_entities(Result.run_id).order_by(Result.start_time.desc()).first()
+    run_id_2 = queries[1].with_entities(Result.run_id).order_by(Result.start_time.desc()).first()
+
+    # Get list of tests matching our filters and run IDs
+    results_1 = queries[0].filter(Result.run_id.in_(run_id_1)).order_by(Result.data["fspath"]).all()
+    results_2 = queries[1].filter(Result.run_id.in_(run_id_2)).order_by(Result.data["fspath"]).all()
+
+    # Build matrix by matching results
+    # Could revisit this if loading is taking too long
+    results = []
+    for result_1 in results_1:
+        result_1 = result_1.to_dict()
+        for result_2 in results_2:
+            result_2 = result_2.to_dict()
+            if (
+                result_1["metadata"]["fspath"] == result_2["metadata"]["fspath"]
+                and result_1["test_id"] == result_2["test_id"]
+                and result_1["result"] != result_2["result"]
+            ):
+                results.append((result_1, result_2))
+                break
+
+    total_items = len(results)
+
+    return {
+        "results": [(result_1, result_2) for result_1, result_2 in results],
+        "pagination": {
+            "totalItems": total_items,
+        },
+    }
+
+
+def get_comparison_data(filters=None):
+    data = _get_comparison_data(filters=filters)
+    return data

--- a/frontend/src/components/classify-failures.js
+++ b/frontend/src/components/classify-failures.js
@@ -122,7 +122,7 @@ export class ClassifyFailuresTable extends React.Component {
     });
   }
 
-  updateFilters(name, operator, value, callback) {
+  updateFilters(filterId, name, operator, value, callback) {
     let filters = this.state.filters;
     if ((value === null) || (value.length === 0)) {
       delete filters[name];
@@ -133,15 +133,15 @@ export class ClassifyFailuresTable extends React.Component {
     this.setState({filters: filters, page: 1}, callback);
   }
 
-  setFilter = (field, value) => {
+  setFilter = (filterId, field, value) => {
     // maybe process values array to string format here instead of expecting caller to do it?
     let operator = (value.includes(";")) ? 'in' : 'eq'
-    this.updateFilters(field, operator, value, this.refreshResults)
+    this.updateFilters(filterId, field, operator, value, this.refreshResults)
   }
 
-  removeFilter = id => {
+  removeFilter = (filterId, id) => {
     if ((id !== "result") && (id !== "run_id")) {   // Don't allow removal of error/failure filter
-      this.updateFilters(id, null, null, this.refreshResults)
+      this.updateFilters(filterId, id, null, null, this.refreshResults)
     }
   }
 
@@ -173,7 +173,6 @@ export class ClassifyFailuresTable extends React.Component {
     params['filter'] = toAPIFilter(filters);
     params['pageSize'] = this.state.pageSize;
     params['page'] = this.state.page;
-
     this.setState({rows: [['Loading...', '', '', '', '']]});
     HttpClient.get([Settings.serverUrl, 'result'], params)
       .then(response => HttpClient.handleResponse(response))
@@ -219,6 +218,10 @@ export class ClassifyFailuresTable extends React.Component {
         runId={run_id}
         setFilter={this.setFilter}
         customFilters={{'result': filters['result']}}
+        activeFilters={this.state.filters}
+        onRemoveFilter={this.removeFilter}
+        hideFilters={["run_id", "project_id"]}
+        id={0}
       />,
     ]
     return (
@@ -256,10 +259,7 @@ export class ClassifyFailuresTable extends React.Component {
             canSelectAll={true}
             onRowSelect={this.onTableRowSelect}
             variant={TableVariant.compact}
-            activeFilters={this.state.filters}
             filters={resultFilters}
-            onRemoveFilter={this.removeFilter}
-            hideFilters={["run_id", "project_id"]}
           />
         </CardBody>
       </Card>

--- a/frontend/src/components/result.js
+++ b/frontend/src/components/result.js
@@ -64,7 +64,9 @@ export class ResultView extends React.Component {
     hideTestObject: PropTypes.bool,
     hideTestHistory: PropTypes.bool,
     history: PropTypes.object,
-    location: PropTypes.object
+    location: PropTypes.object,
+    comparisonResults: PropTypes.array,
+    hideArtifact: PropTypes.bool
   }
 
   constructor(props) {
@@ -76,6 +78,7 @@ export class ResultView extends React.Component {
       activeTab: this.getTabIndex(this.getDefaultTab()),
       artifactTabs: [],
       testHistoryTable: null,
+      comparisonResults: this.props.comparisonResults
     };
     if (this.props.history) {
       // Watch the history to update tabs
@@ -130,7 +133,12 @@ export class ResultView extends React.Component {
   };
 
   getTestHistoryTable = () => {
-    this.setState({testHistoryTable: <TestHistoryTable testResult={this.state.testResult}/>});
+    if (this.state.comparisonResults !== undefined) {
+      this.setState({testHistoryTable: <TestHistoryTable comparisonResults={this.state.comparisonResults} testResult={this.state.testResult}/>});
+    } else {
+      this.setState({testHistoryTable: <TestHistoryTable testResult={this.state.testResult}/>});
+    }
+
   }
 
   getTestResult(resultId) {
@@ -145,7 +153,6 @@ export class ResultView extends React.Component {
       .then(data => {
         let artifactTabs = [];
         data.artifacts.forEach((artifact) => {
-          console.log(artifact);
           HttpClient.get([Settings.serverUrl, 'artifact', artifact.id, 'view'])
             .then(response => {
               let contentType = response.headers.get('Content-Type');
@@ -508,7 +515,7 @@ export class ResultView extends React.Component {
             </Card>
           </Tab>
           }
-          {artifactTabs}
+          {!this.props.hideArtifact && artifactTabs}
           {!this.props.hideTestHistory &&
           <Tab eventKey="test-history" title={<TabTitle icon={SearchIcon} text="Test History"/>}>
           {testHistoryTable}

--- a/frontend/src/components/view.js
+++ b/frontend/src/components/view.js
@@ -10,9 +10,10 @@ import {
 
 import { HttpClient } from '../services/http';
 import { Settings } from '../settings';
-import { JenkinsJobView, JenkinsJobAnalysisView } from '../views';
+import { CompareRunsView, JenkinsJobView, JenkinsJobAnalysisView } from '../views';
 
 const VIEW_MAP = {
+  'compare-runs-view': CompareRunsView,
   'jenkins-job-view': JenkinsJobView,
   'jenkins-analysis-view': JenkinsJobAnalysisView
 };

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -76,6 +76,9 @@ export const FILTERABLE_RESULT_FIELDS = [
   'metadata.importance',
   'metadata.title',
   'metadata.endpoint',
+  'metadata.user_properties.BaseOS',
+  'metadata.user_properties.SatelliteVersion',
+  'metadata.user_properties.SnapVersion'
   // TODO support object/dict filtering
   // https://github.com/ibutsu/ibutsu-server/issues/229
   //'metadata.params',

--- a/frontend/src/utilities.js
+++ b/frontend/src/utilities.js
@@ -128,7 +128,7 @@ export function toAPIFilter(filters) {
   // Take UI style filter object with field/op/val keys and generate an array of filter strings for the API
   let filter_strings = []
   for (const key in filters) {
-    if (Object.prototype.hasOwnProperty.call(filters, key) && !!filters[key]) {
+    if (Object.prototype.hasOwnProperty.call(filters, key) && !!filters[key] && key !== 'id') {
       const val = filters[key]['val'];
       const op = OPERATIONS[filters[key]['op']];
       filter_strings.push(key + op + val);
@@ -241,6 +241,47 @@ export function resultToClassificationRow(result, index, filterFunc) {
         {title: <ClassificationDropdown testResult={result} />},
         {title: round(result.duration) + 's'},
       ],
+    },
+    // child row (this is set in the onCollapse function for lazy-loading)
+    {
+      "parent": 2*index,
+      "cells": [{title: <div/>}]
+    }
+  ];
+}
+
+export function resultToComparisonRow(result, index) {
+  let resultIcons = [];
+  let markers = [];
+  result.forEach(result => {
+    resultIcons.push(getIconForResult(result.result))
+    if (result.metadata && result.metadata.markers) {
+        for (const marker of result.metadata.markers) {
+          // Don't add duplicate markers
+          if (markers.filter(m => m.key === marker.name).length === 0) {
+            markers.push(<Badge isRead key={marker.name}>{marker.name}</Badge>);
+          }
+        }
+      }
+  });
+
+  if (result[0].metadata && result[0].metadata.component) {
+    markers.push(<Badge key={result[0].metadata.component}>{result[0].metadata.component}</Badge>);
+  }
+
+  let cells = []
+  cells.push({title: <React.Fragment><Link to={`/results/${result[0].id}`}>{result[0].test_id}</Link> {markers}</React.Fragment>});
+  result.forEach((result, index) => {
+    cells.push({title: <span className={result.result}>{resultIcons[index]} {toTitleCase(result.result)}</span>});
+  });
+
+
+  return [
+    // parent row
+    {
+      "isOpen": false,
+      "result": result,
+      "cells": cells,
     },
     // child row (this is set in the onCollapse function for lazy-loading)
     {

--- a/frontend/src/views/compareruns.js
+++ b/frontend/src/views/compareruns.js
@@ -1,0 +1,312 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Flex,
+  FlexItem,
+  TextContent,
+  Checkbox,
+  Button,
+  Text
+} from '@patternfly/react-core';
+import {
+  TableVariant,
+  expandable
+} from '@patternfly/react-table';
+import { FILTERABLE_RESULT_FIELDS } from '../constants';
+import {
+  FilterTable,
+  MetaFilter,
+  ResultView
+} from '../components';
+import { HttpClient } from '../services/http';
+import { Settings } from '../settings';
+import {
+  toAPIFilter,
+  getSpinnerRow,
+  resultToComparisonRow
+} from '../utilities';
+
+export class CompareRunsView extends React.Component {
+  static propTypes = {
+    location: PropTypes.object,
+    history: PropTypes.object,
+    view: PropTypes.object
+  };
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      columns: [{title: 'Test', cellFormatters: [expandable]}, 'Run 1', 'Run 2'],
+      rows: [getSpinnerRow(3)],
+      results: [],
+      selectedResults: [],
+      cursor: null,
+      pageSize: 0,
+      page: 1,
+      totalItems: 0,
+      totalPages: 0,
+      isEmpty: false,
+      isError: false,
+      includeSkipped: false,
+      isLoading: false,
+      filters: [Object.assign({
+        'result': {op: 'in', val: 'failed;error;passed'},
+        'id': 0
+        }),
+        Object.assign({
+          'result': {op: 'in', val: 'failed;error;passed'},
+          'id': 1
+        })],
+      loadingProps: {}
+    }
+    this.refreshResults = this.refreshResults.bind(this);
+    this.onCollapse = this.onCollapse.bind(this);
+  }
+
+  onSkipCheck = (checked) => {
+    let filters = this.state.filters;
+    filters.forEach(filter => {
+      filter["result"]["val"] = ("failed;error;passed") + ((checked) ? ";skipped;xfailed" : "")
+    });
+
+    this.setState(
+      {includeSkipped: checked, filters},
+      this.refreshResults
+    );
+  }
+
+  setFilter = (filterId, field, value) => {
+    // maybe process values array to string format here instead of expecting caller to do it?
+    let operator = (value.includes(";")) ? 'in' : 'eq';
+    this.updateFilters(filterId, field, operator, value)
+  }
+
+  updateFilters(filterId, name, operator, value) {
+    let newFilters = this.state.filters.map((filter) => {
+      if (filter.id === filterId) {
+        if ((value === null) || (value.length === 0)) {
+          delete filter[name];
+        }
+        else {
+          filter[name] = {'op': operator, 'val': String(value)};
+        }
+      }
+      return filter
+    });
+    this.setState({filters: newFilters, page: 1});
+  }
+
+  removeFilter = (filterId, id) => {
+    if ((id !== "result") && (id !== "run_id")) {   // Don't allow removal of error/failure filter
+      this.updateFilters(filterId, id, null, null)
+    }
+  }
+
+  getResultsForTable() {
+    const filter = this.state.filters;
+
+    // Check to see if filters have been set besides id and result
+    let isNew = false;
+    filter.forEach(filter => {
+      for (const prop in filter) {
+        if (prop !== "id" && prop !== "result") {
+          isNew = true;
+        }
+      }
+    })
+
+    // Add loading animations to button and table
+    this.setState({rows: [getSpinnerRow(3)], isEmpty: false, isError: false});
+    this.setState({rows: [['Loading...', '', '']]});
+    this.setState({
+      loadingProps: {
+        'spinnerAriaValueText': 'Loading',
+        'spinnerAriaLabelledBy': 'primary-loading-button',
+        'isLoading': true
+      },
+      isLoading: true
+    })
+
+    if (isNew == true) {
+      // Build params and filters for each MetaFilter
+      let apiFilters = [];
+      filter.forEach(filter => {
+        apiFilters.push(toAPIFilter(filter));
+      })
+      let params = [];
+      params['filters'] = apiFilters;
+
+      // Retrieve results from database
+      HttpClient.get([Settings.serverUrl, 'widget', 'compare-runs-view'], params)
+        .then(response => HttpClient.handleResponse(response))
+        .then(data => this.setState({
+            results: data.results,
+            rows: data.results.map((result, index) => resultToComparisonRow(result, index)).flat(),
+            totalItems: data.pagination.totalItems,
+            pageSize: data.pagination.totalItems,
+            isEmpty: data.pagination.totalItems === 0,
+            loadingProps: {},
+            isLoading: false
+        }))
+        .catch((error) => {
+          console.error('Error fetching result data:', error);
+          this.setState({rows: [], isEmpty: false, isError: true});
+          this.setState({loadingProps: {}});
+          this.setState({isLoading: false});
+        });
+    } else {
+      this.setState({rows: [['No filters set.', '', '']]});
+      this.setState({loadingProps: {}});
+      this.setState({isLoading: false});
+    }
+  }
+
+  onCollapse(event, rowIndex, isOpen) {
+    const { rows } = this.state;
+
+    // lazy-load the result view so we don't have to make a bunch of artifact requests
+    if (isOpen) {
+      let result = rows[rowIndex].result;
+      let hideSummary=true;
+      let hideTestObject=true;
+      let defaultTab="test-history";
+      if (result.result === "skipped") {
+        hideSummary=false;
+        hideTestObject=false;
+      }
+      rows[rowIndex + 1].cells = [{
+        title: <ResultView hideArtifact={true} comparisonResults={result} defaultTab={defaultTab} hideTestHistory={false} hideSummary={hideSummary} hideTestObject={hideTestObject} testResult={result[0]}/>
+      }]
+    }
+    rows[rowIndex].isOpen = isOpen;
+    this.setState({rows});
+  }
+
+  setPage = (_event, pageNumber) => {
+    this.setState({page: pageNumber}, () => {
+      this.getResultsForTable();
+    });
+  }
+
+  refreshResults = () => {
+    this.setState({selectedResults: []});
+    this.getResultsForTable();
+  }
+
+  // Remove all active filters and clear table
+  clearFilters = () => {
+    this.setState({
+      filters: [Object.assign({
+      'result': {op: 'in', val: 'failed;error;passed'},
+      'id': 0
+      }),
+      Object.assign({
+        'result': {op: 'in', val: 'failed;error;passed'},
+        'id': 1
+      })],
+      page: 1,
+      totalItems: 0,
+      totalPages: 0},
+      this.getResultsForTable
+    );
+
+  }
+
+  componentDidMount() {
+    this.getResultsForTable();
+  }
+
+  render() {
+    const {
+      columns,
+      rows,
+      filters,
+      includeSkipped
+    } = this.state;
+
+    const pagination = {
+      pageSize: this.state.pageSize,
+      page: this.state.page,
+      totalItems: this.state.totalItems
+    }
+
+    const resultFilters = [
+      <Flex key="metafilters" direction={{default: 'column'}} spaceItems={{default: 'spaceItemsMd'}}>
+        <FlexItem key="metafilter1">
+          <TextContent style={{ fontWeight: 'bold' }}>
+            Run 1:
+          </TextContent>
+          <MetaFilter
+            fieldOptions={FILTERABLE_RESULT_FIELDS}
+            setFilter={this.setFilter}
+            customFilters={{'result': filters['result']}}
+            activeFilters={this.state.filters[0]}
+            onRemoveFilter={this.removeFilter}
+            hideFilters={["run_id", "project_id", "id"]}
+            id={0}
+          />
+        </FlexItem>
+        <FlexItem key="metafilter2">
+          <TextContent style={{ fontWeight: 'bold' }}>
+            Run 2:
+          </TextContent>
+          <MetaFilter
+            fieldOptions={FILTERABLE_RESULT_FIELDS}
+            setFilter={this.setFilter}
+            customFilters={{'result': filters['result']}}
+            activeFilters={this.state.filters[1]}
+            onRemoveFilter={this.removeFilter}
+            hideFilters={["run_id", "project_id", "id"]}
+            id={1}
+          />
+        </FlexItem>
+      </Flex>
+    ]
+    return (
+      <Card>
+        <CardHeader>
+          <Flex style={{ width: '100%' }}>
+            <FlexItem grow={{ default: 'grow' }}>
+              <TextContent>
+                <Text component="h2" className="pf-c-title pf-m-xl">Select Test Run metadata to compare</Text>
+              </TextContent>
+            </FlexItem>
+            <FlexItem>
+              <TextContent>
+                <Checkbox id="include-skips" label="Include skips, xfails" isChecked={includeSkipped} aria-label="include-skips-checkbox" onChange={this.onSkipCheck}/>
+              </TextContent>
+            </FlexItem>
+            <FlexItem>
+              <Button variant="primary" onClick={this.refreshResults} {...this.state.loadingProps}>
+                {this.state.isLoading ? 'Loading Results' : 'Apply Filters'}
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button variant="secondary" onClick={this.clearFilters} isDanger>Clear Filters</Button>
+            </FlexItem>
+          </Flex>
+        </CardHeader>
+        <CardBody>
+          <FilterTable
+            columns={columns}
+            rows={rows}
+            pagination={pagination}
+            isEmpty={this.state.isEmpty}
+            isError={this.state.isError}
+            onCollapse={this.onCollapse}
+            onSetPage={this.setPage}
+            canSelectAll={false}
+            variant={TableVariant.compact}
+            filters={resultFilters}
+            onRemoveFilter={this.removeFilter}
+            hideFilters={["project_id"]}
+          />
+        </CardBody>
+      </Card>
+    );
+  }
+}

--- a/frontend/src/views/index.js
+++ b/frontend/src/views/index.js
@@ -1,2 +1,3 @@
 export { JenkinsJobView } from './jenkinsjob';
 export { JenkinsJobAnalysisView } from './jenkinsjobanalysis';
+export { CompareRunsView } from './compareruns';


### PR DESCRIPTION
This feature adds the ability for admins to define a new view for comparing runs. At the moment users can use MetaFilter and FilterTable to select the different types of results they would like to compare. They will then retrieve a list of tests where the results are not the same. I have a video demo I can share if you would like to see current functionality while this is being reviewed.

Some relevant notes:
- I made an update to MetaFilter so that the filters are shown within the MetaFilter render function instead of the FilterTable's render
- I also gave MetaFilter a property called `id` that takes a number so that you can define multiple filters for your FilterTable
- Adjusted ResultView to allow optional showing of artifacts (logs)
- Adjusted ResultView and TestHistory to take a property `comparisonResults`, so that I can pass along only the results I retrieved from the DB to the `onCollapse` function in `compareruns.js`