### PR TITLE
Release 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+Version 2.4.3
+=============
+
+* Added accessibility marker filter to remove irrelevant results
+* Adding ability to edit dashboard widgets
+* Update backend/ibutsu_server/util/__init__.py
+* Fixing test history bug
+* Add more UUID validation
+* Updated precommit
+* Migration to component testing using Cypress
+* Fixed url for flake8 hook
+* Fixing Jenkins Bar and Line charts
+* Change the homemade copy-paste component to the one from PatternFly
+* Add instructions for how to download an artifact
+* Adding days and project_id to compare-runs-data calls
+
 Version 2.4.2
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.4.2
+  version: 2.4.3
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.4.2"
+VERSION = "2.4.3"
 REQUIRES = [
     "alembic",
     "celery",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.19.3",


### PR DESCRIPTION
* Added accessibility marker filter to remove irrelevant results
* Adding ability to edit dashboard widgets
* Fixing test history bug
* Add more UUID validation
* Updated precommit
* Migration to component testing using Cypress
* Fixed url for flake8 hook
* Fixing Jenkins Bar and Line charts
* Change the homemade copy-paste component to the one from PatternFly
* Add instructions for how to download an artifact
* Adding days and project_id to compare-runs-data calls