### PR TITLE
Adding ability to edit dashboard widgets

### DIFF
--- a/frontend/src/components/edit-widget-modal.js
+++ b/frontend/src/components/edit-widget-modal.js
@@ -1,0 +1,162 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import Linkify from 'react-linkify';
+
+import { HttpClient } from '../services/http';
+import { Settings } from '../settings';
+import { linkifyDecorator } from './decorators';
+
+
+
+export class EditWidgetModal extends React.Component {
+  static propTypes = {
+    onSave: PropTypes.func,
+    onClose: PropTypes.func,
+    isOpen: PropTypes.bool,
+    data: PropTypes.object,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      widgetType: null,
+      title: props.data.title,
+      params: props.data.params,
+      weight: props.data.weight,
+      isTitleValid: true,
+      areParamsFilled: true,
+      componentLoaded: false,
+    };
+  }
+
+
+  onNameChange = (name) => {
+    this.setState({name});
+  }
+
+  onExpiryDateChange = (expiryStr) => {
+    this.setState({expiryDate: expiryStr});
+  }
+
+  onSave = () => {
+    const updatedWidget = {
+      title: this.state.title,
+      params: this.state.params,
+      weight: parseInt(this.state.weight),
+      type: 'widget',
+      widget: this.props.data.widget
+    }
+    this.props.onSave(updatedWidget);
+    this.setState({
+      widgetType: null,
+      title: '',
+      params: {},
+      weight: 0,
+      isTitleValid: false,
+      areParamsFilled: false
+    });
+  }
+
+  onClose = () => {
+    this.setState({
+      title: '',
+      params: {},
+      weight: 0,
+      isTitleValid: false,
+      areParamsFilled: false,
+    });
+    this.props.onClose();
+  }
+
+  onTitleChange = (value) => {
+    this.setState({title: value, isTitleValid: (value !== '')});
+  }
+
+  onWeightChange = (value) => {
+    this.setState({weight: value});
+  }
+
+  onParamChange = (value, event) => {
+    const params = this.state.params;
+    let areParamsFilled = true;
+    if (event) {
+      params[event.target.name] = value;
+    }
+    this.setState({params: params});
+    this.state.widgetType.params.forEach(widgetParam => {
+        if ((widgetParam.required) && (!params[widgetParam.name])) {
+          areParamsFilled = false;
+        }
+    });
+    this.setState({areParamsFilled: areParamsFilled});
+  }
+
+  componentDidMount() {
+    HttpClient.get([Settings.serverUrl, 'widget', 'types'], {'type': 'widget'})
+      .then(response => HttpClient.handleResponse(response))
+      .then(data => {
+        data.types.forEach(type => {
+          if (type.id == this.props.data.widget) {
+            this.setState({widgetType: type});
+            this.setState({componentLoaded: true});
+          }
+        });
+      });
+  }
+
+  render () {
+    const { widgetType, componentLoaded } = this.state;
+    return (
+      <Modal
+        variant={ModalVariant.small}
+        title="Edit widget"
+        isOpen={this.props.isOpen}
+        onClose={this.onClose}
+        actions={[
+          <Button key="save" variant="primary" onClick={this.onSave}>Save</Button>,
+          <Button key="cancel" variant="link" onClick={this.onClose}>Cancel</Button>
+        ]}
+      >
+        <Form>
+          <FormGroup label="Title" fieldId="widget-title" helperText="A title for the widget" validated={this.isTitleValid} helperTextInvalid="Please enter a title for this widget" helperTextInvalidIcon={<ExclamationCircleIcon/>} isRequired>
+            <TextInput type="text" id="widget-title" name="widget-title" value={this.state.title} onChange={this.onTitleChange} validated={this.state.isTitleValid} isRequired />
+          </FormGroup>
+          <FormGroup label="Weight" fieldId="widget-weight" helperText="How widgets are ordered on the dashboard">
+            <TextInput type="number" id="widget-weight" name="widget-weight" value={this.state.weight} onChange={this.onWeightChange} />
+          </FormGroup>
+          {componentLoaded ? widgetType.params.map(param => {
+            return (
+              <React.Fragment key={param.name}>
+                <FormGroup
+                label={param.name}
+                fieldId={param.name}
+                helperText={<Linkify componentDecorator={linkifyDecorator}>{param.description}</Linkify>}
+                isRequired={param.required}>
+                  <TextInput
+                    value={this.state.params[param.name]}
+                    type={(param.type === 'integer' || param.type === 'float') ? 'number' : 'text'}
+                    id={param.name}
+                    aria-describedby={`${param.name}-helper`}
+                    name={param.name}
+                    onChange={this.onParamChange}
+                    isRequired={param.required}
+                  />
+                </FormGroup>
+              </React.Fragment>
+            )
+          }): ""}
+        </Form>
+      </Modal>
+    );
+  }
+}

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -17,3 +17,4 @@ export { TabTitle } from './tabs';
 export { TableEmptyState, TableErrorState } from './tablestates';
 export { UserDropdown } from './user-dropdown';
 export { View } from './view';
