### PR TITLE
Release 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+Version 2.2.3
+=============
+
+* Runs can now display artifacts - Update the archive importer code to handle run artifacts - Make archive importer less flakey - Fix fetching the artifacts from the frontend - Remove Python 3.7 from the version matrix, add 3.10
+* Modified documentation and README
+* Make project mandatory
+* Remove aria attributes, and try to add the legend data back in
+* Bump eventsource from 1.1.0 to 1.1.1 in /frontend
+
 Version 2.2.2
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.2.2
+  version: 2.2.3
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.2.2"
+VERSION = "2.2.3"
 REQUIRES = [
     "alembic",
     # Pin Celery to be compatible with Kombu

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
* Runs can now display artifacts
* Update the archive importer code to handle run artifacts (closes #364)
* Make archive importer less flakey 
* Fix fetching the artifacts from the frontend 
* Remove Python 3.7 from the version matrix, add 3.10
* Modified documentation and README
* Make project mandatory
* Fix GET non-existent runs and results returning 500 (fixes #366)