### PR TITLE
Use source instead of build number when filtering results in Importance by Component widget

### DIFF
--- a/backend/ibutsu_server/widgets/importance_component.py
+++ b/backend/ibutsu_server/widgets/importance_component.py
@@ -25,16 +25,14 @@ def get_importance_component(
     ).get("jobs")
 
     # A list of job build numbers to filter our runs by
-    job_ids = []
-    for job in jobs:
-        job_ids.append(job["build_number"])
+    job_ids = [job["source"] for job in jobs]
 
     # query for RUN ids
     # metadata has to have a string to column to work
     # because it is a sqlalchemy property otherwise (AFAIK)
     bnumdat = string_to_column("metadata.jenkins.build_number", Run)
     run_data = (
-        Run.query.filter(bnumdat.in_(job_ids), Run.component.in_(components.split(",")))
+        Run.query.filter(Run.source.in_(job_ids), Run.component.in_(components.split(",")))
         .add_columns(Run.id, bnumdat.label("build_number"))
         .all()
     )

--- a/backend/ibutsu_server/widgets/importance_component.py
+++ b/backend/ibutsu_server/widgets/importance_component.py
@@ -1,10 +1,10 @@
-from sqlalchemy import desc, func
 from collections import defaultdict
+
+from sqlalchemy import desc
 
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Result, Run
 from ibutsu_server.filters import string_to_column
-from ibutsu_server.widgets.jenkins_job_view import get_jenkins_job_view
 
 
 def get_importance_component(

--- a/backend/ibutsu_server/widgets/importance_component.py
+++ b/backend/ibutsu_server/widgets/importance_component.py
@@ -13,8 +13,8 @@ def _get_results(job_name, builds, components, project):
     jnamedat = string_to_column("metadata.jenkins.job_name", Run)
     sub_query = (
         session.query(Run.id)
-        .filter(jnamedat==job_name)
-        .filter(Run.project_id==project)
+        .filter(jnamedat == job_name)
+        .filter(Run.project_id == project)
         .order_by(desc("start_time"))
         .limit(builds)
         .subquery()
@@ -52,7 +52,6 @@ def get_importance_component(
     project=None,
     count_skips=False,
 ):
-
     result_data = _get_results(job_name, builds, components, project)
 
     """

--- a/backend/ibutsu_server/widgets/importance_component.py
+++ b/backend/ibutsu_server/widgets/importance_component.py
@@ -115,7 +115,7 @@ def get_importance_component(
                     }
                 else:
                     sdatdict[component][bnum][importance] = {
-                        "percentage": 0,
+                        "percentage": "-",
                         "result_list": res_list,
                     }
 

--- a/backend/ibutsu_server/widgets/importance_component.py
+++ b/backend/ibutsu_server/widgets/importance_component.py
@@ -16,17 +16,16 @@ def get_importance_component(
     project=None,
     count_skips=False,
 ):
-
     # Get the last 'builds' runs from a specific Jenkins Job as a subquery
     bnumdat = string_to_column("metadata.jenkins.build_number", Run)
     jnamedat = string_to_column("metadata.jenkins.job_name", Run)
     sub_query = (
-            session.query(bnumdat.label("build_number"))
-            .filter(jnamedat.like(job_name))
-            .order_by(desc("start_time"))
-            .limit(builds)
-            .subquery()
-            )
+        session.query(bnumdat.label("build_number"))
+        .filter(jnamedat.like(job_name))
+        .order_by(desc("start_time"))
+        .limit(builds)
+        .subquery()
+    )
 
     # Filter the results based on the jenkins job, build number and component
     mdat = string_to_column("metadata.importance", Result)

--- a/backend/ibutsu_server/widgets/importance_component.py
+++ b/backend/ibutsu_server/widgets/importance_component.py
@@ -115,7 +115,7 @@ def get_importance_component(
                     }
                 else:
                     sdatdict[component][bnum][importance] = {
-                        "percentage": "-",
+                        "percentage": "N/A",
                         "result_list": res_list,
                     }
 


### PR DESCRIPTION
Importance by Component widget uses the _job name_ to fetch runs and the _build number_ and _component_ to group the results. However, there are cases where different jobs may have the same build number and component (for example, two different jobs for stage and prod that contains results for the same component).

This PR modifies the field used in the query from `build_number` to `source` which has more information to not mix runs.