### PR TITLE
Fix dashboard clearing on project change

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -3,7 +3,7 @@ import React from 'react';
 import EventEmitter from 'wolfy87-eventemitter';
 import ElementWrapper from './components/elementWrapper';
 
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { Dashboard } from './dashboard';
 import { ReportBuilder } from './report-builder';
@@ -85,8 +85,8 @@ export class App extends React.Component {
             path="view/:view_id"
             element={<ElementWrapper routeElement={View} />}
           />
+        <Route path="*" element={<Navigate to="dashboard" replace />} />
         </Route>
-
       </Routes>
     );
   }

--- a/frontend/src/components/ibutsu-header.js
+++ b/frontend/src/components/ibutsu-header.js
@@ -237,7 +237,9 @@ export class IbutsuHeader extends React.Component {
       filterValue: ''
     });
     // Consider whether the location should be changed within the emit hooks?
-    this.props.navigate('/project/' + value?.id + '/dashboard/' + value?.default_dashboard_id);
+    let dash_path = "";
+    if (value?.default_dashboard_id != null) {dash_path = '/dashboard/' + value?.default_dashboard_id}
+    this.props.navigate('/project/' + value?.id + dash_path);
 
     // useEffect with dependency on functional component to remove passing value, handlers don't see updated context
     this.emitProjectChange(value);

--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -79,9 +79,13 @@ export class Dashboard extends React.Component {
 
   sync_context = () => {
     // Active dashboard
-    const { activeDashboard } = this.context;
+    const { activeDashboard, setActiveDashboard } = this.context;
     const { selectedDashboard } = this.state;
     const paramDash = this.props.params?.dashboard_id;
+    if (!paramDash) {
+      // No dashboard in the URL, clear context
+      setActiveDashboard();
+    }
     let updatedDash = undefined;
     // API call to update context
     if ( paramDash != null && activeDashboard?.id !== paramDash) {


### PR DESCRIPTION
The dashboard widgets weren't clearing on project change because the context still held the dashboard from the previous project.