### PR TITLE
Fix report deletion through API

### DIFF
--- a/backend/ibutsu_server/controllers/report_controller.py
+++ b/backend/ibutsu_server/controllers/report_controller.py
@@ -113,7 +113,7 @@ def get_report_list(page=1, page_size=25, project=None, token_info=None, user=No
 
 
 @validate_uuid
-def delete_report(id_):
+def delete_report(id_, user=None, token_info=None):
     """Deletes a report
 
     :param id: ID of the report to delete
@@ -121,13 +121,16 @@ def delete_report(id_):
 
     :rtype: tuple
     """
-    try:
-        report = Report.query.get(id_)
-        session.delete(report)
-        session.commit()
-        return "OK", 200
-    except Exception:
+    report = Report.query.get(id_)
+    if not report:
         return "Not Found", 404
+
+    report_file = ReportFile.query.filter(ReportFile.report_id == report.id).first()
+    session.delete(report_file)
+
+    session.delete(report)
+    session.commit()
+    return "OK", 200
 
 
 @validate_uuid


### PR DESCRIPTION
Delete report through API doesn't work. Also before deleting report itself we need to delete ReportFile otherwise DB is going to complain.
Delete report issue I observe:
```
[2024-04-08 12:52:46,979] ERROR in app: Exception on /api/report/4170cf45-9d0e-4da8-8d10-464ffcc29386 [DELETE]
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 2529, in wsgi_app
response = self.full_dispatch_request()
File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1825, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/usr/local/lib/python3.9/site-packages/flask_cors/extension.py", line 176, in wrapped_function
return cors_after_request(app.make_response(f(*args, **kwargs)))
File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1823, in full_dispatch_request
rv = self.dispatch_request()
File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1799, in dispatch_request
return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
File "/usr/local/lib/python3.9/site-packages/connexion/decorators/decorator.py", line 68, in wrapper
response = function(request)
File "/usr/local/lib/python3.9/site-packages/connexion/security/security_handler_factory.py", line 388, in wrapper
return function(request)
File "/usr/local/lib/python3.9/site-packages/connexion/decorators/uri_parsing.py", line 149, in wrapper
response = function(request)
File "/usr/local/lib/python3.9/site-packages/connexion/decorators/validation.py", line 399, in wrapper
return function(request)
File "/usr/local/lib/python3.9/site-packages/connexion/decorators/parameter.py", line 120, in wrapper
return function(**kwargs)
File "/app/ibutsu_server/util/uuid.py", line 28, in validate
return function(**kwargs)
TypeError: delete_report() got an unexpected keyword argument 'user'
```

Tested locally, works as expected