### PR TITLE
increase requests/limits for postgresql pod

### DIFF
--- a/ocp-templates/mpp/backend.yaml
+++ b/ocp-templates/mpp/backend.yaml
@@ -127,7 +127,13 @@ objects:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-          resources: {}
+          resources:
+            limits:
+              cpu: '1'
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         dnsPolicy: ClusterFirst

--- a/ocp-templates/mpp/postgres.yaml
+++ b/ocp-templates/mpp/postgres.yaml
@@ -69,7 +69,11 @@ objects:
             timeoutSeconds: 10
           resources:
             limits:
-              memory: 512Mi
+              memory: 6Gi
+              cpu: '1'
+            requests:
+              memory: 4Gi
+              cpu: '1'
           securityContext:
             capabilities: {}
             privileged: false


### PR DESCRIPTION
With defaults, pg_restore connection was closed when restoring from backup file:
```
2024-02-19 11:53:43.374 UTC [1] LOG:  server process (PID 2321) was terminated by signal 9: Killed

2024-02-19 11:53:43.374 UTC [1] DETAIL:  Failed process was running: COPY public.import_files (id, content, import_id) FROM stdin;
```