### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,6 @@ Version 2.3.0
 * fix ports in frontend json commands
 * add manual/blocked states to api spec
 * modernmize pre commit config
-* Release 2.2.3
-
-* Runs can now display artifacts - Update the archive importer code to handle run artifacts - Make archive importer less flakey - Fix fetching the artifacts from the frontend - Remove Python 3.7 from the version matrix, add 3.10 * Modified documentation and README * Make project mandatory * Remove aria attributes, and try to add the legend data back in * Bump eventsource from 1.1.0 to 1.1.1 in /frontend
 
 Version 2.2.3
 =============

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+Version 2.3.0
+=============
+
+* Bump terser from 4.8.0 to 4.8.1 in /frontend
+* comparison view
+* disable py3.11 for the five bugs on celery
+* restore usage of _orig_func instead of __wrapped__
+* get_app returns a flask app instead of connexion
+* ensure db url parsing handles test configuration
+* drop nose dependency
+* remove python 3.7 and add the modern ones
+* restore env var prefixes in podman pod yaml
+* split ibutsu pod config into configmaps
+* fixup! restore ports
+* black fixes
+* create flask based entrypoints and enable podman play usage
+* tox config: update for python 3.8+ and usedevelop
+* summaries computation: allow any custom summary
+* fix extraction of celery wrappers
+* steamline configuration setup
+* make flask >2 the minimum
+* default settings: use pod name instead of localhost for celery
+* use non-interactive non-terminal containers for ibutsu_pod.sh
+* fix ports in frontend json commands
+* add manual/blocked states to api spec
+* modernmize pre commit config
+* Release 2.2.3
+
+* Runs can now display artifacts - Update the archive importer code to handle run artifacts - Make archive importer less flakey - Fix fetching the artifacts from the frontend - Remove Python 3.7 from the version matrix, add 3.10 * Modified documentation and README * Make project mandatory * Remove aria attributes, and try to add the legend data back in * Bump eventsource from 1.1.0 to 1.1.1 in /frontend
+
 Version 2.2.3
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.2.3
+  version: 2.3.0
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.2.3"
+VERSION = "2.3.0"
 REQUIRES = [
     "alembic",
     # Pin Celery to be compatible with Kombu

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.15.8",

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -30,23 +30,41 @@ function print_usage() {
 }
 
 # Parse the arguments
-for ARG in $*; do
-    if [[ "$ARG" == "-c" ]] || [[ "$ARG" == "--commit" ]]; then
-        CAN_COMMIT=true
-    elif [[ "$ARG" == "-p" ]] || [[ "$ARG" == "--push" ]]; then
-        CAN_PUSH=true
-    elif [[ "$ARG" == "-d" ]] || [[ "$ARG" == "--delete" ]]; then
-        CAN_DELETE=true
-    elif [[ "$ARG" == "-v" ]] || [[ "$ARG" == "--version" ]]; then
-        PRINT_NEW_VERSION=true
-    elif [[ "$ARG" == "-g" ]] || [[ "$ARG" == "--changelog" ]]; then
-        GENERATE_CHANGELOG=true
-    elif [[ "$ARG" == "-h" ]] || [[ "$ARG" == "--help" ]]; then
-        print_usage
-        exit 0
-    else
-        NEW_VERSION=$ARG
-    fi
+while (( "$#" )); do
+    case "$1" in
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        -c|--commit)
+            CAN_COMMIT=true
+            shift
+            ;;
+        -p|--push)
+            CAN_PUSH=true
+            shift
+            ;;
+        -d|--delete)
+            CAN_DELETE=true
+            shift
+            ;;
+        -v|--version)
+            PRINT_NEW_VERSION=true
+            shift
+            ;;
+        -g|--changelog)
+            GENERATE_CHANGELOG=true
+            shift
+            ;;
+        -*|--*)
+            echo "Error: unsupported option $1" >&2
+            exit 1
+            ;;
+        *)
+            NEW_VERSION="$1"
+            shift
+            ;;
+    esac
 done
 
 # Fetch the latest tags from upstream and set the current version


### PR DESCRIPTION
* Bump terser from 4.8.0 to 4.8.1 in /frontend
* comparison view
* restore usage of _orig_func instead of __wrapped__
* get_app returns a flask app instead of connexion
* ensure db url parsing handles test configuration
* drop nose dependency
* remove python 3.7 and add the modern ones
* restore env var prefixes in podman pod yaml
* split ibutsu pod config into configmaps
* create flask based entrypoints and enable podman play usage
* summaries computation: allow any custom summary
* fix extraction of celery wrappers
* steamline configuration setup
* make flask >2 the minimum
* default settings: use pod name instead of localhost for celery
* use non-interactive non-terminal containers for ibutsu_pod.sh
* add manual/blocked states to api spec
