### PR TITLE
"Fix" invisible projects

### DIFF
--- a/frontend/src/components/ibutsu-header.js
+++ b/frontend/src/components/ibutsu-header.js
@@ -90,7 +90,7 @@ export class IbutsuHeader extends React.Component {
   }
 
   getProjects() {
-    const params = {pageSize: 10};
+    const params = {pageSize: 20};  // TODO this isn't a problem, until it is
     if (this.state.filterValue) {
       params['filter'] = ['title%' + this.state.filterValue];
     }


### PR DESCRIPTION
The pagination for project fetch for the header is hardcoded to 10 and doesn't iterate over pages.

This also indicates an issue with the controller implementation, because when filtering you still have invisble projects, because it will apply title filters *after* the page limit is applied.

Confirmed with admin/non-admin setting on an account. Without admin, the user did not have all 10+ projects that exist in RH production instance now, and could see the previously invisible project.

This was triggered by having more than 10 projects in production instance.