### PR TITLE
Promote user_properties on archive import

### DIFF
--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -41,6 +41,10 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
         if metadata:
             result["metadata"] = result.get("metadata", {})
             result["metadata"].update(metadata)
+        # promote user_properties to the level of metadata
+        if "user_properties" in result.get("metadata", {}):
+            user_properties = result["metadata"].pop("user_properties")
+            result["metadata"].update(user_properties)
         result["env"] = result.get("metadata", {}).get("env")
         result["component"] = result.get("metadata", {}).get("component")
         result_record = Result.from_dict(**result)

--- a/frontend/src/components/classify-failures.js
+++ b/frontend/src/components/classify-failures.js
@@ -213,7 +213,6 @@ export class ClassifyFailuresTable extends React.Component {
     const resultFilters = [
       <MetaFilter
         key="metafilter"
-        // user_properties fields shouldn't be injected here
         fieldOptions={FILTERABLE_RESULT_FIELDS}
         runId={run_id}
         setFilter={this.setFilter}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -76,6 +76,8 @@ export const FILTERABLE_RESULT_FIELDS = [
   'metadata.importance',
   'metadata.title',
   'metadata.endpoint',
+  // TODO generic metadata.user_properties filter acceptance
+  // These are way too project specific
   'metadata.user_properties.BaseOS',
   'metadata.user_properties.SatelliteVersion',
   'metadata.user_properties.SnapVersion'


### PR DESCRIPTION
user_properties is promoted into metadata on results from the client, imported results should get the same treatment.

Tested with an archive with user_properties, need to test with one without as well.

This is not addressing junit import, which would have to pull the `properties` elements when trying to parse metadata.