+export { EditWidgetModal } from './edit-widget-modal';

--- a/frontend/src/components/widget-components.js
+++ b/frontend/src/components/widget-components.js
@@ -10,7 +10,7 @@ import {
   Text,
   Tooltip
 } from '@patternfly/react-core';
-import { PficonHistoryIcon, TimesIcon  } from '@patternfly/react-icons';
+import { PficonHistoryIcon, TimesIcon, PencilAltIcon } from '@patternfly/react-icons';
 
 
 export class WidgetHeader extends React.Component {
@@ -19,11 +19,12 @@ export class WidgetHeader extends React.Component {
     getDataFunc: PropTypes.func,
     onDeleteClick: PropTypes.func,
     title: PropTypes.string,
-    actions: PropTypes.array
+    actions: PropTypes.array,
+    onEditClick: PropTypes.func
   }
 
   render () {
-    const { title, getDataFunc, actions, onDeleteClick } = this.props;
+    const { title, getDataFunc, actions, onDeleteClick, onEditClick } = this.props;
     return (
       <CardHeader data-id="widget-header">
         <Text component="h2" style={{ fontSize: 20 }}>{title}</Text>
@@ -33,8 +34,13 @@ export class WidgetHeader extends React.Component {
           <PficonHistoryIcon />
         </Button>
         }
+        {onEditClick &&
+        <Button variant="plain" onClick={onEditClick} title="Edit" aria-label="Edit" isInline>
+          <PencilAltIcon />
+        </Button>
+        }
         {onDeleteClick &&
-         <Button variant="plain" onClick={onDeleteClick} title="Remove from dashboard" aria-label="Delete" isInline>
+        <Button variant="plain" onClick={onDeleteClick} title="Remove from dashboard" aria-label="Delete" isInline>
           <TimesIcon />
         </Button>
         }

--- a/frontend/src/widgets/genericarea.js
+++ b/frontend/src/widgets/genericarea.js
@@ -45,6 +45,7 @@ export class GenericAreaWidget extends React.Component {
     xLabel: PropTypes.string,
     yLabel: PropTypes.string,
     onDeleteClick: PropTypes.func,
+    onEditClick: PropTypes.func
   }
 
   constructor(props) {
@@ -158,7 +159,7 @@ export class GenericAreaWidget extends React.Component {
     const legendData = this.getLegendData();
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getData} onDeleteClick={this.props.onDeleteClick}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getData} onEditClick={this.props.onEditClick} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="generic-area">
           {this.state.areaChartError &&
             <p>Error fetching data</p>

--- a/frontend/src/widgets/genericbar.js
+++ b/frontend/src/widgets/genericbar.js
@@ -39,6 +39,7 @@ export class GenericBarWidget extends React.Component {
     xLabelTooltip: PropTypes.string,
     yLabel: PropTypes.string,
     onDeleteClick: PropTypes.func,
+    onEditClick: PropTypes.func
   }
 
   constructor(props) {
@@ -202,7 +203,7 @@ export class GenericBarWidget extends React.Component {
   render() {
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getData} onDeleteClick={this.props.onDeleteClick}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getData} onEditClick={this.props.onEditClick} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="recent-runs">
           {this.state.genericBarError &&
             <p>Error fetching data</p>

--- a/frontend/src/widgets/jenkinsheatmap.js
+++ b/frontend/src/widgets/jenkinsheatmap.js
@@ -30,7 +30,8 @@ export class JenkinsHeatmapWidget extends React.Component {
     hideDropdown: PropTypes.bool,
     dropdownItems: PropTypes.array,
     includeAnalysisLink: PropTypes.bool,
-    onDeleteClick: PropTypes.func
+    onDeleteClick: PropTypes.func,
+    onEditClick: PropTypes.func
   }
 
   constructor(props) {
@@ -207,7 +208,7 @@ export class JenkinsHeatmapWidget extends React.Component {
     const actions = this.getJenkinsAnalysisLink() || {};
     return (
       <Card>
-        <WidgetHeader title={this.title} actions={actions} getDataFunc={this.getHeatmap} onDeleteClick={this.props.onDeleteClick}/>
+        <WidgetHeader title={this.title} actions={actions} getDataFunc={this.getHeatmap} onEditClick={this.props.onEditClick} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="heatmap" style={{paddingTop: '0.5rem'}}>
           {(!this.state.heatmapError && this.state.isLoading) &&
           <Text component="h2">Loading ...</Text>

--- a/frontend/src/widgets/resultaggregator.js
+++ b/frontend/src/widgets/resultaggregator.js
@@ -27,6 +27,7 @@ export class ResultAggregatorWidget extends React.Component {
     params: PropTypes.object,
     dropdownItems: PropTypes.array,
     onDeleteClick: PropTypes.func,
+    onEditClick: PropTypes.func
   }
 
   constructor(props) {
@@ -111,7 +112,7 @@ export class ResultAggregatorWidget extends React.Component {
     ];
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getResultData} onDeleteClick={this.props.onDeleteClick}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getResultData} onEditClick={this.props.onEditClick} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody data-id="recent-result-data">
           {this.state.resultAggregatorError &&
             <p>Error fetching data</p>

--- a/frontend/src/widgets/resultsummary.js
+++ b/frontend/src/widgets/resultsummary.js
@@ -22,6 +22,7 @@ export class ResultSummaryWidget extends React.Component {
     title: PropTypes.string,
     params: PropTypes.object,
     onDeleteClick: PropTypes.func,
+    onEditClick: PropTypes.func
   }
 
   constructor(props) {
@@ -86,7 +87,7 @@ export class ResultSummaryWidget extends React.Component {
                 ];
     return (
       <Card>
-        <WidgetHeader title={this.title} getDataFunc={this.getResultSummary} onDeleteClick={this.props.onDeleteClick}/>
+        <WidgetHeader title={this.title} getDataFunc={this.getResultSummary} onEditClick={this.props.onEditClick} onDeleteClick={this.props.onDeleteClick}/>
         <CardBody>
           <div>
             {!this.state.isLoading &&


### PR DESCRIPTION
Solving https://github.com/ibutsu/ibutsu-server/issues/389

This PR adds a button to each widget for editing the widget. When the button is clicked a Modal pops up with the fields already filled out with the widgets details. Users can then make changes and click save. Note: All edits will shown on save except for the widget's title. For some reason it only updates on a full page refresh. I can look into this more. 

Everything else is working correctly, but I have this error in the console that I can't track down in the code. 
![Screenshot from 2022-11-30 12-23-05](https://user-images.githubusercontent.com/48397354/204866111-2e7c80d9-f120-4c0b-aca2-a43bc56e8041.png)
