### PR TITLE
Fix run filtering and apply filters to report buttons

### DIFF
--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -45,11 +45,13 @@ export class ResultList extends React.Component {
   static propTypes = {
     location: PropTypes.object,
     navigate: PropTypes.func,
-    eventEmitter: PropTypes.object
+    eventEmitter: PropTypes.object,
+    params: PropTypes.object,
   }
 
   constructor(props) {
     super(props);
+    // TODO just use props.params when converting to funcational component
     const params = new URLSearchParams(props.location.search);
     let page = 1, pageSize = 20, filters = {};
     if (params.toString() !== '') {
@@ -299,7 +301,7 @@ export class ResultList extends React.Component {
   };
 
   applyReport = () => {
-    this.props.navigate('/reports?' + buildParams(this.state.filters).join('&'))
+    this.props.navigate('/project/' + this.props.params.project_id + '/reports?' + buildParams(this.state.filters).join('&'))
   };
 
   updateFilters(name, operator, value, callback) {

--- a/frontend/src/run-list.js
+++ b/frontend/src/run-list.js
@@ -90,7 +90,8 @@ export class RunList extends React.Component {
   static propTypes = {
     location: PropTypes.object,
     navigate: PropTypes.func,
-    eventEmitter: PropTypes.object
+    eventEmitter: PropTypes.object,
+    params: PropTypes.object,
   }
 
   constructor(props) {
@@ -142,6 +143,10 @@ export class RunList extends React.Component {
       this.getRuns(value);
     });
   }
+
+  applyReport = () => {
+    this.props.navigate('/project/' + this.props.params.project_id + '/reports?' + buildParams(this.state.filters).join('&'))
+  };
 
   onFieldToggle = () => {
     this.setState({isFieldOpen: !this.state.isFieldOpen});
@@ -575,6 +580,7 @@ export class RunList extends React.Component {
                 onApplyFilter={this.applyFilter}
                 onRemoveFilter={this.removeFilter}
                 onClearFilters={this.clearFilters}
+                onApplyReport={this.applyReport}
                 onSetPage={this.setPage}
                 onSetPageSize={this.setPageSize}
                 hideFilters={["project_id"]}

--- a/frontend/src/run-list.js
+++ b/frontend/src/run-list.js
@@ -292,7 +292,7 @@ export class RunList extends React.Component {
     let params = buildParams(this.state.filters);
     params.push('page=' + this.state.page);
     params.push('pageSize=' + this.state.pageSize);
-    this.props.navigate('/runs?' + params.join('&'))
+    this.props.navigate('?' + params.join('&'))
   }
 
   setPage = (_event, pageNumber) => {

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -123,7 +123,7 @@ podman run -dt \
        $POSTGRES_EXTRA_ARGS \
        --name ibutsu-postgres \
        --rm \
-       postgres:15
+       postgres:12
 echo "done."
 echo -n "Adding redis to the pod:    "
 podman run -dt \


### PR DESCRIPTION
Reported by Eva Sebestova

When applying filters to the run page, the URL was improperly formed for the navigation call.

I also fixed the 'apply active filters to report' links for both run-list and result-list

https://issues.redhat.com/browse/IQE-3166