### PR TITLE
Control sensitive fields better

### DIFF
--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -81,7 +81,10 @@ def string_to_column(field, model):
         if field not in ARRAY_FIELDS and field not in NUMERIC_FIELDS:
             column = column.as_string()
     else:
-        column = getattr(model, field)
+        try:
+            column = getattr(model, field)
+        except AttributeError:
+            return None
     return column
 
 

--- a/backend/ibutsu_server/widgets/filter_heatmap.py
+++ b/backend/ibutsu_server/widgets/filter_heatmap.py
@@ -43,6 +43,8 @@ def _get_heatmap(filters, builds, group_field, project=None):
 
     # generate the group_field
     group_field = string_to_column(group_field, Run)
+    if not group_field:
+        return {}
 
     # get the runs on which to run the aggregation, we select from a subset of runs to improve
     # performance, otherwise we'd be aggregating over ALL runs

--- a/backend/ibutsu_server/widgets/jenkins_heatmap.py
+++ b/backend/ibutsu_server/widgets/jenkins_heatmap.py
@@ -101,6 +101,9 @@ def _get_heatmap(job_name, builds, group_field, count_skips, project=None, addit
 
     # generate the group_fields
     group_field = string_to_column(group_field, Run)
+    if not group_field:
+        return {}, builds
+
     job_name = string_to_column("metadata.jenkins.job_name", Run)
     build_number = string_to_column("metadata.jenkins.build_number", Run)
     annotations = string_to_column("metadata.annotations", Run)

--- a/backend/ibutsu_server/widgets/result_aggregator.py
+++ b/backend/ibutsu_server/widgets/result_aggregator.py
@@ -36,6 +36,8 @@ def _get_recent_result_data(group_field, days, project=None, run_id=None, additi
 
     # generate the group field
     group_field = string_to_column(group_field, Result)
+    if not group_field:
+        return []
 
     # create the query
     query = (

--- a/backend/ibutsu_server/widgets/run_aggregator.py
+++ b/backend/ibutsu_server/widgets/run_aggregator.py
@@ -26,6 +26,8 @@ def _get_recent_run_data(weeks, group_field, project=None, additional_filters=No
 
     # generate the group field
     group_field = string_to_column(group_field, Run)
+    if not group_field:
+        return data
 
     # create the query
     query = session.query(


### PR DESCRIPTION
This is going to help us avoid backend failures with 500 as we didn't check what user put into some fields and python had issues with it. Example, when user put into `group field` incorrect value `"component=foo"`, as the result backend fails as Run object doesn't have this attribute:

```
  File "/app/ibutsu_server/filters.py", line 84, in string_to_column
    column = getattr(model, field)
AttributeError: type object 'Run' has no attribute 'component=foo'
```

If there are some issues to find a column - we return None from `string_to_column` helper function. Then widgets that have this field mandatory will return empty data