### PR TITLE
fix api errors found in fuzzy testing, part 3

### DIFF
--- a/backend/ibutsu_server/controllers/report_controller.py
+++ b/backend/ibutsu_server/controllers/report_controller.py
@@ -110,6 +110,7 @@ def get_report_list(page=1, page_size=25, project=None, token_info=None, user=No
     }
 
 
+@validate_uuid
 def delete_report(id_):
     """Deletes a report
 
@@ -127,6 +128,7 @@ def delete_report(id_):
         return "Not Found", 404
 
 
+@validate_uuid
 def view_report(id_, filename, token_info=None, user=None):
     """View the report file
 
@@ -138,6 +140,7 @@ def view_report(id_, filename, token_info=None, user=None):
     return _build_report_response(id_)[1]
 
 
+@validate_uuid
 def download_report(id_, filename, token_info=None, user=None):
     """Download the report file
 

--- a/backend/ibutsu_server/controllers/run_controller.py
+++ b/backend/ibutsu_server/controllers/run_controller.py
@@ -120,10 +120,15 @@ def add_run(run=None, token_info=None, user=None):
         return "Bad request, JSON is required", 400
     run = Run.from_dict(**connexion.request.get_json())
 
+    if not run.data:
+        return "Bad request, no data supplied", 400
+
     if run.data and not (run.data.get("project") or run.project_id):
         return "Bad request, project or project_id is required", 400
 
     project = get_project(run.data["project"])
+    if not project:
+        return "Invalid project", 400
     if not project_has_user(project, user):
         return "Forbidden", 403
     run.project = project

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2465,6 +2465,8 @@ components:
           description: The source of the test results
           example: iqe-jenkins
           type: string
+      required:
+        - type
       type: object
     Report:
       example:

--- a/backend/ibutsu_server/test/test_result_controller.py
+++ b/backend/ibutsu_server/test/test_result_controller.py
@@ -105,6 +105,7 @@ class TestResultController(BaseTestCase):
         Create a test result
         """
         result = ADDED_RESULT.to_dict()
+        self.mock_result.query.get.return_value = None
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",


### PR DESCRIPTION
1. Validate more UUIDs
2. Validate if the result already exists
3. Don’t try to add project_id to the result if the project was not found
4. Make report type required in the schema