### PR TITLE
Add resolution to victory core package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,12 @@
     "typescript": "^4.9.5",
     "wolfy87-eventemitter": "^5.2.9"
   },
+  "resolutions": {
+    "victory-core": "<36.9.0"
+  },
+  "overrides": {
+    "victory-core": "<36.9.0"
+  },
   "scripts": {
     "start": "serve -s build -l tcp://0.0.0.0:8080",
     "build": "./bin/write-version-file.js && react-scripts build",


### PR DESCRIPTION
Resolves react-chart dependency issue. For more info see https://github.com/patternfly/patternfly-react/issues/10064

Note that PR has both `resolutions` (for yarn) and `overrides` (for npm). We might need to take a look later how to deal with it and use only one package manager because our tests use yarn and I see yarn is mentioned in the doc but npm is used in Dockerfile to build FE