### PR TITLE
Set socket timeouts for redis

### DIFF
--- a/backend/ibutsu_server/tasks/__init__.py
+++ b/backend/ibutsu_server/tasks/__init__.py
@@ -80,6 +80,9 @@ def create_celery_app(_app=None):
             "ibutsu_server.tasks.runs",
         ],
     )
+    app.conf.redis_socket_timeout = SOCKET_TIMEOUT
+    app.conf.redis_socket_connect_timeout = SOCKET_CONNECT_TIMEOUT
+    app.conf.redis_retry_on_timeout = True
     app.conf.broker_transport_options = app.conf.result_backend_transport_options = {
         "socket_timeout": SOCKET_TIMEOUT,
         "socket_connect_timeout": SOCKET_CONNECT_TIMEOUT,

--- a/backend/ibutsu_server/tasks/__init__.py
+++ b/backend/ibutsu_server/tasks/__init__.py
@@ -71,6 +71,9 @@ def create_celery_app(_app=None):
     app = Celery(
         "ibutsu_server",
         broker=_app.config.get("CELERY_BROKER_URL"),
+        broker_connection_retry=True,
+        broker_connection_retry_on_startup=True,
+        worker_cancel_long_running_tasks_on_connection_loss=True,
         include=[
             "ibutsu_server.tasks.db",
             "ibutsu_server.tasks.importers",


### PR DESCRIPTION
When disconnected from redis, the worker does not recover and begin consuming tasks again.

https://github.com/celery/celery/issues/8030 suggests adding socket timeout options -- which is what the goal of this PR is.