### PR TITLE
Rename master branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Ibutsu Server
-![tests](https://github.com/ibutsu/ibutsu-server/actions/workflows/tests.yaml/badge.svg?branch=master)
+![tests](https://github.com/ibutsu/ibutsu-server/actions/workflows/tests.yaml/badge.svg?branch=main)
 [![Documentation Status](https://readthedocs.org/projects/ibutsu/badge/?version=latest)](https://docs.ibutsu-project.org/en/latest/?badge=latest)
 
 Ibutsu is a test result reporting and artifact storage system. Ibutsu gives your team the ability to

--- a/docs/source/examples/okd-template.rst
+++ b/docs/source/examples/okd-template.rst
@@ -993,8 +993,8 @@ OKD/OpenShift Template
     value: https://github.com/ibutsu/ibutsu-server.git
   - name: IBUTSU_REPO_BRANCH
     displayName: Ibutsu Repository Branch
-    description: The branch to pull the code from (defaults to master)
-    value: master
+    description: The branch to pull the code from (defaults to main)
+    value: main
   - name: APP_NAME
     displayName: App Name
     description: The name of the application

--- a/docs/source/user-guide/filter-help.rst
+++ b/docs/source/user-guide/filter-help.rst
@@ -86,5 +86,5 @@ of these filters include:
 * ``metadata.tags=platform-experience,source=local,summary.passes>10``
 * ``metadata.assignee=jdoe,metadata.exception_name=AssertionError,result=failed``
 
-.. _filters.py: https://github.com/ibutsu/ibutsu-server/blob/master/backend/ibutsu_server/filters.py
-.. _Runs/Results: https://github.com/ibutsu/ibutsu-server/blob/master/backend/ibutsu_server/db/models.py
+.. _filters.py: https://github.com/ibutsu/ibutsu-server/blob/main/backend/ibutsu_server/filters.py
+.. _Runs/Results: https://github.com/ibutsu/ibutsu-server/blob/main/backend/ibutsu_server/db/models.py

--- a/ocp-templates/README.md
+++ b/ocp-templates/README.md
@@ -10,7 +10,7 @@ The supported template set is ``mpp``, it has been updated to support Deployment
 
 ## Stage
 The stage templates are set up to use the images at [quay.io/organization/ibutsu](https://quay.io/organization/ibutsu) that are tagged with
-``master``. These images are built and tagged as ``master`` on every merge into [github.com/ibutsu/ibutsu-server](https://github.com/ibutsu/ibutsu-server).
+``main``. These images are built and tagged as ``main`` on every merge into [github.com/ibutsu/ibutsu-server](https://github.com/ibutsu/ibutsu-server).
 These are meant to deploy the "staging" or "unstable" instance of Ibutsu.
 
 ## Prod

--- a/ocp-templates/prod/flower.yaml
+++ b/ocp-templates/prod/flower.yaml
@@ -150,5 +150,5 @@ parameters:
   value: https://github.com/ibutsu/ibutsu-server.git
 - name: IBUTSU_REPO_BRANCH
   displayName: Ibutsu Repository Branch
-  description: The branch to pull the code from (defaults to master)
-  value: master
+  description: The branch to pull the code from (defaults to main)
+  value: main

--- a/ocp-templates/stage/backend.yaml
+++ b/ocp-templates/stage/backend.yaml
@@ -126,7 +126,7 @@ objects:
         - ibutsu-backend
         from:
           kind: ImageStreamTag
-          name: backend:master
+          name: backend:main
           namespace: ${NAMESPACE}
       type: ImageChange
     - type: ConfigChange
@@ -144,11 +144,11 @@ objects:
     - annotations: null
       from:
         kind: DockerImage
-        name: quay.io/ibutsu/backend:master
+        name: quay.io/ibutsu/backend:main
       generation: 3
       importPolicy:
         scheduled: true
-      name: master
+      name: main
       referencePolicy:
         type: Source
 # -----------------------------------------------

--- a/ocp-templates/stage/flower.yaml
+++ b/ocp-templates/stage/flower.yaml
@@ -150,5 +150,5 @@ parameters:
   value: https://github.com/ibutsu/ibutsu-server.git
 - name: IBUTSU_REPO_BRANCH
   displayName: Ibutsu Repository Branch
-  description: The branch to pull the code from (defaults to master)
-  value: master
+  description: The branch to pull the code from (defaults to main)
+  value: main

--- a/ocp-templates/stage/frontend.yaml
+++ b/ocp-templates/stage/frontend.yaml
@@ -70,7 +70,7 @@ objects:
         - ibutsu-frontend
         from:
           kind: ImageStreamTag
-          name: frontend:master
+          name: frontend:main
           namespace: ${NAMESPACE}
       type: ImageChange
     - type: ConfigChange
@@ -88,11 +88,11 @@ objects:
     - annotations: null
       from:
         kind: DockerImage
-        name: quay.io/ibutsu/frontend:master
+        name: quay.io/ibutsu/frontend:main
       generation: 3
       importPolicy:
         scheduled: true
-      name: master
+      name: main
       referencePolicy:
         type: Source
 # -----------------------------------------------

--- a/ocp-templates/stage/scheduler.yaml
+++ b/ocp-templates/stage/scheduler.yaml
@@ -75,7 +75,7 @@ objects:
         - ibutsu-scheduler
         from:
           kind: ImageStreamTag
-          name: scheduler:master
+          name: scheduler:main
           namespace: ${NAMESPACE}
       type: ImageChange
     - type: ConfigChange
@@ -93,11 +93,11 @@ objects:
     - annotations: null
       from:
         kind: DockerImage
-        name: quay.io/ibutsu/scheduler:master
+        name: quay.io/ibutsu/scheduler:main
       generation: 3
       importPolicy:
         scheduled: true
-      name: master
+      name: main
       referencePolicy:
         type: Source
 # -----------------------------------------------

--- a/ocp-templates/stage/worker.yaml
+++ b/ocp-templates/stage/worker.yaml
@@ -77,7 +77,7 @@ objects:
         - ibutsu-worker
         from:
           kind: ImageStreamTag
-          name: worker:master
+          name: worker:main
           namespace: ${NAMESPACE}
       type: ImageChange
     - type: ConfigChange
@@ -95,11 +95,11 @@ objects:
     - annotations: null
       from:
         kind: DockerImage
-        name: quay.io/ibutsu/worker:master
+        name: quay.io/ibutsu/worker:main
       generation: 3
       importPolicy:
         scheduled: true
-      name: master
+      name: main
       referencePolicy:
         type: Source
 # -----------------------------------------------

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -111,7 +111,7 @@ if [[ "$CAN_COMMIT" = true ]]; then
     if [[ "$CAN_PUSH" = true ]]; then
         echo -n "Pushing up to origin/$BRANCH_NAME..."
         git push -q origin $BRANCH_NAME
-        git checkout master
+        git checkout main
         if [[ "$CAN_DELETE" = true ]]; then
             git branch -D $BRANCH_NAME
             echo "Deleted branch $BRANCH_NAME"


### PR DESCRIPTION
Update references to account for the GitHub renaming of `master` branch to `main`.

The open PRs were updated automatically by GitHub, but any local environments will need to be handled by the owner.