### PR TITLE
fix api errors found in fuzzy testing, part 1

### DIFF
--- a/backend/ibutsu_server/controllers/group_controller.py
+++ b/backend/ibutsu_server/controllers/group_controller.py
@@ -16,6 +16,7 @@ def add_group(group=None):
         return "Bad request, JSON required", 400
     group = Group.from_dict(**connexion.request.get_json())
     session.add(group)
+    session.commit()
     return group.to_dict(), 201
 
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2123,6 +2123,7 @@ components:
                 description: The ID of the user
                 example: 81e2c9d6-1593-4559-af4f-90f6f1f8fa03
                 type: string
+                format: uuid
               email:
                 description: The user's e-mail address
                 example: user@domain.com
@@ -2144,6 +2145,7 @@ components:
                 description: The ID of the group of this project
                 example: a16ad60e-bf23-4195-99dc-594858ad3e5e
                 type: string
+                format: uuid
                 nullable: true
             required:
               - email
@@ -2179,6 +2181,7 @@ components:
           description: Unique ID of the test result
           example: a16ad60e-bf23-4195-99dc-594858ad3e5e
           type: string
+          format: uuid
         test_id:
           description: Unique id
           example: test_click_on_button
@@ -2216,10 +2219,12 @@ components:
           example: 64c2ab9e-cd64-4815-bf73-83b00c2e650f
           type: string
           nullable: true
+          format: uuid
         project_id:
           description: The project this run is associated with
           example: 44941c55-9736-42f6-acce-ca3c4739d0f3
           type: string
+          format: uuid
           nullable: true
         metadata:
           example:
@@ -2262,6 +2267,7 @@ components:
           description: Unique ID of the test run
           example: 64c2ab9e-cd64-4815-bf73-83b00c2e650f
           type: string
+          format: uuid
         created:
           description: The time this record was created
           example: 2020-05-15T16:18:32.014053
@@ -2293,6 +2299,7 @@ components:
           description: The project this run is associated with
           example: 44941c55-9736-42f6-acce-ca3c4739d0f3
           type: string
+          format: uuid
           nullable: true
         summary:
           description: A summary of the test results
@@ -2330,16 +2337,19 @@ components:
           description: Unique ID of the artifact
           example: 22785097-a256-4aad-874b-9c204caba341
           type: string
+          format: uuid
         result_id:
           description: ID of test result to attach artifact to
           example: a16ad60e-bf23-4195-99dc-594858ad3e5e
           type: string
+          format: uuid
         run_id:
           description: ID of test run to attach artifact to
           example: 04af3d2a-55c5-4562-9ed6-3bf30ac6753e
           type: string
+          format: uuid
         filename:
-          description: ID of pet to update
+          description: name of the file
           type: string
         additional_metadata:
           description: Additional data to pass to server
@@ -2360,6 +2370,7 @@ components:
           description: Unique ID of the project
           example: 44941c55-9736-42f6-acce-ca3c4739d0f3
           type: string
+          format: uuid
         name:
           description: The machine name of the project
           example: my-project
@@ -2372,11 +2383,13 @@ components:
           description: The ID of the owner of this project
           example: 6b8b01ad-a17e-4ca1-8df5-fadb41439567
           type: string
+          format: uuid
           nullable: true
         group_id:
           description: The ID of the group of this project
           example: a16ad60e-bf23-4195-99dc-594858ad3e5e
           type: string
+          format: uuid
           nullable: true
       type: object
     Dashboard:
@@ -2392,6 +2405,7 @@ components:
           description: Unique ID of the dashboard
           example: 62faa4ce-d264-46c2-813e-579949c8ab9b
           type: string
+          format: uuid
         title:
           description: The title of the dashboard
           example: My Dashboard
@@ -2408,10 +2422,12 @@ components:
           description: The ID of the project this dashboard is associated with
           example: 44941c55-9736-42f6-acce-ca3c4739d0f3
           type: string
+          format: uuid
         user_id:
           description: The ID of a user this dashboard might be associated with
           example: 90be2a4a-1a4d-4779-b40f-f08ccd7101d5
           type: string
+          format: uuid
       type: object
     Group:
       example:
@@ -2422,6 +2438,7 @@ components:
           description: Unique ID of the group
           example: a16ad60e-bf23-4195-99dc-594858ad3e5e
           type: string
+          format: uuid
         name:
           description: The name of the group
           example: Group A
@@ -2464,6 +2481,7 @@ components:
           description: Unique ID of the report
           example: a9560d7d-dbe4-4a7f-8d09-dde6b5b137ae
           type: string
+          format: uuid
         filename:
           description: The filename of the report
           example: myreport.zip
@@ -2503,6 +2521,7 @@ components:
           description: The database ID of the import
           example: e56740ba-0dbb-43ac-a556-364eefbf1f62
           type: string
+          format: uuid
         status:
           description: The current status of the import, can be one of "pending", "running", "done"
           example: done
@@ -2519,6 +2538,7 @@ components:
           description: The ID of the run from the import
           example: 64c2ab9e-cd64-4815-bf73-83b00c2e650f
           type: string
+          format: uuid
       type: object
     WidgetConfig:
       example:
@@ -2538,6 +2558,7 @@ components:
           description: The internal ID of the WidgetConfig
           example: afbcf5c7-1ffd-4367-b228-5a868c29e0ef
           type: string
+          format: uuid
         type:
           description: The type of widget, one of either "widget" or "view"
           example: widget
@@ -2550,6 +2571,7 @@ components:
           description: The project ID for which the widget is designed
           example: 44941c55-9736-42f6-acce-ca3c4739d0f3
           type: string
+          format: uuid
         weight:
           description: The weighting for the widget, lower weight means it will display first
           example: 0
@@ -2825,6 +2847,7 @@ components:
           description: The ID of the user
           example: 81e2c9d6-1593-4559-af4f-90f6f1f8fa03
           type: string
+          format: uuid
         email:
           description: The user's e-mail address
           example: user@domain.com
@@ -2846,6 +2869,7 @@ components:
           description: The ID of the group of this project
           example: a16ad60e-bf23-4195-99dc-594858ad3e5e
           type: string
+          format: uuid
           nullable: true
       required:
         - email
@@ -2880,10 +2904,12 @@ components:
           description: The ID of the token
           example: e2772010-bc06-47ed-8b6b-767ab87427cc
           type: string
+          format: uuid
         user_id:
           description: The ID of the user that owns this token
           example: 81e2c9d6-1593-4559-af4f-90f6f1f8fa03
           type: string
+          format: uuid
         name:
           description: The name given to this token
           example: My user token
@@ -3190,6 +3216,7 @@ components:
       schema:
         format: int32
         type: integer
+        minimum: 1
       style: form
   securitySchemes:
     jwt:


### PR DESCRIPTION
This is fixing some of the reported errors.

1. Handle the case for creating a project with the same project id
2. Handle the case for creating a project with the group id that doesn't exist. Creating a project without group id is permitted by the openapi schema.
3. Fix negative offset. Set it to 0 in case it is negative.
4. Validate id is in UUID format.
5. Add missing DB commit for creating a group.
6. Add `format: uuid` for all ids in UUID format to the openapi schema. It doesn't seem to affect validation but I think it's a good practice.
7. Fix description of the filename parameter `description: ID of pet to update` to the `description: name of the file`
8. Add minimum to the `PageSize` in openapi. It provides automatic validation. Before it was possible to request page_size of 0, which caused

```
 ZeroDivisionError: integer division or modulo by zero
```

Now API returns a proper 400 with an error message 
```
"detail": "0 is less than the minimum of 1\n\nFailed validating 'minimum' in schema: ...
```