### PR TITLE
Fix: RuntimeError - generator didn't yield

### DIFF
--- a/backend/ibutsu_server/tasks/__init__.py
+++ b/backend/ibutsu_server/tasks/__init__.py
@@ -9,7 +9,6 @@ from flask import current_app
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Report
 from redis import Redis
-from redis.exceptions import LockError
 
 LOCK_EXPIRE = 1
 task = None
@@ -139,14 +138,10 @@ def lock(name, timeout=LOCK_EXPIRE, app=None):
         socket_timeout=SOCKET_TIMEOUT,
         socket_connect_timeout=SOCKET_CONNECT_TIMEOUT,
     )
-    try:
-        # Get a lock so that we don't run this task concurrently
-        logging.info(f"Trying to get a lock for {name}")
-        with redis_client.lock(name, blocking_timeout=timeout):
-            yield
-    except LockError:
-        # If this task is locked, discard it so that it doesn't clog up the system
-        logging.info(f"Task {name} is already locked, discarding")
+    # Get a lock so that we don't run this task concurrently
+    logging.info(f"Trying to get a lock for {name}")
+    with redis_client.lock(name, blocking_timeout=timeout):
+        yield
 
 
 __all__ = ["create_celery_app", "lock", "task"]

--- a/backend/ibutsu_server/tasks/results.py
+++ b/backend/ibutsu_server/tasks/results.py
@@ -1,20 +1,27 @@
+import logging
+
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Result
 from ibutsu_server.db.models import Run
 from ibutsu_server.tasks import lock
 from ibutsu_server.tasks import task
+from redis.exceptions import LockError
 
 
 @task
 def add_result_start_time(run_id):
     """Update all results in a run to add the 'start_time' field to a result"""
-    with lock(f"update-run-lock-{run_id}"):
-        run = Run.query.get(run_id)
-        if not run:
-            return
-        results = Result.query.filter(Result.data["metadata"]["run"] == run_id).all()
-        for result in results:
-            if not result.get("start_time"):
-                result.data["start_time"] = result.get("starttime")
-                session.add(result)
-        session.commit()
+    task_name = f"update-run-lock-{run_id}"
+    try:
+        with lock(task_name):
+            run = Run.query.get(run_id)
+            if not run:
+                return
+            results = Result.query.filter(Result.data["metadata"]["run"] == run_id).all()
+            for result in results:
+                if not result.get("start_time"):
+                    result.data["start_time"] = result.get("starttime")
+                    session.add(result)
+            session.commit()
+    except LockError:
+        logging.warning(f"Task {task_name} is already locked, discarding")

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from datetime import timedelta
 
@@ -7,6 +8,7 @@ from ibutsu_server.db.models import Result
 from ibutsu_server.db.models import Run
 from ibutsu_server.tasks import lock
 from ibutsu_server.tasks import task
+from redis.exceptions import LockError
 
 
 METADATA_TO_COPY = ["jenkins", "tags"]
@@ -37,60 +39,64 @@ def _status_to_summary(status):
 @task(max_retries=1000)
 def update_run(run_id):
     """Update the run summary from the results, this task will retry 1000 times"""
-    with lock(f"update-run-lock-{run_id}"):
-        run = Run.query.get(run_id)
-        if not run:
-            return
+    try:
+        task_name = f"update-run-lock-{run_id}"
+        with lock(task_name):
+            run = Run.query.get(run_id)
+            if not run:
+                return
 
-        # initialize some necessary variables
-        summary = {
-            "errors": 0,
-            "failures": 0,
-            "skips": 0,
-            "tests": 0,
-            "xpasses": 0,
-            "xfailures": 0,
-            "collected": run.summary.get("collected", 0),
-        }
-        run.duration = 0.0
-        metadata = run.data or {}
+            # initialize some necessary variables
+            summary = {
+                "errors": 0,
+                "failures": 0,
+                "skips": 0,
+                "tests": 0,
+                "xpasses": 0,
+                "xfailures": 0,
+                "collected": run.summary.get("collected", 0),
+            }
+            run.duration = 0.0
+            metadata = run.data or {}
 
