### PR TITLE
create-admin password AttributeError work-around

### DIFF
--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -238,11 +238,18 @@ class User(Model, ModelMixin):
         return self._password
 
     @password.setter
-    def password_set(self, value):
+    def password_set(self, value: str):
         self._password = bcrypt.generate_password_hash(value).decode("utf8")
 
     def check_password(self, plaintext):
         return bcrypt.check_password_hash(self.password, plaintext)
+
+    def set_password(self, value: str):
+        """
+        The password setter breaks with an AttributeError, so this is a temporary work-around
+        until that can be resolved.
+        """
+        self._password = bcrypt.generate_password_hash(value).decode("utf8")
 
     def to_dict(self, with_projects=False):
         """An overridden method to include projects"""

--- a/backend/ibutsu_server/db/util.py
+++ b/backend/ibutsu_server/db/util.py
@@ -52,15 +52,13 @@ def add_superadmin(
     elif user and not user.is_superadmin:
         user.is_superadmin = True
     else:
-
         user = models.User(
             email=email,
             name=name,
-            password=password,
             is_superadmin=True,
             is_active=True,
         )
-
+        user.set_password(password)
         session.add(user)
 
     session.commit()

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -20,7 +20,7 @@ REQUIRES = [
     "gunicorn",
     "kombu",
     "lxml",
-    "psycopg2",
+    "psycopg2-binary",
     "pymongo",
     "python-jose[cryptography]",
     "python-magic",

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -20,7 +20,7 @@ REQUIRES = [
     "gunicorn",
     "kombu",
     "lxml",
-    "psycopg2-binary",
+    "psycopg2",
     "pymongo",
     "python-jose[cryptography]",
     "python-magic",


### PR DESCRIPTION
Using the current hybrid_property setter, an AttributeError surfaces when using the --create-admin functionality. The current code looks correct when compared against the SQLAlchemy documentation, so I've implemented a light-weight work-around. It involves setting the password without using the hybrid property setter. I suspect a true solution would involve an upgrade of SQLAlchemy, which would be a heavy lift for fixing such simple functionality.