### PR TITLE
Fix expiry date validation by updating onChange handler

### DIFF
--- a/frontend/src/components/add-token-modal.js
+++ b/frontend/src/components/add-token-modal.js
@@ -14,15 +14,6 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 
-function getToday() {
-  const now = new Date();
-  return now.toISOString().split('T')[0];
-}
-
-function dateParse(val) {
-  return val && val.split('-').length === 3 && new Date(`${val}T00:00:00`);
-}
-
 export class AddTokenModal extends React.Component {
   static propTypes = {
     onSave: PropTypes.func,
@@ -34,7 +25,7 @@ export class AddTokenModal extends React.Component {
     super(props);
     this.state = {
       name: '',
-      expiryDate: getToday(),
+      expiryDate: '',
       isNameValid: true,
       isExpiryValid: true
     };
@@ -44,7 +35,7 @@ export class AddTokenModal extends React.Component {
     this.setState({name});
   }
 
-  onExpiryDateChange = (expiryStr) => {
+  onExpiryDateChange = (_event, expiryStr) => {
     this.setState({expiryDate: expiryStr});
   }
 
@@ -124,7 +115,6 @@ export class AddTokenModal extends React.Component {
           >
             <DatePicker
               appendTo={() => document.getElementById('add-token-modal')}
-              dateParse={dateParse}
               onChange={this.onExpiryDateChange}
               value={this.state.expiryDate}
               inputProps={{


### PR DESCRIPTION
It seems that the onChange event changed function signature sometime between when I initially implemented it, and now. Fixing that makes all our problems go away, amazing!