### PR TITLE
fix api errors found in fuzzy testing, part 4

### DIFF
--- a/backend/ibutsu_server/controllers/admin/user_controller.py
+++ b/backend/ibutsu_server/controllers/admin/user_controller.py
@@ -5,7 +5,9 @@ from ibutsu_server.db.models import Project
 from ibutsu_server.db.models import User
 from ibutsu_server.filters import convert_filter
 from ibutsu_server.util.admin import check_user_is_admin
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.uuid import validate_uuid
+
 
 HIDDEN_FIELDS = ["_password", "password", "activation_code"]
 
@@ -43,7 +45,7 @@ def admin_get_user_list(filter_=None, page=1, page_size=25, token_info=None, use
             if filter_clause is not None:
                 query = query.filter(filter_clause)
 
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_items = query.count()
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
     users = query.order_by(User.email.asc()).offset(offset).limit(page_size).all()

--- a/backend/ibutsu_server/controllers/dashboard_controller.py
+++ b/backend/ibutsu_server/controllers/dashboard_controller.py
@@ -6,6 +6,7 @@ from ibutsu_server.db.models import User
 from ibutsu_server.db.models import WidgetConfig
 from ibutsu_server.filters import convert_filter
 from ibutsu_server.util.projects import project_has_user
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.uuid import validate_uuid
 
 
@@ -78,7 +79,7 @@ def get_dashboard_list(
                 query = query.filter(filter_clause)
 
     query = query.order_by(Dashboard.title.asc())
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_items = query.count()
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
     dashboards = query.offset(offset).limit(page_size).all()

--- a/backend/ibutsu_server/controllers/group_controller.py
+++ b/backend/ibutsu_server/controllers/group_controller.py
@@ -1,6 +1,8 @@
 import connexion
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Group
+from ibutsu_server.util.query import get_offset
+from ibutsu_server.util.uuid import is_uuid
 from ibutsu_server.util.uuid import validate_uuid
 
 
@@ -17,6 +19,8 @@ def add_group(group=None):
     group = Group.from_dict(**connexion.request.get_json())
     if group.id and Group.query.get(group.id):
         return f"The group with ID {group.id} already exists", 400
+    if not is_uuid(group.id):
+        return f"Group ID {group.id} is not in UUID format", 400
     session.add(group)
     session.commit()
     return group.to_dict(), 201
@@ -50,7 +54,7 @@ def get_group_list(page=1, page_size=25, token_info=None, user=None):
 
     :rtype: List[Group]
     """
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     query = Group.query
     total_items = query.count()
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)

--- a/backend/ibutsu_server/controllers/project_controller.py
+++ b/backend/ibutsu_server/controllers/project_controller.py
@@ -4,6 +4,7 @@ from ibutsu_server.db.models import Project
 from ibutsu_server.db.models import User
 from ibutsu_server.util.projects import add_user_filter
 from ibutsu_server.util.projects import project_has_user
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.uuid import convert_objectid_to_uuid
 from ibutsu_server.util.uuid import is_uuid
 from ibutsu_server.util.uuid import validate_uuid
@@ -74,7 +75,7 @@ def get_project_list(
         query = query.filter(Project.owner_id == owner_id)
     if group_id:
         query = query.filter(Project.group_id == group_id)
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_items = query.count()
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
     projects = query.offset(offset).limit(page_size).all()

--- a/backend/ibutsu_server/controllers/report_controller.py
+++ b/backend/ibutsu_server/controllers/report_controller.py
@@ -7,6 +7,7 @@ from ibutsu_server.db.models import Report
 from ibutsu_server.db.models import ReportFile
 from ibutsu_server.tasks.reports import REPORTS
 from ibutsu_server.util.projects import get_project_id
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.uuid import validate_uuid
 
 
@@ -95,7 +96,7 @@ def get_report_list(page=1, page_size=25, project=None, token_info=None, user=No
     if project:
         project_id = get_project_id(project)
         query = query.filter(Report.project_id == project_id)
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_items = query.count()
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
     reports = query.order_by(Report.created.desc()).offset(offset).limit(page_size).all()

--- a/backend/ibutsu_server/controllers/result_controller.py
+++ b/backend/ibutsu_server/controllers/result_controller.py
@@ -10,6 +10,7 @@ from ibutsu_server.util.count import get_count_estimate
 from ibutsu_server.util.projects import add_user_filter
 from ibutsu_server.util.projects import get_project
 from ibutsu_server.util.projects import project_has_user
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.query import query_as_task
 from ibutsu_server.util.uuid import validate_uuid
 
@@ -118,7 +119,7 @@ def get_result_list(filter_=None, page=1, page_size=25, estimate=False, token_in
     else:
         total_items = query.count()
 
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
 
     results = query.order_by(Result.start_time.desc()).offset(offset).limit(page_size).all()

--- a/backend/ibutsu_server/controllers/run_controller.py
+++ b/backend/ibutsu_server/controllers/run_controller.py
@@ -12,6 +12,7 @@ from ibutsu_server.util.projects import add_user_filter
 from ibutsu_server.util.projects import get_project
 from ibutsu_server.util.projects import get_project_id
 from ibutsu_server.util.projects import project_has_user
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.query import query_as_task
 from ibutsu_server.util.uuid import validate_uuid
 
@@ -77,7 +78,7 @@ def get_run_list(filter_=None, page=1, page_size=25, estimate=False, token_info=
     else:
         total_items = query.count()
 
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
     runs = query.order_by(Run.start_time.desc()).offset(offset).limit(page_size).all()
     return {

--- a/backend/ibutsu_server/controllers/user_controller.py
+++ b/backend/ibutsu_server/controllers/user_controller.py
@@ -5,6 +5,7 @@ from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Token
 from ibutsu_server.db.models import User
 from ibutsu_server.util.jwt import generate_token
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.uuid import validate_uuid
 
 HIDDEN_FIELDS = ["_password", "password", "activation_code"]
@@ -57,7 +58,7 @@ def get_token_list(page=1, page_size=25, token_info=None, user=None):
 
     query = Token.query.filter(Token.user == user, Token.name != "login-token")
     total_items = query.count()
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
     tokens = query.offset(offset).limit(page_size).all()
     return {

--- a/backend/ibutsu_server/controllers/widget_config_controller.py
+++ b/backend/ibutsu_server/controllers/widget_config_controller.py
@@ -6,6 +6,7 @@ from ibutsu_server.db.models import WidgetConfig
 from ibutsu_server.filters import convert_filter
 from ibutsu_server.util.projects import get_project
 from ibutsu_server.util.projects import project_has_user
+from ibutsu_server.util.query import get_offset
 from ibutsu_server.util.uuid import validate_uuid
 from sqlalchemy import or_
 
@@ -80,7 +81,7 @@ def get_widget_config_list(filter_=None, page=1, page_size=25):
                 filter_clause = convert_filter(filter_string, WidgetConfig)
             if filter_clause is not None:
                 query = query.filter(filter_clause)
-    offset = (page * page_size) - page_size
+    offset = get_offset(page, page_size)
     total_items = query.count()
     total_pages = (total_items // page_size) + (1 if total_items % page_size > 0 else 0)
     widgets = query.order_by(WidgetConfig.weight.asc()).offset(offset).limit(page_size)

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -50,6 +50,11 @@ class ModelMixin(object):
         # because metadata is a reserved attr name, translate it to data
         if "metadata" in record_dict:
             record_dict["data"] = record_dict.pop("metadata") or {}
+
+        # remove empty keys
+        for key in list(record_dict.keys()):
+            if not key:
+                del record_dict[key]
         return cls(**record_dict)
 
     def update(self, record_dict):

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2131,6 +2131,7 @@ components:
                 description: The user's e-mail address
                 example: user@domain.com
                 type: string
+                format: email
               name:
                 description: The user's name
                 example: Namey McNameface
@@ -2786,6 +2787,7 @@ components:
           description: The e-mail address of the user
           example: me@example.com
           type: string
+          format: email
         password:
           description: The password for the user
           example: mysupersecretpassword
@@ -2803,6 +2805,7 @@ components:
           description: The user's e-mail address
           example: user@domain.com
           type: string
+          format: email
         password:
           description: The user's password
           example: supersecretpassword
@@ -2819,6 +2822,7 @@ components:
           description: The user's e-mail address
           example: user@domain.com
           type: string
+          format: email
       required:
         - email
       type: object
@@ -2857,6 +2861,7 @@ components:
           description: The user's e-mail address
           example: user@domain.com
           type: string
+          format: email
         name:
           description: The user's name
           example: Namey McNameface

--- a/backend/ibutsu_server/test/test_login_controller.py
+++ b/backend/ibutsu_server/test/test_login_controller.py
@@ -56,7 +56,12 @@ class TestLoginController(BaseTestCase):
         Log in to the API
         """
         login_details = {"email": "", "password": ""}
-        expected_response = {"code": "EMPTY", "message": "Username and/or password are empty"}
+        expected_response = {
+            "detail": "'' is not a 'email' - 'email'",
+            "status": 400,
+            "title": "Bad Request",
+            "type": "about:blank",
+        }
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
         response = self.client.open(
             "/api/login",
@@ -65,7 +70,7 @@ class TestLoginController(BaseTestCase):
             data=json.dumps(login_details),
             content_type="application/json",
         )
-        self.assert_401(response, "Response body is : " + response.data.decode("utf-8"))
+        self.assert_400(response, "Response body is : " + response.data.decode("utf-8"))
         assert response.json == expected_response
 
     def test_login_no_user(self):

--- a/backend/ibutsu_server/test/test_project_controller.py
+++ b/backend/ibutsu_server/test/test_project_controller.py
@@ -94,7 +94,10 @@ class TestProjectController(BaseTestCase):
         Get a single project by ID
         """
         self.mock_project.query.filter.return_value.first.return_value = None
-        headers = {"Accept": "application/json", "Authorization": f"Bearer {self.jwt_token}"}
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.jwt_token}",
+        }
         response = self.client.open(
             "/api/project/{id}".format(id=MOCK_ID), method="GET", headers=headers
         )
@@ -108,7 +111,10 @@ class TestProjectController(BaseTestCase):
         Get a single project by name
         """
         self.mock_project.query.filter.return_value.first.return_value = MOCK_PROJECT
-        headers = {"Accept": "application/json", "Authorization": f"Bearer {self.jwt_token}"}
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.jwt_token}",
+        }
         response = self.client.open(
             "/api/project/{id}".format(id=MOCK_ID), method="GET", headers=headers
         )
