### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+Version 2.4.0
+=============
+
+* fix api errors found in fuzzy testing, part 4
+* linting
+* fix api, part 3
+* cleaned up and removed unnecessary comments
+* Changed fetches to HttpClient.gets in accessibilityanalysis view
+* Fixing up axe data summary display
+* fix api errors found in fuzzy testing, part 2
+* Promote user_properties on archive import
+* fix api errors found in fuzzy testing, part 1
+* add schemathesis to actions
+* Upgrade Celery to the latest version
+* Update podman and Docker Compose configurations
+* Flask listens on 127.0.0.1 by default, add the ability to specify it for podman
+* Drop the tarfile open mode to autodetect compression
+
 Version 2.3.0
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.3.0
+  version: 2.4.0
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.3.0"
+VERSION = "2.4.0"
 REQUIRES = [
     "alembic",
     "celery",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.15.8",


### PR DESCRIPTION
* Fix various API errors found in fuzzy testing
* Add/update the accessibility dashboard
* Promote user_properties on archive import
* Add schemathesis to actions
* Upgrade Celery to the latest version
* Update podman and Docker Compose configurations
* Flask listens on 127.0.0.1 by default, add the ability to specify it for podman
* Drop the tarfile open mode to autodetect compression