### PR TITLE
Update from localhost to 127.0.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,11 @@
 repos:
-- repo: https://github.com/asottile/reorder_python_imports
-  rev: v3.9.0
-  hooks:
-  - id: reorder-python-imports
 - repo: https://github.com/ambv/black
-  rev: 22.10.0
+  rev: 24.4.2
   hooks:
   - id: black
     args: [--safe, --quiet, --line-length, "100"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -17,16 +13,16 @@ repos:
     args: [ --allow-multiple-documents ]
   - id: debug-statements
 - repo: https://github.com/pycqa/flake8
-  rev: 6.1.0
+  rev: 7.0.0
   hooks:
   - id: flake8
     args: [--max-line-length, "100", --ignore, "E203, W503"]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.2
+  rev: v3.15.2
   hooks:
   - id: pyupgrade
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v8.27.0
+  rev: v9.3.0
   hooks:
   - id: eslint
     additional_dependencies:

--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -1,3 +1,5 @@
+LOCALHOST = "127.0.0.1"
+
 OAUTH_CONFIG = {
     "google": {
         "scope": ["https://www.googleapis.com/auth/userinfo.profile"],

--- a/backend/ibutsu_server/controllers/health_controller.py
+++ b/backend/ibutsu_server/controllers/health_controller.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     IS_CONNECTED = False
 
+from ibutsu_server.constants import LOCALHOST
+
 
 def get_health(token_info=None, user=None):
     """Get a health report
@@ -46,7 +48,7 @@ def get_health_info(token_info=None, user=None):
     :rtype: HealthInfo
     """
     return {
-        "frontend": current_app.config.get("FRONTEND_URL", "http://localhost:3000"),
-        "backend": current_app.config.get("BACKEND_URL", "http://localhost:8080"),
-        "api_ui": current_app.config.get("BACKEND_URL", "http://localhost:8080") + "/api/ui/",
+        "frontend": current_app.config.get("FRONTEND_URL", f"http://{LOCALHOST}:3000"),
+        "backend": current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080"),
+        "api_ui": current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080") + "/api/ui/",
     }

--- a/backend/ibutsu_server/controllers/login_controller.py
+++ b/backend/ibutsu_server/controllers/login_controller.py
@@ -10,6 +10,7 @@ from flask import make_response
 from flask import redirect
 from google.auth.transport.requests import Request
 from google.oauth2 import id_token
+from ibutsu_server.constants import LOCALHOST
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Token
 from ibutsu_server.db.models import User
@@ -170,7 +171,7 @@ def auth(provider):
         return "Bad request", 400
     code = connexion.request.args["code"]
     frontend_url = build_url(
-        current_app.config.get("FRONTEND_URL", "http://localhost:3000"), "login"
+        current_app.config.get("FRONTEND_URL", f"http://{LOCALHOST}:3000"), "login"
     )
     provider_config = _get_provider_config(provider)
     user = _get_user_from_provider(provider, provider_config, code)
@@ -222,7 +223,7 @@ def register(email=None, password=None):
 
     # Send an activation e-mail
     activation_url = build_url(
-        current_app.config.get("BACKEND_URL", "http://localhost:8080/"),
+        current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080"),
         "api",
         "login",
         "activate",
@@ -292,7 +293,9 @@ def activate(activation_code=None):
     if result := validate_activation_code(activation_code):
         return result
     user = User.query.filter(User.activation_code == activation_code).first()
-    login_url = build_url(current_app.config.get("FRONTEND_URL", "http://localhost:3000"), "login")
+    login_url = build_url(
+        current_app.config.get("FRONTEND_URL", f"http://{LOCALHOST}:3000"), "login"
+    )
     if user:
         user.is_active = True
         user.activation_code = None

--- a/backend/ibutsu_server/db/util.py
+++ b/backend/ibutsu_server/db/util.py
@@ -1,6 +1,7 @@
 """
 Various utility DB functions
 """
+
 from typing import Optional
 
 from ibutsu_server.db import models

--- a/backend/ibutsu_server/models/base_model_.py
+++ b/backend/ibutsu_server/models/base_model_.py
@@ -38,9 +38,9 @@ class Model:
             elif isinstance(value, dict):
                 result[attr] = dict(
                     map(
-                        lambda item: (item[0], item[1].to_dict())
-                        if hasattr(item[1], "to_dict")
-                        else item,
+                        lambda item: (
+                            (item[0], item[1].to_dict()) if hasattr(item[1], "to_dict") else item
+                        ),
                         value.items(),
                     )
                 )

--- a/backend/ibutsu_server/tasks/db.py
+++ b/backend/ibutsu_server/tasks/db.py
@@ -1,4 +1,5 @@
 """ Tasks for DB related things"""
+
 from datetime import datetime
 from datetime import timedelta
 

--- a/backend/ibutsu_server/tasks/reports.py
+++ b/backend/ibutsu_server/tasks/reports.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from io import StringIO
 
 from flask import current_app
+from ibutsu_server.constants import LOCALHOST
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Report
 from ibutsu_server.db.models import ReportFile
@@ -67,17 +68,17 @@ def _update_report(report):
             "filename": report_filename,
             "mimetype": REPORTS[report_type]["mimetype"],
             "url": "{}/api/report/{}/download/{}".format(
-                current_app.config.get("BACKEND_URL", "http://localhost:8080"),
+                current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080"),
                 report["id"],
                 report_filename,
             ),
             "download_url": "{}/api/report/{}/download/{}".format(
-                current_app.config.get("BACKEND_URL", "http://localhost:8080"),
+                current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080"),
                 report["id"],
                 report_filename,
             ),
             "view_url": "{}/api/report/{}/view/{}".format(
-                current_app.config.get("BACKEND_URL", "http://localhost:8080"),
+                current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080"),
                 report["id"],
                 report_filename,
             ),
@@ -213,7 +214,8 @@ def _get_files(result):
         {
             "filename": report_file.filename,
             "url": "{}/api/artifact/{}/download".format(
-                current_app.config.get("BACKEND_URL", "http://localhost:8080"), str(report_file.id)
+                current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080"),
+                str(report_file.id),
             ),
         }
         for report_file in ReportFile.query.filter(

--- a/backend/ibutsu_server/test/test_login_controller.py
+++ b/backend/ibutsu_server/test/test_login_controller.py
@@ -4,6 +4,7 @@ from flask import json
 from ibutsu_server.test import BaseTestCase
 from ibutsu_server.test import MockUser
 from ibutsu_server.util.jwt import generate_token
+from ibutsu_server.constants import LOCALHOST
 
 MOCK_ID = "6f7c2d52-54dc-4309-8e2e-c74515d39455"
 MOCK_EMAIL = "test@example.com"
@@ -132,7 +133,7 @@ class TestLoginController(BaseTestCase):
         expected_response = {
             "authorization_url": "https://gitlab.com/oauth/authorize",
             "client_id": "dfgfdgh4563453456dsfgdsfg456",
-            "redirect_uri": "http://localhost:8080/api/login/auth/gitlab",
+            "redirect_uri": f"http://{LOCALHOST}:8080/api/login/auth/gitlab",
             "scope": "read_user",
         }
         headers = {"Accept": "application/json", "Content-Type": "application/json"}

--- a/backend/ibutsu_server/util/count.py
+++ b/backend/ibutsu_server/util/count.py
@@ -1,4 +1,5 @@
 """ Utility functions for counting rows in large tables"""
+
 from contextlib import contextmanager
 
 from ibutsu_server.constants import COUNT_ESTIMATE_LIMIT

--- a/backend/ibutsu_server/util/keycloak.py
+++ b/backend/ibutsu_server/util/keycloak.py
@@ -1,5 +1,6 @@
 import requests
 from flask import current_app
+from ibutsu_server.constants import LOCALHOST
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import User
 from ibutsu_server.util.urls import build_url
@@ -11,7 +12,7 @@ def get_keycloak_config(is_private=False):
         "KEYCLOAK_BASE_URL"
     ):
         return {}
-    backend_url = current_app.config.get("BACKEND_URL", "http://localhost:8080/api")
+    backend_url = current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080/api")
     if not backend_url.endswith("/api"):
         backend_url += "/api"
     server_url = current_app.config["KEYCLOAK_BASE_URL"]

--- a/backend/ibutsu_server/util/oauth.py
+++ b/backend/ibutsu_server/util/oauth.py
@@ -1,5 +1,6 @@
 import requests
 from flask import current_app
+from ibutsu_server.constants import LOCALHOST
 from ibutsu_server.constants import OAUTH_CONFIG
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import User
@@ -8,7 +9,7 @@ from ibutsu_server.util.urls import build_url
 
 def get_provider_config(provider, is_private=False):
     """Return the customised config for a provider"""
-    backend_url = current_app.config.get("BACKEND_URL", "http://localhost:8080/api")
+    backend_url = current_app.config.get("BACKEND_URL", f"http://{LOCALHOST}:8080/api")
     provider_upper = provider.upper()
     server_url = current_app.config.get(f"{provider_upper}_BASE_URL")
     provider_config = OAUTH_CONFIG.get(provider, {})

--- a/backend/ibutsu_server/util/query.py
+++ b/backend/ibutsu_server/util/query.py
@@ -1,4 +1,5 @@
 """ Query utilities"""
+
 import re
 
 from ibutsu_server.constants import MAX_PAGE_SIZE

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 """This file provides an entry point for the Docker container"""
+
 from ibutsu_server import get_app
 
 app = get_app()

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,4 +1,5 @@
 """This file provides an entry point for the OpenShift container"""
+
 from ibutsu_server import get_app
 
 application = get_app()

--- a/frontend/public/settings.js
+++ b/frontend/public/settings.js
@@ -1,6 +1,6 @@
 // Public settings for the application. If running in a container, this file will be overwritten
 // at container runtime with ENV variables.
 window.settings = {
-  serverUrl: 'http://localhost:8080/api',
+  serverUrl: 'http://127.0.0.1:8080/api',
   environment: 'development'
 }

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -155,7 +155,7 @@ podman run -d \
                      python -m ibutsu_server --host 0.0.0.0' > /dev/null
 echo "done."
 echo -n "Waiting for backend to respond..."
-until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do
+until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:8080); do
   echo -n '.'
   sleep 5
 done
@@ -193,7 +193,7 @@ podman run -d \
        /bin/bash -c 'npm install && CI=1 npm run devserver' > /dev/null
 echo "done."
 echo -n "Waiting for frontend to respond..."
-until $(curl --output /dev/null --silent --head --fail http://localhost:3000); do
+until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:3000); do
   printf '.'
   sleep 5
 done
@@ -201,8 +201,8 @@ echo "done."
 
 if [[ $CREATE_PROJECT = true ]]; then
     echo -n "Creating default project..."
-    LOGIN_TOKEN=`curl --no-progress-meter --header "Content-Type: application/json" --request POST --data '{"email": "admin@example.com", "password": "admin12345"}' http://localhost:8080/api/login | grep 'token' | cut -d\" -f 4`
-    PROJECT_ID=`curl --no-progress-meter --header "Content-Type: application/json" --header "Authorization: Bearer ${LOGIN_TOKEN}" --request POST --data '{"name": "my-project", "title": "My Project"}' http://localhost:8080/api/project | grep '"id"' | cut -d\" -f 4`
+    LOGIN_TOKEN=`curl --no-progress-meter --header "Content-Type: application/json" --request POST --data '{"email": "admin@example.com", "password": "admin12345"}' http://127.0.0.1:8080/api/login | grep 'token' | cut -d\" -f 4`
+    PROJECT_ID=`curl --no-progress-meter --header "Content-Type: application/json" --header "Authorization: Bearer ${LOGIN_TOKEN}" --request POST --data '{"name": "my-project", "title": "My Project"}' http://127.0.0.1:8080/api/project | grep '"id"' | cut -d\" -f 4`
     echo "done."
 fi
 echo ""


### PR DESCRIPTION
Having issues in podman 5 with pasta networking defaults, using localhost to resolve other containers in the pod.

Hit this moving to podman 5 with Fedora 40. I'm actually using podman without docker, and have even added a podman.sock alias trying to resolve this.

I don't think changing to 127.0.0.1 in these places is detrimental, where using localhost will be dependent on the podman version, and whether rootful network is being used. 

This manifests in three places:

### backend 

Define constant and import it for references to `localhost`, changing them to 127.0.0.1. These are only used as a default, and won't be relevant in production.


### frontend

An error will occur in login.json and no login options will render - similar to the issue reported for SSO integration when CA certs are not setup for the client.  There is a close connection here to the behavior of the login script that needs specific attention, but that should be in a separate PR. This only addresses the default serverUrl in local environments.

Again this should not impact production, where serverUrl is set. 
``` 
componentDidMount() {
    HttpClient.get([Settings.serverUrl, 'login', 'support'])
    
 ```
 
 
 ### Scripts

Scripts for local development pod env deployment also reference localhost, so I have updated references here too. These again do not impact production deployment to openshift. 