### PR TITLE
Release 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+Version 2.5.2
+=============
+
+* Fix up the colours of the fonts of various charts/widgets
+* Migrate to use the built-in TreeView component from PatternFly
+* Check if values are None and default to 0 if they are (fix #418)
+* Add the ability to disable SSL verification
+* Fix the download buttons so that they actually download the artifact or report
+* Parameter should be a string, force the value to be a string
+* Expose the Keycloak login environment in App Interface
+
 Version 2.5.1
 =============
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.5.1
+  version: 2.5.2
 servers:
   - url: /api
 tags:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "ibutsu_server"
-VERSION = "2.5.1"
+VERSION = "2.5.2"
 REQUIRES = [
     "alembic",
     "celery",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.21.3",


### PR DESCRIPTION
* Fix up the colours of the fonts of various charts/widgets
* Migrate to use the built-in TreeView component from PatternFly
* Check if values are None and default to 0 if they are (fix #418)
* Add the ability to disable SSL verification
* Fix the download buttons so that they actually download the artifact or report
* Parameter should be a string, force the value to be a string
* Expose the Keycloak login environment in App Interface