### PR TITLE
Release 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 2.5.1
+=============
+
+* Fix #441 where project id was not being applied to the results
+* Some bug fixes for tokens and projects
+
 Version 2.5.0
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.5.0
+  version: 2.5.1
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.5.0"
+VERSION = "2.5.1"
 REQUIRES = [
     "alembic",
     "celery",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.21.3",


### PR DESCRIPTION
* Fix #441 where project id was not being applied to the results
* Fix an issue where a run ID in a junit XML filename was not used in Ibutsu
* Fix an issue in reports where the report ID went missing
* Some bug fixes for tokens and projects