### PR TITLE
New filter-heatmap widget for making flexible heatmaps

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -107,6 +107,34 @@ WIDGET_TYPES = {
         ],
         "type": "widget",
     },
+    "filter-heatmap": {
+        "id": "filter-heatmap",
+        "title": "Filtered Heatmap",
+        "description": "A heatmap of filtered test runs.",
+        "params": [
+            {
+                "name": "filters",
+                "description": "The filters for the runs to be included" " in the query.",
+                "type": "string",
+                "required": True,
+            },
+            {
+                "name": "builds",
+                "description": "The number of builds to analyze.",
+                "type": "integer",
+                "default": 5,
+                "required": True,
+            },
+            {
+                "name": "group_field",
+                "description": "The field in a result to group by, typically 'component'",
+                "type": "string",
+                "required": True,
+                "default": "component",
+            },
+        ],
+        "type": "widget",
+    },
     "run-aggregator": {
         "id": "run-aggregator",
         "title": "Run Aggregation",

--- a/backend/ibutsu_server/controllers/widget_controller.py
+++ b/backend/ibutsu_server/controllers/widget_controller.py
@@ -5,6 +5,7 @@ from ibutsu_server.widgets.accessibility_analysis import get_accessibility_analy
 from ibutsu_server.widgets.accessibility_analysis import get_accessibility_bar_chart
 from ibutsu_server.widgets.accessibility_dashboard_view import get_accessibility_dashboard_view
 from ibutsu_server.widgets.compare_runs_view import get_comparison_data
+from ibutsu_server.widgets.filter_heatmap import get_filter_heatmap
 from ibutsu_server.widgets.jenkins_heatmap import get_jenkins_heatmap
 from ibutsu_server.widgets.jenkins_job_analysis import get_jenkins_analysis_data
 from ibutsu_server.widgets.jenkins_job_analysis import get_jenkins_bar_chart
@@ -22,6 +23,7 @@ WIDGET_METHODS = {
     "jenkins-analysis-view": get_jenkins_analysis_data,
     "jenkins-bar-chart": get_jenkins_bar_chart,
     "jenkins-heatmap": get_jenkins_heatmap,
+    "filter-heatmap": get_filter_heatmap,
     "jenkins-job-view": get_jenkins_job_view,
     "jenkins-line-chart": get_jenkins_line_chart,
     "run-aggregator": get_recent_run_data,

--- a/backend/ibutsu_server/widgets/filter_heatmap.py
+++ b/backend/ibutsu_server/widgets/filter_heatmap.py
@@ -1,0 +1,119 @@
+from ibutsu_server.constants import HEATMAP_MAX_BUILDS
+from ibutsu_server.constants import HEATMAP_RUN_LIMIT
+from ibutsu_server.db.base import Float
+from ibutsu_server.db.base import session
+from ibutsu_server.db.models import Run
+from ibutsu_server.filters import apply_filters
+from ibutsu_server.filters import string_to_column
+from sqlalchemy import case
+from sqlalchemy import desc
+from sqlalchemy import func
+
+NO_RUN_TEXT = "None"
+NO_PASS_RATE_TEXT = "Build failed"
+
+
+def _calculate_slope(x_data):
+    """Calculate the trend slope of the data
+
+    :param x_data: A list of the result percentages, e.g. [98, 54, 97, 99]
+    :type x_data: list
+
+    :rtype float:
+    """
+    if all(x == 100 for x in x_data):
+        return 100
+    y_data = list(range(len(x_data)))
+    x_avg = sum(x_data) / len(x_data)
+    y_avg = sum(y_data) / len(y_data)
+    try:
+        slope = sum((x - x_avg) * (y - y_avg) for x, y in zip(x_data, y_data)) / sum(
+            (x - x_avg) ** 2 for x in x_data
+        )
+    except ZeroDivisionError:
+        slope = 0
+    return slope
+
+
+def _get_heatmap(filters, builds, group_field, project=None):
+    """Get Filtered Heatmap Data."""
+    filters = filters.split(",")
+    if project:
+        filters.append(f"project_id={project}")
+
+    # generate the group_field
+    group_field = string_to_column(group_field, Run)
+
+    # get the runs on which to run the aggregation, we select from a subset of runs to improve
+    # performance, otherwise we'd be aggregating over ALL runs
+    heatmap_run_limit = int((HEATMAP_RUN_LIMIT / HEATMAP_MAX_BUILDS) * builds)
+    sub_query = (
+        apply_filters(Run.query, filters, Run)
+        .order_by(desc("start_time"))
+        .limit(heatmap_run_limit)
+        .subquery()
+    )
+
+    query = (
+        session.query(
+            Run.id.label("run_id"),
+            group_field.label("group_field"),
+            Run.start_time.label("start_time"),
+            func.sum(Run.summary["failures"].cast(Float)).label("failures"),
+            func.sum(Run.summary["errors"].cast(Float)).label("errors"),
+            func.sum(Run.summary["skips"].cast(Float)).label("skips"),
+            func.sum(Run.summary["xfailures"].cast(Float)).label("xfailures"),
+            func.sum(Run.summary["xpasses"].cast(Float)).label("xpasses"),
+            func.sum(Run.summary["tests"].cast(Float)).label("total"),
+        )
+        .select_entity_from(sub_query)
+        .order_by(desc("start_time"))
+        .group_by(group_field, Run.id, Run.start_time)
+    )
+
+    # add filters to the query
+    query = apply_filters(query, filters, Run)
+
+    # convert the base query to a sub query
+    subquery = query.subquery()
+
+    # create the main query (this allows us to do math on the SQL side)
+    passes = subquery.c.total - (
+        subquery.c.errors + subquery.c.failures + subquery.c.xpasses + subquery.c.xfailures
+    )
+
+    query = session.query(
+        subquery.c.group_field,
+        subquery.c.run_id,
+        subquery.c.start_time,
+        # handle potential division by 0 errors, if the total is 0, set the pass_percent to 0
+        case(
+            [
+                (subquery.c.total == 0, 0),
+            ],
+            else_=(100 * passes / subquery.c.total),
+        ).label("pass_percent"),
+    )
+
+    # parse the data for the frontend
+    query_data = query.all()
+    data = {datum.group_field: [] for datum in query_data}
+    for key in data.keys():
+        runs = [run for run in query_data if run.group_field == key]
+        runs.sort(key=lambda run: run.start_time)
+        for i, datum in enumerate(query_data):
+            if datum.group_field == key and len(data[key]) < builds:
+                data[key].insert(0, [round(datum.pass_percent, 2), datum.run_id, None, str(i + 1)])
+    # compute the slope for each component
+    data_with_slope = data.copy()
+    for key, value in data.items():
+        slope_info = _calculate_slope([v[0] for v in value])
+        data_with_slope[key].insert(0, [slope_info, 0])
+
+    return data_with_slope
+
+
+def get_filter_heatmap(filters, builds, group_field, project=None):
+    """Generate JSON data for a filtered heatmap of runs"""
+    heatmap = _get_heatmap(filters, builds, group_field, project)
+    return {"heatmap": heatmap}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -4,6 +4,7 @@ export const MONITOR_UPLOAD_TIMEOUT = 1 * 1000;  // 1 second
 export const ALERT_TIMEOUT = 5 * 1000;  // 5 seconds
 export const KNOWN_WIDGETS = [
   'jenkins-heatmap',
+  'filter-heatmap',
   'run-aggregator',
   'result-summary',
   'result-aggregator',

--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -34,7 +34,7 @@ import { DeleteModal, NewDashboardModal, NewWidgetWizard, EditWidgetModal } from
 import {
   GenericAreaWidget,
   GenericBarWidget,
-  JenkinsHeatmapWidget,
+  FilterHeatmapWidget,
   ResultAggregatorWidget,
   ResultSummaryWidget
 } from './widgets';
@@ -353,7 +353,17 @@ export class Dashboard extends React.Component {
                 return (
                   <GridItem xl={4} lg={6} md={12} key={widget.id}>
                     {(widget.type === "widget" && widget.widget === "jenkins-heatmap") &&
-                      <JenkinsHeatmapWidget
+                      <FilterHeatmapWidget
+                        title={widget.title}
+                        params={widget.params}
+                        includeAnalysisLink={true}
+                        type='jenkins'
+                        onDeleteClick={() => this.onDeleteWidgetClick(widget.id)}
+                        onEditClick={() => this.onEditWidgetClick(widget.id)}
+                      />
+                    }
+                    {(widget.type === "widget" && widget.widget === "filter-heatmap") &&
+                      <FilterHeatmapWidget
                         title={widget.title}
                         params={widget.params}
                         includeAnalysisLink={true}

--- a/frontend/src/views/jenkinsjobanalysis.js
+++ b/frontend/src/views/jenkinsjobanalysis.js
@@ -13,7 +13,7 @@ import {
   getActiveProject,
   parseFilter,
 } from '../utilities';
-import { JenkinsHeatmapWidget, GenericAreaWidget, GenericBarWidget } from '../widgets';
+import { FilterHeatmapWidget, GenericAreaWidget, GenericBarWidget } from '../widgets';
 import { ParamDropdown } from '../components';
 import { HEATMAP_MAX_BUILDS } from '../constants'
 
@@ -229,7 +229,7 @@ export class JenkinsJobAnalysisView extends React.Component {
       <Tabs activeKey={this.state.activeTab} onSelect={this.onTabSelect} isBox>
         <Tab eventKey='heatmap' title={'Heatmap'}>
           {!isLoading && activeTab === "heatmap" &&
-          <JenkinsHeatmapWidget title={heatmapParams.job_name} params={heatmapParams} hideDropdown={true} labelWidth={400}/>
+          <FilterHeatmapWidget title={heatmapParams.job_name} params={heatmapParams} hideDropdown={true} labelWidth={400} type='jenkins'/>
           }
         </Tab>
         <Tab eventKey='overall-health' title={'Overall Health'}>

--- a/frontend/src/widgets/index.js
+++ b/frontend/src/widgets/index.js
@@ -1,5 +1,5 @@
 export { ResultSummaryWidget } from './resultsummary';
 export { GenericAreaWidget } from './genericarea';
 export { GenericBarWidget } from './genericbar';
-export { JenkinsHeatmapWidget } from './jenkinsheatmap';
+export { FilterHeatmapWidget } from './filterheatmap';
 export { ResultAggregatorWidget } from './resultaggregator';


### PR DESCRIPTION
Adding a new widget for a heatmap that collects runs based off of a filter. Users can specify a list of filters, number of builds, and a group_field to get a heatmap of runs that fit those parameters. Open to suggestions especially on how I implemented the backend. I sort of had to retrieve all of the most recent run results and then manually filter them to make sure they're in the right order and then only return x amount of runs based on what the user passed for builds. Frontend is pretty much the exact same as jenkins-heatmap.