### PR TITLE
Update OCP mpp backend templates

### DIFF
--- a/ocp-templates/mpp/backend.yaml
+++ b/ocp-templates/mpp/backend.yaml
@@ -94,6 +94,11 @@ objects:
               secretKeyRef:
                 name: keycloak-auth
                 key: name
+          - name: JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: jwt-secret
+                key: value
           - name: USER_LOGIN_ENABLED
             value: ${USER_LOGIN_ENABLED}
           imagePullPolicy: Always

--- a/ocp-templates/mpp/backend.yaml
+++ b/ocp-templates/mpp/backend.yaml
@@ -66,9 +66,9 @@ objects:
           - name: CELERY_RESULT_BACKEND
             value: redis://:${REDIS_PASSWORD}@redis.${NAMESPACE}.svc
           - name: FRONTEND_URL
-            value: ${FRONTEND_ROUTE}
+            value: https://${FRONTEND_ROUTE}
           - name: BACKEND_URL
-            value: ${BACKEND_ROUTE}
+            value: https://${BACKEND_ROUTE}
           - name: KEYCLOAK_BASE_URL
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
- we need to add https:// protocol to the FRONTEND_URL/BACKEND_URL values, otherwise the SSO auth will be failing with an invalid redirect-uri error
- JWT secret + var must be used in the backend pod, without it we get error `ibutsu_server.errors.IbutsuError: JWT_SECRET is not defined in configuration or an environment variable`