### PR TITLE
Add missing flask extra

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -6,7 +6,7 @@ VERSION = "2.5.4"
 REQUIRES = [
     "alembic",
     "celery",
-    "connexion",
+    "connexion[flask]",
     "flask_bcrypt",
     "flask_cors",
     "flask_mail",


### PR DESCRIPTION
On creating a new development environment from scratch, the `docker-compose -f docker-compose.dev.yml up`  fails on this dependency missing for the worker:

```
worker_1    | Usage: celery [OPTIONS] COMMAND [ARGS]...
worker_1    | Try 'celery --help' for help.
worker_1    | 
worker_1    | Error: Invalid value for '-A' / '--app': 
worker_1    | Unable to load celery application.
worker_1    | While trying to load the module ibutsu_server.tasks.queues:app the following error occurred:
worker_1    | Traceback (most recent call last):
worker_1    |   File "/mnt/.worker_env/lib/python3.9/site-packages/celery/bin/celery.py", line 58, in convert
worker_1    |     return find_app(value)
worker_1    |   File "/mnt/.worker_env/lib/python3.9/site-packages/celery/app/utils.py", line 383, in find_app
worker_1    |     sym = symbol_by_name(app, imp=imp)
worker_1    |   File "/mnt/.worker_env/lib/python3.9/site-packages/kombu/utils/imports.py", line 59, in symbol_by_name
worker_1    |     module = imp(module_name, package=package, **kwargs)
worker_1    |   File "/mnt/.worker_env/lib/python3.9/site-packages/celery/utils/imports.py", line 109, in import_from_cwd
worker_1    |     return imp(module, package=package)
worker_1    |   File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
worker_1    |     return _bootstrap._gcd_import(name[level:], package, level)
worker_1    |   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
worker_1    |   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
worker_1    |   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
worker_1    |   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
worker_1    |   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
worker_1    |   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
worker_1    |   File "/mnt/ibutsu_server/tasks/queues.py", line 4, in <module>
worker_1    |     app = create_celery_app(get_app())
worker_1    |   File "/mnt/ibutsu_server/__init__.py", line 64, in get_app
worker_1    |     app = App(__name__, specification_dir="./openapi/")
worker_1    |   File "/mnt/.worker_env/lib/python3.9/site-packages/connexion/utils.py", line 284, in _delayed_error
worker_1    |     raise type(exc)(msg).with_traceback(exc.__traceback__)
worker_1    |   File "/mnt/.worker_env/lib/python3.9/site-packages/connexion/__init__.py", line 19, in <module>
worker_1    |     from connexion.apps.flask import FlaskApi, FlaskApp
worker_1    |   File "/mnt/.worker_env/lib/python3.9/site-packages/connexion/apps/flask.py", line 11, in <module>
worker_1    |     from a2wsgi import WSGIMiddleware
worker_1    | ModuleNotFoundError: Please install connexion using the 'flask' extra
```