-        # Fetch all the results for the runs and calculate the summary
-        results = (
-            Result.query.filter(Result.run_id == run_id).order_by(Result.start_time.asc()).all()
-        )
+            # Fetch all the results for the runs and calculate the summary
+            results = (
+                Result.query.filter(Result.run_id == run_id).order_by(Result.start_time.asc()).all()
+            )
 
-        for i, result in enumerate(results):
-            if i == 0:
-                # on the first result, copy over some metadata
-                for column in COLUMNS_TO_COPY:
-                    _copy_column(result, run, column)
+            for i, result in enumerate(results):
+                if i == 0:
+                    # on the first result, copy over some metadata
+                    for column in COLUMNS_TO_COPY:
+                        _copy_column(result, run, column)
 
-                for key in METADATA_TO_COPY:
-                    _copy_result_metadata(result, metadata, key)
+                    for key in METADATA_TO_COPY:
+                        _copy_result_metadata(result, metadata, key)
 
-            key = _status_to_summary(result.result)
-            if key in summary:
-                summary[key] = summary.get(key, 0) + 1
-            # update the number of tests that actually ran
-            summary["tests"] += 1
-            if result.duration:
-                run.duration += result.duration
+                key = _status_to_summary(result.result)
+                if key in summary:
+                    summary[key] = summary.get(key, 0) + 1
+                # update the number of tests that actually ran
+                summary["tests"] += 1
+                if result.duration:
+                    run.duration += result.duration
 
-        # determine the number of passes
-        summary["passes"] = summary["tests"] - (
-            summary["errors"]
-            + summary["xpasses"]
-            + summary["xfailures"]
-            + summary["failures"]
-            + summary["skips"]
-        )
-        # determine the number of tests that didn't run
-        summary["not_run"] = max(summary["collected"] - summary["tests"], 0)
+            # determine the number of passes
+            summary["passes"] = summary["tests"] - (
+                summary["errors"]
+                + summary["xpasses"]
+                + summary["xfailures"]
+                + summary["failures"]
+                + summary["skips"]
+            )
+            # determine the number of tests that didn't run
+            summary["not_run"] = max(summary["collected"] - summary["tests"], 0)
 
-        run.update({"summary": summary, "data": metadata})
-        session.add(run)
-        session.commit()
+            run.update({"summary": summary, "data": metadata})
+            session.add(run)
+            session.commit()
+    except LockError:
+        logging.warning(f"Task {task_name} is already locked, discarding")
 
 
 @task(max_retries=1)


### PR DESCRIPTION
``` 
[2023-07-28 06:32:38,411: INFO/ForkPoolWorker-1] Trying to get a lock for update-run-lock-cae48b31-1129-42c3-b1ad-ca06225ac32d
[2023-07-28 06:32:39,323: INFO/ForkPoolWorker-1] Task update-run-lock-cae48b31-1129-42c3-b1ad-ca06225ac32d is already locked, discarding
[2023-07-28 06:32:39,328: INFO/ForkPoolWorker-1] Task 9e3f4c75-89d8-4224-a24c-f83416bec687 with args ['cae48b31-1129-42c3-b1ad-ca06225ac32d'] is not related to a report
[2023-07-28 06:32:39,328: ERROR/ForkPoolWorker-1] Task ibutsu_server.tasks.runs.update_run[9e3f4c75-89d8-4224-a24c-f83416bec687] raised unexpected: RuntimeError("generator didn't yield")
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 477, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/app/ibutsu_server/tasks/__init__.py", line 35, in __call__
    return super().__call__(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 760, in __protected_call__
    return self.run(*args, **kwargs)
  File "/app/ibutsu_server/tasks/runs.py", line 40, in update_run
    with lock(f"update-run-lock-{run_id}"):
  File "/usr/lib64/python3.9/contextlib.py", line 121, in __enter__
    raise RuntimeError("generator didn't yield") from None
RuntimeError: generator didn't yield
```

So `lock` not yielding anything if a task is locked so the context manager will raise the generator yield error. 

I don't know much about ibutsu codebase so suggestions will be appreciated. 