### PR TITLE
Fixing test history bug

### DIFF
--- a/frontend/src/components/test-history.js
+++ b/frontend/src/components/test-history.js
@@ -66,6 +66,7 @@ export class TestHistoryTable extends React.Component {
       filters: Object.assign({
         'result': {op: 'in', val: "passed;skipped;failed;error;xpassed;xfailed"},
         'test_id': {op: 'eq', val: props.testResult.test_id},
+        'component': {op: 'eq', val: props.testResult.component},
         // default to filter only from 1 weeks ago to the most test's start_time.
         'start_time': {op: 'gt', val: new Date(new Date(props.testResult.start_time).getTime() - (0.25 * 30 * 86400 * 1000)).toISOString()}
         }, props.filters),
@@ -349,7 +350,7 @@ export class TestHistoryTable extends React.Component {
               <Text key="last-passed" component="h4">Last passed:&nbsp;{this.state.lastPassedDate}</Text>,
             ]}
             onRemoveFilter={this.removeFilter}
-            hideFilters={["project_id", "result", "test_id"]}
+            hideFilters={["project_id", "result", "test_id", "component"]}
           />
         </CardBody>
       </Card>


### PR DESCRIPTION
Solving https://github.com/ibutsu/ibutsu-server/issues/408.

As a temporary improvement (not entirely fixed yet) I added component to the filter for test history, so that the history at least only shows results within the same component and the same test name. However it is still possible to have two different tests that have the same name and same component returned in the test history result.