### PR TITLE
Add count_skips field to Importance by Component widget

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -273,6 +273,13 @@ WIDGET_TYPES = {
                 "default": 5,
                 "required": False,
             },
+            {
+                "name": "count_skips",
+                "description": "Count skips against the pass rate.",
+                "type": "boolean",
+                "required": False,
+                "default": False,
+            },
         ],
         "type": "widget",
     },

--- a/backend/ibutsu_server/widgets/importance_component.py
+++ b/backend/ibutsu_server/widgets/importance_component.py
@@ -11,6 +11,7 @@ def get_importance_component(
     builds=5,
     components="",
     project=None,
+    count_skips=False,
 ):
     # taken from get_jenkins_line_chart in jenkins_job_analysis.py
     run_limit = int((JJV_RUN_LIMIT / BARCHART_MAX_BUILDS) * builds)
@@ -91,7 +92,7 @@ def get_importance_component(
                     sdatdict[component][bnum][importance] = []
 
     # this is to change result values into numbers
-    # TODO: This doesn't handle xpassed, xfailed, skipped, etc. so figure that out
+    # TODO: This now handles skipped, but not xpassed or xfailed.
     for component in sdatdict.keys():
         for bnum in sdatdict[component].keys():
             for importance in sdatdict[component][bnum].keys():
@@ -99,7 +100,8 @@ def get_importance_component(
                 passed = 0
                 res_list = []
                 for item in sdatdict[component][bnum][importance]:
-                    total += 1
+                    if count_skips or (not item["result"] == "skipped"):
+                        total += 1
                     res_list.append(item["result_id"])
                     if item["result"] == "passed":
                         passed += 1

--- a/frontend/src/widgets/importancecomponent.js
+++ b/frontend/src/widgets/importancecomponent.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   Card,
   CardBody,
+  CardFooter,
   Text
 } from '@patternfly/react-core';
 
@@ -20,7 +21,7 @@ import { Link } from 'react-router-dom';
 
 import { HttpClient } from '../services/http';
 import { Settings } from '../settings';
-import { WidgetHeader } from '../components/widget-components';
+import { ParamDropdown, WidgetHeader } from '../components/widget-components';
 
 export class ImportanceComponentWidget extends React.Component {
   static propTypes = {
@@ -39,6 +40,7 @@ export class ImportanceComponentWidget extends React.Component {
         table_data: []
       },
       isLoading: true,
+      countSkips: 'No',
     };
   }
 
@@ -68,6 +70,13 @@ export class ImportanceComponentWidget extends React.Component {
       this.params = this.props.params;
       this.getData();
     }
+  }
+
+  onSkipSelect = (value) => {
+    this.setState({countSkips: value}, () => {
+      this.props.params.count_skips = (value === 'Yes');
+      this.getData();
+    });
   }
 
   toPercent(num) {
@@ -114,6 +123,14 @@ export class ImportanceComponentWidget extends React.Component {
           ))}
         </CardBody>
         }
+        <CardFooter>
+          <ParamDropdown
+            dropdownItems={['Yes', 'No']}
+            handleSelect={this.onSkipSelect}
+            defaultValue={this.state.countSkips}
+            tooltip="Count skips as failure:"
+          />
+        </CardFooter>
       </Card>
     );
   }


### PR DESCRIPTION
As done in other widgets, like Jenkins heatmap, it would be useful to allow users to decide if they want to count skipped tests or not in Importance by Component widget.