### PR TITLE
Fix creation user by admin

### DIFF
--- a/backend/ibutsu_server/controllers/admin/user_controller.py
+++ b/backend/ibutsu_server/controllers/admin/user_controller.py
@@ -66,7 +66,7 @@ def admin_add_user(new_user=None, token_info=None, user=None):
     if not connexion.request.is_json:
         return "Bad request, JSON required", 400
     new_user = User.from_dict(**connexion.request.get_json())
-    user_exists = User.query.filter_by(email=new_user.email)
+    user_exists = User.query.filter_by(email=new_user.email).first()
     if user_exists:
         return f"The user with email {new_user.email} already exists", 400
     session.add(new_user)


### PR DESCRIPTION
I found this small bug when playing with Ibutsu locally and tried to have more users than default admin:

**Bug:**
```
?fix-local-dev-setup ~/Documents/WORK/TOOLS/ibutsu-server> curl http://localhost:8080/api/user -H "Accept: application/json" -H "Authorization: Bearer $IBUTSU_TOK"
{
  "email": "admin@example.com",
  "group_id": null,
  "id": "58180e1a-4cd4-4f18-8d73-295871bae8d6",
  "is_active": true,
  "is_superadmin": true,
  "name": "Administrator"
}
(.iqe-env) ?fix-local-dev-setup ~/Documents/WORK/TOOLS/ibutsu-server> curl -X 'POST' http://localhost:8080/api/admin/user -H "Accept: application/json" -H "Authorization: Bearer $IBUTSU_TOK" -H 'Content-Type: application/json' -d '{"email": "user-example-1@domain.com", "is_active": true, "is_superadmin": false, "name": "User example one"}'
"The user with email user-example-1@domain.com already exists"
```