### PR TITLE
Fix result-list URL generation on pagination

### DIFF
--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -358,7 +358,7 @@ export class ResultList extends React.Component {
     let params = buildParams(this.state.filters);
     params.push('page=' + this.state.page);
     params.push('pageSize=' + this.state.pageSize);
-    this.props.navigate('results?' + params.join('&'))
+    this.props.navigate('?' + params.join('&'))
   }
 
   setPage = (_event, pageNumber) => {


### PR DESCRIPTION
When inside a _results_ page (i.e. URLs like `ibutsu/project/<uuid>/results?<filter>`) the paginator adds another **results** token to the path, thus making an invalid URL. 
This PR removes the extra token from the generated URL