### PR TITLE
Add params logging on query failure

### DIFF
--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -370,6 +370,7 @@ export class ResultList extends React.Component {
       }))
       .catch((error) => {
         console.error('Error fetching result data:', error);
+        console.info('Params for result query: ', params)
         this.setState({rows: [], isEmpty: false, isError: true});
       });
   }


### PR DESCRIPTION
This feels a bit dumb, but the filter behavior has been inconsistent,
and I'd like to be able to see what the params were if/when the failure
occurs. Can use this to reproduce within api tests, as I've been unable to do so (at all)
when running ibutsu locally with a smaller data set.

Related to #378 