### PR TITLE
Enable project routing in widgets URLs

### DIFF
--- a/frontend/src/widgets/filterheatmap.js
+++ b/frontend/src/widgets/filterheatmap.js
@@ -52,6 +52,7 @@ export class FilterHeatmapWidget extends React.Component {
       analysisViewId: null,
       countSkips: 'No',
     };
+    this.renderCell = this.renderCell.bind(this);
   }
 
   getJenkinsAnalysisViewId() {
@@ -175,10 +176,10 @@ export class FilterHeatmapWidget extends React.Component {
             title += item.name + ": " + item.value + "\n";
           }
         });
-        contents = <p title={title}><Link to={`/runs/${value[1]}`}>{Math.floor(value[0])}</Link></p>;
+        contents = <p title={title}><Link to={'/project/' + this.props.params.project + `/runs/${value[1]}`}>{Math.floor(value[0])}</Link></p>;
       }
       else {
-        contents = <Link to={`/runs/${value[1]}`}>{Math.floor(value[0])}</Link>;
+        contents = <Link to={'/project/' + this.props.params.project + `/runs/${value[1]}`}>{Math.floor(value[0])}</Link>;
       }
     }
     return <div style={style}>{contents}</div>;
@@ -221,7 +222,7 @@ export class FilterHeatmapWidget extends React.Component {
       data.push(values);
       values.forEach((item) => {
         if (!!item && (item.length > 2) && !!item[3]) {
-          newLabels.push(<Link to={`/results?metadata.jenkins.build_number[eq]=${item[3]}&metadata.jenkins.job_name[eq]=` + this.params['job_name']} key={item[3]}>{item[3]}</Link>);
+          newLabels.push(<Link to={'/project/' + (this.props.params.project) +`/results?metadata.jenkins.build_number[eq]=${item[3]}&metadata.jenkins.job_name[eq]=` + this.params['job_name']} key={item[3]}>{item[3]}</Link>);
         }
       });
       if (newLabels.length > labels.length) {

--- a/frontend/src/widgets/importancecomponent.js
+++ b/frontend/src/widgets/importancecomponent.js
@@ -104,7 +104,7 @@ export class ImportanceComponentWidget extends React.Component {
                   <Tr key={importance}>
                     <Td>{importance}</Td>
                     {tdat.bnums.map((buildnum) => (
-                      <Td key={buildnum}><Link to={`/results?id[in]=${tdat.data[buildnum][importance]["result_list"].join(";")}`}>{this.toPercent(tdat.data[buildnum][importance]["percentage"])}</Link></Td>
+                      <Td key={buildnum}><Link to={'/project/' + this.props.params.project + `/results?id[in]=${tdat.data[buildnum][importance]["result_list"].join(";")}`}>{this.toPercent(tdat.data[buildnum][importance]["percentage"])}</Link></Td>
                     ))}
                   </Tr>
                   ))}


### PR DESCRIPTION
Widgets that filter results and runs create URLs that belong to projects, this PR enables the project routing on mentioned widgets