### PR TITLE
avoid simultaneous installation of packages in the same volume in docker-compose.dev

### DIFF
--- a/backend/worker-entrypoint.sh
+++ b/backend/worker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# give some more time for backend container
+sleep 30
+
+# create the venv (it will not fail if already exists) and activate
+python -m venv .ibutsu_env && source .ibutsu_env/bin/activate
+
+# all the packages should be installed in backend container, waiting for it
+until pip show ibutsu-server; do
+  >&2 echo "Waiting for backend"
+  sleep 5
+done
+
+# start the worker
+./celery_worker.sh

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,7 +49,7 @@ services:
       - CELERY_BROKER_URL=redis://redis:6379
       - CELERY_RESULT_BACKEND=redis://redis:6379
     image: python:3.9
-    command: /bin/bash -c 'python -m venv .ibutsu_env && source .ibutsu_env/bin/activate && pip install -U pip setuptools wheel && pip install -r requirements.txt && ./celery_worker.sh'
+    command: ./worker-entrypoint.sh
     working_dir: /mnt
     volumes:
       - "./backend:/mnt"


### PR DESCRIPTION
`backend` and `worker` containers use the same volume

```
volumes:
    - "./backend:/mnt"
```

and they do the same commands
```
/bin/bash -c 'python -m venv .ibutsu_env && source .ibutsu_env/bin/activate && pip install -U pip setuptools wheel && pip install -r requirements.txt
```

This leads to a weird racing condition, so I added a waiting mechanism. The worker container waits for the backend container to install `ibutsu-server` package.

Example from compose logs:
```
worker_1    | WARNING: Package(s) not found: ibutsu-server
worker_1    | Waiting for backend
worker_1    | WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
worker_1    | WARNING: Package(s) not found: ibutsu-server
worker_1    | Waiting for backend
backend_1   |   Running setup.py develop for ibutsu-server
backend_1   | Successfully installed Flask-2.1.3 Flask-SQLAlchemy-2.5.1 Jinja2-3.1.2 Mako-1.2.1 MarkupSafe-2.1.1 PyYAML-6.0 alembic-1.8.1 amqp-2.6.1 async-timeout-4.0.2 attrs-21.4.0 bcrypt-3.2.2 billiard-3.6.4.0 blinker-1.5 cachetools-5.2.0 celery-4.3.0 certifi-2022.6.15 cffi-1.15.1 charset-normalizer-2.1.0 click-8.1.3 clickclick-20.10.2 connexion-2.14.0 cryptography-37.0.4 deprecated-1.2.13 ecdsa-0.18.0 flask_bcrypt-1.0.1 flask_cors-3.0.10 flask_mail-0.9.1 google-api-core-2.8.2 google-api-python-client-2.54.0 google-auth-2.9.1 google-auth-httplib2-0.1.0 google-auth-oauthlib-0.5.2 googleapis-common-protos-1.56.4 gunicorn-20.1.0 httplib2-0.20.4 ibutsu-server-2.3.0 idna-3.3 importlib-metadata-4.12.0 inflection-0.5.1 itsdangerous-2.1.2 jsonschema-4.7.2 kombu-4.6.3 lxml-4.9.1 oauthlib-3.2.0 packaging-21.3 protobuf-4.21.3 psycopg2-binary-2.9.3 pyasn1-0.4.8 pyasn1-modules-0.2.8 pycparser-2.21 pymongo-4.2.0 pyparsing-3.0.9 pyrsistent-0.18.1 python-jose-3.3.0 python-magic-0.4.27 python_dateutil-2.6.0 pytz-2022.1 redis-4.3.4 requests-2.28.1 requests-oauthlib-1.3.1 rsa-4.9 six-1.16.0 sqlalchemy-1.3.23 sqlalchemy-json-0.5.0 swagger-ui-bundle-0.0.2 uritemplate-4.1.1 urllib3-1.26.10 vine-1.3.0 werkzeug-2.0.3 wrapt-1.14.1 zipp-3.8.1
worker_1    | WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
worker_1    | Name: ibutsu-server
worker_1    | Version: 2.3.0
worker_1    | Summary: Ibutsu
worker_1    | Home-page: 
worker_1    | Author: 
worker_1    | Author-email: Raoul Snyman <rsnyman@redhat.com>
worker_1    | License: 
worker_1    | Location: /mnt
worker_1    | Requires: alembic, celery, connexion, Flask, Flask-SQLAlchemy, flask_bcrypt, flask_cors, flask_mail, google-api-python-client, google-auth, google-auth-httplib2, google-auth-oauthlib, gunicorn, kombu, lxml, psycopg2-binary, pymongo, python-jose, python-magic, python_dateutil, PyYAML, redis, setuptools, sqlalchemy, sqlalchemy-json, swagger-ui-bundle, vine, werkzeug
worker_1    | Required-by: 

....

backend_1   |  * Running on http://127.0.0.1:8080/ (Press CTRL+C to quit)
backend_1   |  * Restarting with stat
worker_1    | /mnt/.ibutsu_env/lib/python3.9/site-packages/celery/platforms.py:800: RuntimeWarning: You're running the worker with superuser privileges: this is
worker_1    | absolutely not recommended!
worker_1    | 
worker_1    | Please specify a different user using the --uid option.
worker_1    | 
worker_1    | User information: uid=1000 euid=1000 gid=0 egid=0
worker_1    | 
worker_1    |   warnings.warn(RuntimeWarning(ROOT_DISCOURAGED.format(
backend_1   |  * Debugger is active!
backend_1   |  * Debugger PIN: 620-375-227

```