### PR TITLE
fix api errors found in fuzzy testing, part 2

### DIFF
--- a/backend/docker/start_fuzz_testing.sh
+++ b/backend/docker/start_fuzz_testing.sh
@@ -11,4 +11,5 @@ response=$(curl -s -X POST http://backend:8080/api/login \
 
 token=$(jq -r '.token' <<< "${response}")
 
-st run http://backend:8080/api/openapi.json -H "Authorization: Bearer ${token}"
+# ignore the health endpoint, because it does return 5xx
+st run -E ^\(?\!/api/health\).* http://backend:8080/api/openapi.json -H "Authorization: Bearer ${token}"

--- a/backend/ibutsu_server/controllers/admin/project_controller.py
+++ b/backend/ibutsu_server/controllers/admin/project_controller.py
@@ -8,6 +8,7 @@ from ibutsu_server.filters import convert_filter
 from ibutsu_server.util.admin import check_user_is_admin
 from ibutsu_server.util.uuid import convert_objectid_to_uuid
 from ibutsu_server.util.uuid import is_uuid
+from ibutsu_server.util.uuid import validate_uuid
 
 
 def admin_add_project(project=None, token_info=None, user=None):
@@ -39,6 +40,7 @@ def admin_add_project(project=None, token_info=None, user=None):
     return project.to_dict(), 201
 
 
+@validate_uuid
 def admin_get_project(id_, token_info=None, user=None):
     """Get a single project by ID
 
@@ -101,6 +103,7 @@ def admin_get_project_list(
     }
 
 
+@validate_uuid
 def admin_update_project(id_, project=None, token_info=None, user=None):
     """Update a project
 
@@ -146,6 +149,7 @@ def admin_update_project(id_, project=None, token_info=None, user=None):
     return project.to_dict()
 
 
+@validate_uuid
 def admin_delete_project(id_, token_info=None, user=None):
     """Delete a single project"""
     check_user_is_admin(user)

--- a/backend/ibutsu_server/controllers/admin/user_controller.py
+++ b/backend/ibutsu_server/controllers/admin/user_controller.py
@@ -64,11 +64,15 @@ def admin_add_user(new_user=None, token_info=None, user=None):
     if not connexion.request.is_json:
         return "Bad request, JSON required", 400
     new_user = User.from_dict(**connexion.request.get_json())
+    user_exists = User.query.filter_by(email=new_user.email)
+    if user_exists:
+        return f"The user with email {new_user.email} already exists", 400
     session.add(new_user)
     session.commit()
     return _hide_sensitive_fields(new_user.to_dict()), 201
 
 
+@validate_uuid
 def admin_update_user(id_, user_info=None, token_info=None, user=None):
     """Update a single user in the system"""
     check_user_is_admin(user)
@@ -86,6 +90,7 @@ def admin_update_user(id_, user_info=None, token_info=None, user=None):
     return _hide_sensitive_fields(requested_user.to_dict())
 
 
+@validate_uuid
 def admin_delete_user(id_, token_info=None, user=None):
     """Delete a single user"""
     check_user_is_admin(user)

--- a/backend/ibutsu_server/controllers/artifact_controller.py
+++ b/backend/ibutsu_server/controllers/artifact_controller.py
@@ -26,6 +26,7 @@ def _build_artifact_response(id_):
     return artifact, response
 
 
+@validate_uuid
 def view_artifact(id_, token_info=None, user=None):
     """Stream an artifact directly to the client/browser
 
@@ -42,6 +43,7 @@ def view_artifact(id_, token_info=None, user=None):
     return response
 
 
+@validate_uuid
 def download_artifact(id_, token_info=None, user=None):
     """Download an artifact
 
@@ -173,6 +175,7 @@ def upload_artifact(body, token_info=None, user=None):
     return artifact.to_dict(), 201
 
 
+@validate_uuid
 def delete_artifact(id_, token_info=None, user=None):
     """Deletes an artifact
 

--- a/backend/ibutsu_server/controllers/dashboard_controller.py
+++ b/backend/ibutsu_server/controllers/dashboard_controller.py
@@ -2,6 +2,7 @@ import connexion
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Dashboard
 from ibutsu_server.db.models import Project
+from ibutsu_server.db.models import User
 from ibutsu_server.db.models import WidgetConfig
 from ibutsu_server.filters import convert_filter
 from ibutsu_server.util.projects import project_has_user
@@ -21,6 +22,8 @@ def add_dashboard(dashboard=None, token_info=None, user=None):
     dashboard = Dashboard.from_dict(**connexion.request.get_json())
     if dashboard.project_id and not project_has_user(dashboard.project_id, user):
         return "Forbidden", 403
+    if dashboard.user_id and not User.query.get(dashboard.user_id):
+        return f"User with ID {dashboard.user_id} doesn't exist", 400
     session.add(dashboard)
     session.commit()
     return dashboard.to_dict(), 201
@@ -90,6 +93,7 @@ def get_dashboard_list(
     }
 
 
+@validate_uuid
 def update_dashboard(id_, dashboard=None, token_info=None, user=None):
     """Update a dashboard
 
@@ -118,6 +122,7 @@ def update_dashboard(id_, dashboard=None, token_info=None, user=None):
     return dashboard.to_dict()
 
 
+@validate_uuid
 def delete_dashboard(id_, token_info=None, user=None):
     """Deletes a dashboard
 

--- a/backend/ibutsu_server/controllers/group_controller.py
+++ b/backend/ibutsu_server/controllers/group_controller.py
@@ -15,6 +15,8 @@ def add_group(group=None):
     if not connexion.request.is_json:
         return "Bad request, JSON required", 400
     group = Group.from_dict(**connexion.request.get_json())
+    if group.id and Group.query.get(group.id):
+        return f"The group with ID {group.id} already exists", 400
     session.add(group)
     session.commit()
     return group.to_dict(), 201
@@ -64,7 +66,8 @@ def get_group_list(page=1, page_size=25, token_info=None, user=None):
     }
 
 
-def update_group(id_, group=None):
+@validate_uuid
+def update_group(id_, group=None, **kwargs):
     """Update a group
 
 

--- a/backend/ibutsu_server/controllers/health_controller.py
+++ b/backend/ibutsu_server/controllers/health_controller.py
@@ -27,14 +27,14 @@ def get_database_health(token_info=None, user=None):
     # Try to connect to the database, and handle various responses
     try:
         if not IS_CONNECTED:
-            response = ({"status": "Error", "message": "Incomplete database configuration"}, 500)
+            response = ({"status": "Error", "message": "Incomplete database configuration"}, 503)
         else:
             Result.query.first()
             response = ({"status": "OK", "message": "Service is running"}, 200)
     except OperationalError:
-        response = ({"status": "Error", "message": "Unable to connect to the database"}, 500)
+        response = ({"status": "Error", "message": "Unable to connect to the database"}, 503)
     except InterfaceError:
-        response = ({"status": "Error", "message": "Incorrect connection configuration"}, 500)
+        response = ({"status": "Error", "message": "Incorrect connection configuration"}, 503)
     except Exception as e:
         response = ({"status": "Error", "message": str(e)}, 500)
     return response

--- a/backend/ibutsu_server/controllers/import_controller.py
+++ b/backend/ibutsu_server/controllers/import_controller.py
@@ -61,10 +61,12 @@ def add_import(
     if connexion.request.form.get("project"):
         project = connexion.request.form["project"]
     if project:
-        project = get_project(project)
+        project_obj = get_project(project)
+        if not project_obj:
+            return f"Project {project} doesn't exist", 400
         if not project_has_user(project, user):
             return "Forbidden", 403
-        data["project_id"] = project.id
+        data["project_id"] = project_obj.id
     if connexion.request.form.get("metadata"):
         metadata = json.loads(connexion.request.form.get("metadata"))
     data["metadata"] = metadata

--- a/backend/ibutsu_server/controllers/project_controller.py
+++ b/backend/ibutsu_server/controllers/project_controller.py
@@ -6,6 +6,7 @@ from ibutsu_server.util.projects import add_user_filter
 from ibutsu_server.util.projects import project_has_user
 from ibutsu_server.util.uuid import convert_objectid_to_uuid
 from ibutsu_server.util.uuid import is_uuid
+from ibutsu_server.util.uuid import validate_uuid
 
 
 def add_project(project=None, token_info=None, user=None):
@@ -19,6 +20,9 @@ def add_project(project=None, token_info=None, user=None):
     if not connexion.request.is_json:
         return "Bad request, JSON required", 400
     project = Project.from_dict(**connexion.request.get_json())
+    # check if project already exists
+    if project.id and Project.query.get(project.id):
+        return f"Project id {project.id} already exist", 400
     user = User.query.get(user)
     if user:
         project.owner = user
@@ -28,6 +32,7 @@ def add_project(project=None, token_info=None, user=None):
     return project.to_dict(), 201
 
 
+@validate_uuid
 def get_project(id_, token_info=None, user=None):
     """Get a single project by ID
 
@@ -84,7 +89,8 @@ def get_project_list(
     }
 
 
-def update_project(id_, project=None, token_info=None, user=None):
+@validate_uuid
+def update_project(id_, project=None, token_info=None, user=None, **kwargs):
     """Update a project
 
     :param id: ID of test project

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -221,11 +221,13 @@ paths:
                 resultId:
                   description: ID of result to attach artifact to
                   type: string
+                  format: uuid
                 runId:
                   description: ID of run to attach artifact to
                   type: string
+                  format: uuid
                 filename:
-                  description: ID of pet to update
+                  description: name of the file
                   type: string
                 file:
                   description: file to upload
@@ -1981,6 +1983,7 @@ paths:
           required: true
           schema:
             type: string
+            format: uuid
           style: simple
       responses:
         200:

--- a/backend/ibutsu_server/test/__init__.py
+++ b/backend/ibutsu_server/test/__init__.py
@@ -75,6 +75,14 @@ class BaseTestCase(TestCase):
         """
         self.assert_status(response, 201, message)
 
+    def assert_503(self, response, message=None):
+        """
+        Checks if response status code is 503
+        :param response: Flask response
+        :param message: Message to display on test failure
+        """
+        self.assert_status(response, 503, message)
+
     def assert_equal(self, first, second, msg=None):
         """Alias"""
         return self.assertEqual(first, second, msg)

--- a/backend/ibutsu_server/test/test_group_controller.py
+++ b/backend/ibutsu_server/test/test_group_controller.py
@@ -45,6 +45,7 @@ class TestGroupController(BaseTestCase):
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.jwt_token}",
         }
+        self.mock_group.query.get.return_value = None
         response = self.client.open(
             "/api/group",
             method="POST",

--- a/backend/ibutsu_server/test/test_health_controller.py
+++ b/backend/ibutsu_server/test/test_health_controller.py
@@ -19,7 +19,7 @@ class TestHealthController(BaseTestCase):
             "Authorization": f"Bearer {self.jwt_token}",
         }
         response = self.client.open("/api/health/database", method="GET", headers=headers)
-        self.assert_500(response, "Response body is : " + response.data.decode("utf-8"))
+        self.assert_503(response, "Response body is : " + response.data.decode("utf-8"))
 
     def test_get_health(self):
         """Test case for get_health

--- a/backend/ibutsu_server/test/test_project_controller.py
+++ b/backend/ibutsu_server/test/test_project_controller.py
@@ -67,6 +67,7 @@ class TestProjectController(BaseTestCase):
         self.user_patcher = patch("ibutsu_server.controllers.project_controller.User")
         self.mock_user = self.user_patcher.start()
         self.mock_user.query.get.return_value = MOCK_USER
+        self.mock_project.query.get.return_value = None
 
         headers = {
             "Accept": "application/json",
@@ -109,7 +110,7 @@ class TestProjectController(BaseTestCase):
         self.mock_project.query.filter.return_value.first.return_value = MOCK_PROJECT
         headers = {"Accept": "application/json", "Authorization": f"Bearer {self.jwt_token}"}
         response = self.client.open(
-            "/api/project/{id}".format(id=MOCK_NAME), method="GET", headers=headers
+            "/api/project/{id}".format(id=MOCK_ID), method="GET", headers=headers
         )
         self.assert_200(response, "Response body is : " + response.data.decode("utf-8"))
         self.assert_equal(response.json, MOCK_PROJECT_DICT)

--- a/backend/ibutsu_server/util/login.py
+++ b/backend/ibutsu_server/util/login.py
@@ -1,0 +1,16 @@
+import base64
+import binascii
+
+
+def validate_activation_code(activation_code):
+    """
+    activation code must be present and base64 encoded
+    """
+    if not activation_code:
+        return "Not Found", 404
+    try:
+        decoded_value = base64.urlsafe_b64decode(activation_code)
+    except (binascii.Error, ValueError):
+        return f"Activation code {activation_code} is not valid", 400
+    if not decoded_value:
+        return f"Activation code {activation_code} is not valid", 400


### PR DESCRIPTION
This is a second batch of fixing API errors found in fuzzy testing.

It includes:
1. Modify the test command - exclude `/api/health` because it returns 5xx error codes
2. Validate UUID in more places
3. Check if the object already exists in various places
4. Replace error code from `500` to `503` in database health check. It is more specific.
5. Fix another typo in openapi schema `description: ID of pet to update`
6. Add `validate_activation_code` function to validate the activation code