@@ -124,13 +130,21 @@ class TestProjectController(BaseTestCase):
             ("page", 56),
             ("pageSize", 56),
         ]
-        headers = {"Accept": "application/json", "Authorization": f"Bearer {self.jwt_token}"}
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.jwt_token}",
+        }
         response = self.client.open(
             "/api/project", method="GET", headers=headers, query_string=query_string
         )
         self.assert_200(response, "Response body is : " + response.data.decode("utf-8"))
         expected_response = {
-            "pagination": {"page": 56, "pageSize": 56, "totalItems": 1, "totalPages": 1},
+            "pagination": {
+                "page": 56,
+                "pageSize": 56,
+                "totalItems": 1,
+                "totalPages": 1,
+            },
             "projects": [MOCK_PROJECT_DICT],
         }
         assert response.json == expected_response

--- a/backend/ibutsu_server/util/query.py
+++ b/backend/ibutsu_server/util/query.py
@@ -5,6 +5,15 @@ from ibutsu_server.constants import MAX_PAGE_SIZE
 from ibutsu_server.tasks.query import query_task
 
 
+def get_offset(page, page_size):
+    """
+    Get the offset for the query
+    """
+    offset = (page * page_size) - page_size
+    offset = 0 if offset < 0 else offset
+    return offset
+
+
 def query_as_task(function):
     """
     Depending on page_size, runs a query as a task.


### PR DESCRIPTION
This is a 4th batch of fixing API errors found in fuzzy testing.

It includes:

1. Fixing offset in all places
2. Add some more uuid validation
3. Fix `from_dict` method, so it doesn’t throw an error in case of empty keys (e.g. empty strings)
4. Add missing email format validation to openapi schema