### PR TITLE
Convert IbutsuHeader to functional component

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -44,7 +44,7 @@ export default [
                 ...globals.browser,
                 ...globals.node,
                 ...globals.cypress,
-                es202: true,
+                es2020: true,
             },
             parser: pkg,
             parserOptions: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "react-router-dom": "^6.28.0",
     "react-scripts": "^5.0.1",
     "react-simple-oauth2-login": "^0.5.4",
+    "react-toastify": "^11.0.2",
     "serve": "^12.0.1",
     "typescript": "^4.9.5",
     "wolfy87-eventemitter": "^5.2.9"
@@ -79,5 +80,8 @@
   },
   "bin": {
     "write-version-file": "./bin/write-version-file.cjs"
+  },
+  "jest": {
+    "resetMocks": false
   }
 }

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -25,7 +25,6 @@ export class App extends React.Component {
     this.state = {
       uploadFileName: '',
       importId: '',
-      notifications: [],
       searchValue: '',
       views: []
     };

--- a/frontend/src/app.test.js
+++ b/frontend/src/app.test.js
@@ -2,6 +2,21 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Base } from './base';
 
-it('renders without crashing', () => {
-  render(<Base />);
-});
+
+describe('Render full app', () => {
+  beforeEach(() => {
+    // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      // eslint-disable-next-line no-undef
+      value: jest.fn().mockImplementation(query => ({
+        matches: false,
+        media: query,
+        onchange: null,
+      })),
+    });
+  })
+  it('renders without crashing', () => {
+    render(<Base />);
+  });
+})

--- a/frontend/src/components/FileUpload.spec.cy.js
+++ b/frontend/src/components/FileUpload.spec.cy.js
@@ -2,7 +2,6 @@ import { mount } from 'cypress/react';
 import React from 'react';
 
 import { FileUpload } from '.';
-import { IbutsuContext } from '../services/context';
 
 describe('FileUpload', () => {
 
@@ -11,35 +10,4 @@ describe('FileUpload', () => {
     cy.get('button');
   });
 
-  it('should fire the beforeUpload when a file is changed', () => {
-    const beforeUpload = cy.spy().as('buSpy');
-    mount(
-      <IbutsuContext.Provider value={{'primaryObject': {'id': '1234'}}}>
-        <FileUpload url='/upload' beforeUpload={beforeUpload}>Upload</FileUpload>
-      </IbutsuContext.Provider>
-      );
-    cy.get('input[type="file"]')
-      .selectFile({
-        contents: 'cypress/fixtures/example.json',
-      },
-      {force: true, log: true});
-    cy.get('@buSpy').should('have.been.called');
-  });
-
-  it('should upload the file and trigger the afterUpload event', () => {
-    const afterUpload = cy.spy().as('auSpy');
-
-    cy.intercept('POST', '/upload', {});
-    mount(
-      <IbutsuContext.Provider value={{'primaryObject': {'id': '1234'}}}>
-        <FileUpload url='/upload' afterUpload={afterUpload}>Upload</FileUpload>
-      </IbutsuContext.Provider>
-    );
-    cy.get('input[type="file"]')
-      .selectFile({
-        contents: 'cypress/fixtures/example.json',
-      },
-      {force: true, log: true});
-    cy.get('@auSpy').should('have.been.called');
-  });
 });

--- a/frontend/src/components/admin-page.js
+++ b/frontend/src/components/admin-page.js
@@ -11,14 +11,13 @@ import {
 import { Link, Outlet } from 'react-router-dom';
 import ElementWrapper from './elementWrapper';
 
-import { IbutsuHeader } from './ibutsu-header';
+import IbutsuHeader from './ibutsu-header';
 import PropTypes from 'prop-types';
 
 
 
 const AdminPage = (props) => {
     // TODO useEffect instead of eventEmitter prop
-    // TODO notifications on admin page with state and AlertGroup
     const navigation = (
       // TODO what is onNavSelect doing here ... I just carried this from a class ref
       <PageSidebar theme="dark" >

--- a/frontend/src/components/fileupload.js
+++ b/frontend/src/components/fileupload.js
@@ -1,23 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import UploadIcon from '@patternfly/react-icons/dist/esm/icons/upload-icon';
+
 
 import { HttpClient } from '../services/http';
 import { IbutsuContext } from '../services/context';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { AlertActionLink, Button, ButtonVariant, Icon, Tooltip } from '@patternfly/react-core';
+import { getDarkTheme } from '../utilities';
+import { toast } from 'react-toastify';
+import ToastWrapper from './toast-wrapper';
+import { Settings } from '../settings';
+import { ALERT_TIMEOUT } from '../constants';
 
 export class FileUpload extends React.Component {
   // TODO: refactor to functional
   // TODO: Consider explicit project selection for upload instead of inferred from context
+  // TODO: support multiple upload
   static contextType = IbutsuContext;
   static propTypes = {
     url: PropTypes.string.isRequired,
     name: PropTypes.string,
-    multiple: PropTypes.bool,
-    beforeUpload: PropTypes.func,
-    afterUpload: PropTypes.func,
     children: PropTypes.node,
-    className: PropTypes.node,
-    isUnstyled: PropTypes.bool,
   }
 
   constructor(props) {
@@ -25,11 +28,13 @@ export class FileUpload extends React.Component {
     this.state = {
       url: props.url,
       name: props.name ? props.name : 'file',
-      multiple: !!props.multiple,
-      beforeUpload: props.beforeUpload ? props.beforeUpload : Function.prototype,
-      afterUpload: props.afterUpload ? props.afterUpload : Function.prototype
+      importId: null,
+      intervalId: null
     };
     this.inputRef = React.createRef();
+    this.importToastRef = React.createRef();
+    this.intervalId = React.createRef();
+
   }
 
   onClick = () => {
@@ -39,35 +44,96 @@ export class FileUpload extends React.Component {
   onFileChange = (e) => {
     let files = e.target.files || e.dataTransfer.files;
     if (files.length > 0) {
-      this.state.beforeUpload(files);
       this.uploadFile(files[0]);
       // Clear the upload field
       this.inputRef.current.value = '';
     }
   }
 
+  checkImportStatus = (importId) => {
+    const { primaryObject } = this.context;
+
+    HttpClient.get([Settings.serverUrl, 'import', importId])
+    .then(response => HttpClient.handleResponse(response))
+    .then(data => {
+      if (data['status'] === 'done') {
+        clearInterval(this.intervalId.current);
+        this.importId = null;
+        let action = null;
+        if (data.metadata.run_id) {
+          const RunButton = () => (
+            <AlertActionLink component='a' href={'/project/' + (data.metadata.project_id || primaryObject.id) + '/runs/' + data.metadata.run_id}>
+              Go to Run
+            </AlertActionLink>
+          )
+          action = <RunButton />;
+        }
+        toast.update(this.importToastRef.current,
+          {
+            data: {
+              type:'success',
+              title:'Import Complete',
+              message: `${data.filename} has been successfully imported as run ${data.metadata.run_id}`,
+              action: action
+            },
+            type: 'success',
+            autoClose: ALERT_TIMEOUT
+          }
+        )
+
+      }
+    });
+  }
+
   uploadFile = (file) => {
     const files = {};
     const { primaryObject } = this.context;
     files[this.state.name] = file;
+
     HttpClient.upload(
       this.state.url,
       files,
       {'project': primaryObject?.id}
-    ).then((response) => {
-      response = HttpClient.handleResponse(response, 'response');
-      this.state.afterUpload(response);
+    )
+    .then((response) => HttpClient.handleResponse(response, 'response'))
+    .then(data => {
+      data.json().then((importObject) => {
+        this.importToastRef.current = toast(<ToastWrapper />,
+          {
+            data: {
+              type: 'info',
+              title: 'Import Starting',
+              message: importObject.filename + ' is being imported...'
+            },
+            type: 'info',
+            theme: getDarkTheme() ? 'dark' : 'light'
+          }
+        );
+        this.intervalId.current = setInterval(() => {this.checkImportStatus(importObject['id'])}, 5000);
+        })
+    })
+    .catch(error => {
+      toast.update(this.importToastRef.current,
+        {
+          data: {
+            type: 'danger',
+            title: 'Import Error',
+            message: 'There was a problem uploading your file: ' + error
+          },
+          type: 'error'
+        }
+      );
     });
   }
 
   render() {
-    const { children, className } = this.props;
+    const { children } = this.props;
     const { primaryObject } = this.context;
     return (
       <React.Fragment>
-        <input type="file" multiple={this.state.multiple} style={{display: 'none'}} onChange={this.onFileChange} ref={this.inputRef} />
+        <input type="file" multiple={false} style={{display: 'none'}} onChange={this.onFileChange} ref={this.inputRef} />
         <Tooltip content="Upload a result archive to the selected project.">
-          <Button className={className} onClick={this.onClick} isAriaDisabled={!primaryObject}>
+          <Button variant={ButtonVariant.tertiary} icon={<Icon><UploadIcon/></Icon>} onClick={this.onClick} isAriaDisabled={!primaryObject}>
             {children}
           </Button>
         </Tooltip>

--- a/frontend/src/components/ibutsu-header.js
+++ b/frontend/src/components/ibutsu-header.js
@@ -1,12 +1,11 @@
-import React from 'react';
+import React, {useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-
 import {
   AboutModal,
-  AlertActionLink,
   Brand,
   Button,
   ButtonVariant,
+  Icon,
   Flex,
   FlexItem,
   Masthead,
@@ -19,7 +18,6 @@ import {
   Select,
   SelectList,
   SelectOption,
-  Switch,
   TextContent,
   Toolbar,
   ToolbarContent,
@@ -30,205 +28,92 @@ import {
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
+  ToggleGroup,
+  ToggleGroupItem,
 } from '@patternfly/react-core';
-import { BarsIcon, MoonIcon, ServerIcon, TimesIcon, QuestionCircleIcon, UploadIcon } from '@patternfly/react-icons';
+import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
+import MoonIcon from '@patternfly/react-icons/dist/esm/icons/moon-icon';
+import SunIcon from '@patternfly/react-icons/dist/esm/icons/sun-icon';
+import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
+
 
 import { FileUpload, UserDropdown } from '../components';
-import { MONITOR_UPLOAD_TIMEOUT, VERSION_CHECK_TIMEOUT } from '../constants';
-import  packageJson from '../../package.json'
+import { VERSION } from '../constants';
 import { HttpClient } from '../services/http';
 import { Settings } from '../settings';
-import { getDateString, getTheme, setTheme } from '../utilities';
 import { IbutsuContext } from '../services/context';
+import { useNavigate, useParams } from 'react-router-dom';
+import { setDocumentDarkTheme } from '../utilities';
 
+function IbutsuHeader (props) {
+  // hooks
+  const context = useContext(IbutsuContext);
+  const params = useParams();
+  const navigate = useNavigate();
 
-export class IbutsuHeader extends React.Component {
-  // TODO: convert to functional
-  static contextType = IbutsuContext;
-  static propTypes = {
-    eventEmitter: PropTypes.object,
-    navigate: PropTypes.func,
-    version: PropTypes.string,
-    params: PropTypes.object,
-  }
+  // states
+  const [isProjectSelectOpen, setIsProjectSelectOpen] = useState(false);
+  const [selectedProject, setSelectedProject] = useState();
+  const [inputValue, setInputValue] = useState();
+  const [filterValue, setFilterValue] = useState();
+  const [projects, setProjects] = useState([]);
+  const [filteredProjects, setFilteredProjects] = useState([]);
+  const [isAboutOpen, setIsAboutOpen] = useState();
+  const [endpoint] = useState('project'); // TODO: portal dashboard
 
-  constructor(props) {
-    super(props);
-    this.eventEmitter = props.eventEmitter;
-    this.versionCheckId = '';
+  // values from hooks
+  const { project_id } = params;
+  const { setPrimaryObject, setPrimaryType, setDefaultDashboard, darkTheme, setDarkTheme } = context;
 
-    this.state = {
-      // version
-      version: packageJson.version,
-      // upload state
-      uploadFileName: '',
-      importId: '',
-      monitorUploadId: null,
-      // project state
-      isProjectSelectorOpen: false,
-      selectedProject: '',
-      inputValue: '',
-      filterValue: '',
-      projects: [],
-      filteredProjects: [],
-      // misc
-      isAboutOpen: false,
-      isDarkTheme: getTheme() === 'dark',
-    };
-  }
+  useEffect(() => {
+    // update projects/portals when the filter input changes
+    // TODO: iterate over pages, fix controller filtering behavior to apply pageSize AFTER filter
+    let api_params = {pageSize: 20};
+    if (filterValue) {
+      api_params['filter'] = ['title%' + filterValue];
+    }
+    HttpClient.get([Settings.serverUrl, endpoint], api_params)
+      .then(response => HttpClient.handleResponse(response))
+      .then(data => {
+        setProjects(data[endpoint+'s']);
+        setFilteredProjects(data[endpoint+'s']);
+      })
+  }, [filterValue, endpoint]);
 
-  sync_context = () => {
-    // Primary object
-    const { primaryObject, setPrimaryObject, setPrimaryType } = this.context;
-    const { selectedProject } = this.state;
-    const paramProject = this.props.params?.project_id;
-    let updatedPrimary = undefined;
+  useEffect(() => {
+    setDocumentDarkTheme(darkTheme);
+  }, [darkTheme]);
 
-    // API fetch and set the context
-    if (paramProject && primaryObject?.id !== paramProject) {
-      HttpClient.get([Settings.serverUrl, 'project', paramProject])
+  useEffect(() => {
+    if (selectedProject?.id !== project_id) {
+
+      HttpClient.get([Settings.serverUrl, '/project/', project_id])
         .then(response => HttpClient.handleResponse(response))
-        .then(data => {
-          updatedPrimary = data;
+        .then((data) => {
           setPrimaryObject(data)
           setPrimaryType('project')
-          // update state
-          this.setState({
-            selectedProject: data,
-            isProjectSelectorOpen: false,
-            inputValue: data?.title,
-            filterValue: ''
-          });
-      });
-    }
-
-    // update selector state
-    if (updatedPrimary && !selectedProject) {
-      this.setState({
-        selectedProject: updatedPrimary,
-        inputValue: updatedPrimary.title
-      })
-    }
-
-    if ( updatedPrimary ) {
-      this.emitProjectChange(updatedPrimary);
-    }
-  }
-
-  showNotification(type, title, message, action = null, timeout = null, key = null) {
-    if (!this.eventEmitter) {
-      return;
-    }
-    this.eventEmitter.emit('showNotification', type, title, message, action, timeout, key);
-  }
-
-  checkVersion() {
-    const frontendUrl = window.location.origin;
-    HttpClient.get([frontendUrl, 'version.json'], {'v': getDateString()})
-      .then(response => HttpClient.handleResponse(response))
-      .then((data) => {
-        if (data && data.version && (data.version !== this.state.version)) {
-          const action = <AlertActionLink onClick={() => { window.location.reload(); }}>Reload</AlertActionLink>;
-          this.showNotification(
-            'info',
-            'Ibutsu has been updated',
-            'A newer version of Ibutsu is available, click reload to get it.',
-            action,
-            true,
-            'check-version');
-        }
-      });
-  }
-
-  emitProjectChange(value = null) {
-    if (!this.eventEmitter) {
-      return;
-    }
-    this.eventEmitter.emit('projectChange', value);
-  }
-
-  getSelectorOptions = (endpoint = 'project') => {
-    // adding s here seems dumb, but this scope is small, it's only abstracted for 2 things
-    // TODO: iterate over pages, fix controller filtering behavior to apply pageSize AFTER filter
-    const pluralEndpoint = endpoint+'s';
-    const params = {pageSize: 20};
-    if (this.state.filterValue) {
-      params['filter'] = ['title%' + this.state.filterValue];
-    }
-    HttpClient.get([Settings.serverUrl, endpoint], params)
-      .then(response => HttpClient.handleResponse(response))
-      .then(data => {
-          this.setState(
-            {
-              projects: data[pluralEndpoint],
-              filteredProjects: data[pluralEndpoint],
-            })
-        }
-    );
-  }
-
-  // TODO: separate functional upload component from ibutsu-header
-  onBeforeUpload = (files) => {
-    for (var i = 0; i < files.length; i++) {
-      this.showNotification('info', 'File Uploaded', files[i].name + ' has been uploaded, importing will start momentarily.');
-    }
-  }
-
-  onAfterUpload = (response) => {
-    response = HttpClient.handleResponse(response, 'response');
-    if (response.status >= 200 && response.status < 400) {
-      response.json().then((importObject) => {
-        this.showNotification('info', 'Import Starting', importObject.filename + ' is being imported...');
-        this.setState({importId: importObject['id']}, () => {
-          let monitorUploadId = setInterval(this.monitorUpload, MONITOR_UPLOAD_TIMEOUT);
-          this.setState({monitorUploadId});
+          setDefaultDashboard(data.default_dashboard_id)
+          setSelectedProject(data);
+          setFilterValue();
+          setInputValue(data.title);
+          setIsProjectSelectOpen(false);
         });
-      });
     }
-    else {
-      this.showNotification('danger', 'Import Error', 'There was a problem importing your file');
-    }
-  }
+  }, [project_id, selectedProject, setDefaultDashboard, setPrimaryObject, setPrimaryType])
 
-  monitorUpload = () => {
-    const { primaryObject } = this.context;
-    HttpClient.get([Settings.serverUrl, 'import', this.state.importId])
-      .then(response => HttpClient.handleResponse(response))
-      .then(data => {
-        if (data['status'] === 'done') {
-          clearInterval(this.state.monitorUploadId);
-          this.setState({monitorUploadId: null});
-          let action = null;
-          if (data.metadata.run_id) {
-            const RunButton = () => (
-              <AlertActionLink onClick={() => {this.props.navigate('/project/' + (data.metadata.project_id || primaryObject.id) + '/runs/' + data.metadata.run_id)}}>
-                Go to Run
-              </AlertActionLink>
-            )
-            action = <RunButton />;
-          }
-          this.showNotification('success', 'Import Complete', `${data.filename} has been successfully imported as run ${data.metadata.run_id}`, action);
-        }
-      });
-  }
-
-  onProjectToggle = () => {
-    this.setState({isProjectSelectorOpen: !this.state.isProjectSelectorOpen});
-  }
-
-  onProjectSelect = (_event, value) => {
+  function onProjectSelect(_event, value) {
     const {
       primaryObject,
       setPrimaryObject,
       setPrimaryType,
       setDefaultDashboard,
-    } = this.context;
+    } = context;
     if (primaryObject?.id === value?.id) {
-      this.setState({
-        isProjectSelectorOpen: false,
-        inputValue: value.title,
-        filterValue: ''
-      });
+      setIsProjectSelectOpen(false);
+      setInputValue(value.title);
+      setFilterValue('');
       return;
     }
     // update context
@@ -237,116 +122,58 @@ export class IbutsuHeader extends React.Component {
     setDefaultDashboard(value.default_dashboard_id);
 
     // update state
-    this.setState({
-      selectedProject: value,
-      isProjectSelectorOpen: false,
-      inputValue: value?.title,
-      filterValue: ''
-    });
-    // Consider whether the location should be changed within the emit hooks?
-    let dash_path = '';
-    if (value?.default_dashboard_id != null) {dash_path = '/dashboard/' + value?.default_dashboard_id}
-    this.props.navigate('/project/' + value?.id + dash_path);
+    setSelectedProject(value);
+    setIsProjectSelectOpen(false);
+    setInputValue(value?.title);
+    setFilterValue('');
 
-    // useEffect with dependency on functional component to remove passing value, handlers don't see updated context
-    this.emitProjectChange(value);
+    navigate('/project/' + value?.id + '/dashboard/');
   }
 
-  onProjectClear = () => {
-    const { setPrimaryObject } = this.context;
+  function onProjectClear() {
+    const { setPrimaryObject } = context;
 
-    this.setState({
-      selectedProject: '',
-      isProjectSelectorOpen: false,
-      inputValue: '',
-      filterValue: ''
-    });
+    setSelectedProject('');
+    setIsProjectSelectOpen(false);
+    setInputValue('');
+    setFilterValue('');
+
     setPrimaryObject();
 
-    this.props.navigate('/project');
-
-    this.emitProjectChange();
+    navigate('/project');
   }
 
-  onProjectTextInputChange = (_event, value) => {
-    this.setState({
-      inputValue: value,
-      filterValue: value
-    }, this.getSelectorOptions('project'));
+  function onProjectTextInputChange(_event, value) {
+    setInputValue(value);
+    setFilterValue(value);
   }
 
-  toggleAbout = () => {
-    this.setState({isAboutOpen: !this.state.isAboutOpen});
-  }
-
-  onThemeChanged = (isChecked) => {
-    setTheme(isChecked ? 'dark' : 'light');
-    this.setState({isDarkTheme: isChecked});
-  }
-
-  componentWillUnmount() {
-    if (this.state.monitorUploadId) {
-      clearInterval(this.state.monitorUploadId);
-    }
-    if (this.versionCheckId) {
-      clearInterval(this.versionCheckId);
-    }
-  }
-
-  componentDidMount() {
-    this.getSelectorOptions('project');
-    this.sync_context();
-    this.checkVersion();
-    this.versionCheckId = setInterval(() => this.checkVersion(), VERSION_CHECK_TIMEOUT);
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (
-      prevState.filterValue !== this.state.filterValue
-    ) {
-      let newSelectOptionsProject = this.state.projects;
-      if (this.state.inputValue) {
-        newSelectOptionsProject = this.state.projects.filter(menuItem =>
-          String(menuItem.title).toLowerCase().includes(this.state.filterValue.toLowerCase())
-        );
-
-        if (!this.state.isProjectSelectorOpen) {
-          this.setState({ isProjectSelectorOpen: true });
-        }
-      }
-
-      this.setState({
-        filteredProjects: newSelectOptionsProject,
-      });
-    }
-  }
-
-  toggle = toggleRef => (
+  const toggle = toggleRef => (
     <MenuToggle
       variant="typeahead"
-      onClick={this.onProjectToggle}
-      isExpanded={this.state.isProjectSelectorOpen}
+      onClick={() => {setIsProjectSelectOpen(!isProjectSelectOpen)}}
+      isExpanded={isProjectSelectOpen}
       isFullWidth
       innerRef={toggleRef}
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
-          value={this.state.inputValue}
-          onClick={this.onProjectToggle}
-          onChange={this.onProjectTextInputChange}
+          value={inputValue}
+          onClick={() => {setIsProjectSelectOpen(!isProjectSelectOpen)}}
+          onChange={onProjectTextInputChange}
           id="typeahead-select-input"
           autoComplete="off"
           placeholder="No active project"
           role="combobox"
-          isExpanded={this.state.isProjectSelectorOpen}
+          isExpanded={isProjectSelectOpen}
           aria-controls="select-typeahead-listbox"
         />
         <TextInputGroupUtilities>
-          {!!this.state.inputValue && (
-            <Button variant="plain" onClick={() => {
-              this.onProjectClear()
+          {!!inputValue && (
+            <Button onClick={() => {
+              onProjectClear()
             }} aria-label="Clear input value">
-              <TimesIcon aria-hidden />
+              <Icon><TimesIcon aria-hidden /></Icon>
             </Button>
           )}
         </TextInputGroupUtilities>
@@ -354,163 +181,165 @@ export class IbutsuHeader extends React.Component {
     </MenuToggle>
   );
 
-  render() {
-    document.title = 'Ibutsu';
-    const apiUiUrl = Settings.serverUrl + '/ui/';
-    const {
-      selectedProject,
-      projects,
-      filteredProjects,
-      filterValue,
-    } = this.state;
 
-    const topNav = (
-      <Flex>
-        <FlexItem id="project-selector">
-          <Select
-            id="typeahead-select"
-            isOpen={this.state.isProjectSelectorOpen}
-            selected={selectedProject}
-            onSelect={this.onProjectSelect}
-            onOpenChange={() => {
-              this.setState({isProjectSelectorOpen: false});
-            }}
-            toggle={this.toggle}
-          >
-            <SelectList id="select-typeahead-listbox">
-              {(projects.length === 0 && !filterValue) && (
-                <SelectOption
-                  isDisabled={true}
-                  description="Ask Ibutsu admins to add you to a project">
-                  No projects available
-                </SelectOption>
-              )}
-              {(projects.length === 0 && !!filterValue) && (
-                <SelectOption isDisabled={true}>
-                  {`No results found for "${filterValue}"`}
-                </SelectOption>
-              )}
-              {filteredProjects.map((project, index) => (
-                <SelectOption
-                  key={project.id || index}
-                  onClick={() => this.setState({selectedProject: project})}
-                  value={project}
-                  description={project.name}
-                  isDisabled={project.isDisabled}>
-                  {project.title}
-                </SelectOption>
-              ))}
-              {projects.length === 10 && (
-                <SelectOption isDisabled>Search for more...</SelectOption>
-              )}
-            </SelectList>
-          </Select>
-        </FlexItem>
-      </Flex>
-    );
-    const headerTools = (
-      <Toolbar id="toolbar" isFullHeight isStatic style={{paddingLeft: '30px'}}>
-        <ToolbarContent>
-          <ToolbarGroup variant="filter-group">
-            <ToolbarItem>
-              {topNav}
-            </ToolbarItem>
-          </ToolbarGroup>
-          <ToolbarGroup
-            variant="icon-button-group"
-            align={{
-              default: 'alignRight'
-            }}
-            spacer={{
-              default: 'spacerNone',
-              md: 'spacerMd'
-            }}
-          >
-            <ToolbarItem>
-              <Button
-                aria-label="About"
-                onClick={this.toggleAbout}
-                variant={ButtonVariant.plain}
-                icon={<QuestionCircleIcon />} />
-            </ToolbarItem>
-            <ToolbarItem>
-              <FileUpload
-                className="pf-v5-c-button pf-m-plain"
-                name="importFile"
-                url={`${Settings.serverUrl}/import`}
-                multiple={false}
-                beforeUpload={this.onBeforeUpload}
-                afterUpload={this.onAfterUpload}
-                title="Import xUnit XML or Ibutsu Archive"
-              ><UploadIcon /> Import</FileUpload>
-            </ToolbarItem>
-            <ToolbarItem>
-              <a
-                href={apiUiUrl}
-                className="pf-v5-c-button pf-m-plain"
-                target="_blank"
-                rel="noopener noreferrer"
-              ><ServerIcon/> API</a>
-            </ToolbarItem>
-            <ToolbarItem>
-              <Switch
-              id="theme-toggle"
-              label={<MoonIcon />}
-              isChecked={this.state.isDarkTheme}
-              onChange={(_event, isChecked) => this.onThemeChanged(isChecked)} />
-            </ToolbarItem>
-            <ToolbarItem id="user-dropdown">
-              <UserDropdown eventEmitter={this.eventEmitter}/>
-            </ToolbarItem>
-          </ToolbarGroup>
+  const projectSelect = (
+    <Flex>
+      <FlexItem id="project-selector">
+        <Select
+          id="typeahead-select"
+          isOpen={isProjectSelectOpen}
+          selected={selectedProject}
+          onSelect={onProjectSelect}
+          onOpenChange={(isOpen) => {setIsProjectSelectOpen(isOpen);}}
+          toggle={toggle}
+        >
+          <SelectList id="select-typeahead-listbox">
+            {(projects.length === 0 && !filterValue) && (
+              <SelectOption
+                isDisabled={true}
+                description="Ask Ibutsu admins to add you to a project">
+                No projects available
+              </SelectOption>
+            )}
+            {(projects.length === 0 && !!filterValue) && (
+              <SelectOption isDisabled={true}>
+                {`No results found for "${filterValue}"`}
+              </SelectOption>
+            )}
+            {filteredProjects.map((project, index) => (
+              <SelectOption
+                key={project.id || index}
+                onClick={() => {setSelectedProject(project)}}
+                value={project}
+                description={project.name}
+                isDisabled={project.isDisabled}>
+                {project.title}
+              </SelectOption>
+            ))}
+            {projects.length === 10 && (
+              <SelectOption isDisabled>Search for more...</SelectOption>
+            )}
+          </SelectList>
+        </Select>
+      </FlexItem>
+    </Flex>
+  );
+
+  const headerTools = (
+    <Toolbar id="toolbar" isFullHeight isStatic style={{paddingLeft: '30px'}}>
+      <ToolbarContent>
+        <ToolbarGroup variant="filter-group">
+          <ToolbarItem>
+            {projectSelect}
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup
+          variant="icon-button-group"
+          align={{
+            default: 'alignRight'
+          }}
+        >
+          <ToolbarItem spacer={{ default: 'spacerSm' }}>
+            <Button
+              aria-label="About"
+              onClick={() => {setIsAboutOpen(!isAboutOpen);}}
+              variant={ButtonVariant.plain}
+              icon={<Icon><QuestionCircleIcon /></Icon>} />
+          </ToolbarItem>
+          <ToolbarItem spacer={{ default: 'spacerSm' }}>
+            <FileUpload
+              name="importFile"
+              url={`${Settings.serverUrl}/import`}
+              title="Import xUnit XML or Ibutsu Archive"
+            >Import</FileUpload>
+          </ToolbarItem>
+          <ToolbarItem spacer={{ default: 'spacerSm' }}>
+            <Button
+              component='a'
+              href={Settings.serverUrl + '/ui/'}
+              variant={ButtonVariant.tertiary}
+              target="_blank"
+              rel="noopener noreferrer"
+              icon={<Icon><ServerIcon/></Icon>}
+            > API</Button>
+          </ToolbarItem>
+          <ToolbarItem spacer={{ default: 'spacerSm' }}>
+            <ToggleGroup>
+              <ToggleGroupItem
+                aria-label='Light theme'
+                icon={<Icon><SunIcon /></Icon>}
+                buttonId='theme-toggle-light'
+                isSelected={!darkTheme}
+                onChange={() => {setDarkTheme(false)}}
+              />
+              <ToggleGroupItem
+                aria-label='Dark theme'
+                icon={<Icon><MoonIcon /></Icon>}
+                buttonId='theme-toggle-dark'
+                isSelected={darkTheme}
+                onChange={() => {setDarkTheme(true)}}
+              />
+            </ToggleGroup>
+          </ToolbarItem>
+          <ToolbarItem id="user-dropdown" >
+            <UserDropdown eventEmitter={props.eventEmitter}/>
+          </ToolbarItem>
+        </ToolbarGroup>
       </ToolbarContent>
     </Toolbar>
-    );
-    return (
-      <React.Fragment>
-        <AboutModal
-          isOpen={this.state.isAboutOpen}
-          onClose={this.toggleAbout}
-          brandImageSrc="/images/ibutsu.svg"
-          brandImageAlt="Ibutsu"
-          productName="Ibutsu"
-          backgroundImageSrc="/images/about-bg.jpg"
-          trademark="Copyright (c) 2021 Red Hat, Inc."
-        >
-          <TextContent>
-            <TextList component="dl">
-              <TextListItem component="dt">Version</TextListItem>
-              <TextListItem component="dd">{this.state.version}</TextListItem>
-              <TextListItem component="dt">Source code</TextListItem>
-              <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server" target="_blank" rel="noopener noreferrer">github.com/ibutsu/ibutsu-server</a></TextListItem>
-              <TextListItem component="dt">Documentation</TextListItem>
-              <TextListItem component="dd"><a href="https://docs.ibutsu-project.org/" target="_blank" rel="noopener noreferrer">docs.ibutsu-project.org</a></TextListItem>
-              <TextListItem component="dt">Report bugs</TextListItem>
-              <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server/issues/new" target="_blank" rel="noopener noreferrer">Submit an issue</a></TextListItem>
-            </TextList>
-          </TextContent>
-          <p style={{marginTop: '2rem'}}>* Note: artifact files (screenshots, logs) are retained for 3 months</p>
-        </AboutModal>
-        <Masthead>
-          <MastheadToggle>
-            <PageToggleButton
-              variant="plain"
-              aria-label="Global navigation"
-              id="vertical-nav-toggle"
-            >
-              <BarsIcon />
-            </PageToggleButton>
-          </MastheadToggle>
-          <MastheadMain>
-            <MastheadBrand href="/">
-              <Brand src="/images/ibutsu-wordart-164.png" alt="Ibutsu"/>
-            </MastheadBrand>
-          </MastheadMain>
-          <MastheadContent>
-            {headerTools}
-          </MastheadContent>
-        </Masthead>
-      </React.Fragment>
-    );
-  }
+  )
+
+  return (
+    <React.Fragment>
+      <AboutModal
+        isOpen={isAboutOpen}
+        onClose={() => {setIsAboutOpen(!isAboutOpen);}}
+        brandImageSrc="/images/ibutsu.svg"
+        brandImageAlt="Ibutsu"
+        productName="Ibutsu"
+        backgroundImageSrc="/images/about-bg.jpg"
+        trademark="Copyright (c) 2021 Red Hat, Inc."
+      >
+        <TextContent>
+          <TextList component="dl">
+            <TextListItem component="dt">Version</TextListItem>
+            <TextListItem component="dd">{VERSION}</TextListItem>
+            <TextListItem component="dt">Source code</TextListItem>
+            <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server" target="_blank" rel="noopener noreferrer">github.com/ibutsu/ibutsu-server</a></TextListItem>
+            <TextListItem component="dt">Documentation</TextListItem>
+            <TextListItem component="dd"><a href="https://docs.ibutsu-project.org/" target="_blank" rel="noopener noreferrer">docs.ibutsu-project.org</a></TextListItem>
+            <TextListItem component="dt">Report bugs</TextListItem>
+            <TextListItem component="dd"><a href="https://github.com/ibutsu/ibutsu-server/issues/new" target="_blank" rel="noopener noreferrer">Submit an issue</a></TextListItem>
+          </TextList>
+        </TextContent>
+        <p style={{marginTop: '2rem'}}>* Note: artifact files (screenshots, logs) are retained for 3 months</p>
+      </AboutModal>
+      <Masthead>
+        <MastheadToggle >
+          <PageToggleButton
+            variant="plain"
+            aria-label="Global navigation"
+            id="vertical-nav-toggle"
+          >
+            <Icon><BarsIcon/></Icon>
+          </PageToggleButton>
+        </MastheadToggle>
+        <MastheadMain>
+          <MastheadBrand href='/'>
+            <Brand src="/images/ibutsu-wordart-164.png" alt="Ibutsu"/>
+          </MastheadBrand>
+        </MastheadMain>
+        <MastheadContent>
+          {headerTools}
+        </MastheadContent>
+      </Masthead>
+    </React.Fragment>
+  )
 }
+
+IbutsuHeader.propTypes = {
+  // TODO convert UserDropdown to functional and drop eventemitter
+  eventEmitter: PropTypes.object,
+};
+
+export default IbutsuHeader;

--- a/frontend/src/components/ibutsu-page.js
+++ b/frontend/src/components/ibutsu-page.js
@@ -6,9 +6,6 @@ import PropTypes from 'prop-types';
 import { Outlet } from 'react-router-dom';
 
 import {
-  Alert,
-  AlertGroup,
-  AlertVariant,
   EmptyState,
   EmptyStateBody,
   EmptyStateHeader,
@@ -16,13 +13,13 @@ import {
   Page,
 } from '@patternfly/react-core';
 
-import ElementWrapper from './elementWrapper';
-import { IbutsuHeader } from '../components';
-import { ALERT_TIMEOUT } from '../constants';
-import { getDateString } from '../utilities';
+import IbutsuHeader from './ibutsu-header';
 import { IbutsuContext } from '../services/context';
 import IbutsuSidebar from './sidebar';
 import { ArchiveIcon } from '@patternfly/react-icons';
+import { ToastContainer } from 'react-toastify';
+import { ALERT_TIMEOUT } from '../constants';
+
 
 
 export class IbutsuPage extends React.Component {
@@ -40,62 +37,21 @@ export class IbutsuPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      notifications: [],
       views: []
     };
-    this.props.eventEmitter.on('showNotification', (type, title, message, action, timeout, key) => {
-      this.showNotification(type, title, message, action, timeout, key);
-    });
-    this.props.eventEmitter.on('projectChange', () => {
-    });
     // TODO: empty state props.children override
 
   }
 
-  showNotification(type, title, message, action, timeout, key) {
-    let notifications = this.state.notifications;
-    let alertKey = key || getDateString();
-    timeout = timeout !== undefined ? timeout : true
-    if (notifications.find(element => element.key === alertKey) !== undefined) {
-      return;
-    }
-    let notification = {
-      'key': alertKey,
-      'type': AlertVariant[type],
-      'title': title,
-      'message': message,
-      'action': action
-    };
-    notifications.push(notification);
-    this.setState({notifications}, () => {
-      if (timeout === true) {
-        setTimeout(() => {
-          let notifs = this.state.notifications.filter((n) => {
-            if (n.type === type && n.title === title && n.message === message) {
-              return false;
-            }
-            return true;
-          });
-          this.setState({notifications: notifs});
-        }, ALERT_TIMEOUT);
-      }
-    });
-  }
+
 
   render() {
     document.title = this.props.title || 'Ibutsu';
     const { primaryObject } = this.context;
     return (
       <React.Fragment>
-        <AlertGroup isToast>
-          {this.state.notifications.map((notification) => (
-            <Alert key={notification.key} variant={notification.type} title={notification.title} actionLinks={notification.action} timeout={ALERT_TIMEOUT} isLiveRegion>
-              {notification.message}
-            </Alert>
-          ))}
-        </AlertGroup>
         <Page
-          header={<ElementWrapper routeElement={IbutsuHeader} eventEmitter={this.props.eventEmitter}/>}
+          header={<IbutsuHeader eventEmitter={this.props.eventEmitter}/>}
           sidebar={<IbutsuSidebar eventEmitter={this.props.eventEmitter} />}
           isManagedSidebar={true}
           style={{position: 'relative'}}
@@ -111,6 +67,7 @@ export class IbutsuPage extends React.Component {
           </EmptyState>
           }
         </Page>
+        <ToastContainer stacked autoclose={ALERT_TIMEOUT} />
       </React.Fragment>
     );
   }

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -6,7 +6,6 @@ export { DownloadButton } from './download-button';
 export { EmptyObject } from './empty-object';
 export { FileUpload } from './fileupload';
 export { FilterTable, MetaFilter } from './filtertable';
-export { IbutsuHeader } from './ibutsu-header';
 export { IbutsuPage } from './ibutsu-page';
 export { MultiValueInput } from './multivalueinput';
 export { NewDashboardModal } from './new-dashboard-modal';

--- a/frontend/src/components/profile-page.js
+++ b/frontend/src/components/profile-page.js
@@ -12,8 +12,11 @@ import { NavLink, Outlet} from 'react-router-dom';
 
 
 import ElementWrapper from './elementWrapper';
-import { IbutsuHeader } from './ibutsu-header';
+import IbutsuHeader from './ibutsu-header';
 import PropTypes from 'prop-types';
+import { ToastContainer } from 'react-toastify';
+import { ALERT_TIMEOUT } from '../constants';
+import { getDarkTheme } from '../utilities';
 
 
 
@@ -22,9 +25,9 @@ const ProfilePage = (props) => {
 
   const navigation = (
     // TODO what is onNavSelect doing here ...
-    <PageSidebar theme="dark" >
+    <PageSidebar theme={getDarkTheme() ? 'dark' : 'light200'} >
       <PageSidebarBody>
-        <Nav onSelect={React.Component.onNavSelect} theme="dark" aria-label="Nav">
+        <Nav onSelect={React.Component.onNavSelect} theme={getDarkTheme() ? 'dark' : 'light200'} aria-label="Nav">
           <NavList>
             <li className="pf-v5-c-nav__item">
               <NavLink to="profile" className="pf-v5-c-nav__link">Profile</NavLink>
@@ -40,6 +43,7 @@ const ProfilePage = (props) => {
 
   return (
     <React.Fragment>
+        <ToastContainer autoclose={ALERT_TIMEOUT} />
         <Page
             header={<ElementWrapper routeElement={IbutsuHeader} eventEmitter={props.eventEmitter}/>}
             sidebar={navigation}

--- a/frontend/src/components/result.js
+++ b/frontend/src/components/result.js
@@ -27,7 +27,7 @@ import { ClassificationDropdown } from './classification-dropdown';
 import { DownloadButton } from './download-button';
 import { linkifyDecorator } from './decorators'
 import { Settings } from '../settings';
-import { getIconForResult, getTheme, round } from '../utilities';
+import { getIconForResult, getDarkTheme, round } from '../utilities';
 import { TabTitle } from './tabs';
 import { TestHistoryTable } from './test-history';
 
@@ -227,7 +227,7 @@ export class ResultView extends React.Component {
 
   render() {
     let { testResult, artifactTabs, activeTab, testHistoryTable } = this.state;
-    const jsonViewLightThemeOn = getTheme() === 'dark' ? false : true ;
+    const jsonViewLightThemeOn = !getDarkTheme;
     if (activeTab === null) {
       activeTab = this.getDefaultTab();
     }

--- a/frontend/src/components/toast-wrapper.js
+++ b/frontend/src/components/toast-wrapper.js
@@ -1,0 +1,15 @@
+import { Alert, Icon } from '@patternfly/react-core'
+import PropTypes from 'prop-types';
+
+
+const ToastWrapper = ({data}) => (
+    <Alert key={data.key} customIcon={Icon} title={data.title} actionLinks={data.action}>
+        {data.message}
+    </Alert>
+);
+
+ToastWrapper.propTypes = {
+    data: PropTypes.object,
+}
+
+export default ToastWrapper;

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,4 +1,6 @@
-export const VERSION_CHECK_TIMEOUT = 15 * 60 * 1000;  // 15 minutes
+import  packageJson from '../package.json'
+
+export const VERSION = packageJson.version;
 export const MONITOR_UPLOAD_TIMEOUT = 1 * 1000;  // 1 second
 export const ALERT_TIMEOUT = 5 * 1000;  // 5 seconds
 export const KNOWN_WIDGETS = [

--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -23,13 +23,11 @@ import {
   TextInputGroupUtilities,
 } from '@patternfly/react-core';
 
-import {
-  CubesIcon,
-  PlusCircleIcon,
-  TachometerAltIcon,
-  TimesCircleIcon,
-  TimesIcon
-} from '@patternfly/react-icons';
+import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import TachometerAltIcon from '@patternfly/react-icons/dist/esm/icons/tachometer-alt-icon';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import TimesCircleIcon from '@patternfly/react-icons/dist/esm/icons/times-circle-icon';
 
 import { HttpClient } from './services/http';
 import { KNOWN_WIDGETS } from './constants';
@@ -87,7 +85,7 @@ function Dashboard() {
           });
           setWidgets(data.widgets);
         })
-        .catch(error => console.log(error));
+        .catch(error => console.error(error));
     }
   }, [selectedDB, isDeleteWidgetOpen, isEditModalOpen, isNewWidgetOpen]);
 
@@ -103,14 +101,12 @@ function Dashboard() {
         // api filter handles case, contains, and is a loose search on title
         api_params['filter'] = ['title%' + filterDBValue];
       }
-      console.log('fetching dashboards: ');
 
       HttpClient.get([Settings.serverUrl, 'dashboard'], api_params)
         .then(response => HttpClient.handleResponse(response))
         .then(data => {
           setDashboards(data['dashboards']);
           setFilteredDBs(data['dashboards']);
-          console.log('applying default dashboard: '+defaultDashboard);
           if (defaultDashboard && !selectedDB) {
             const default_db_item = data['dashboards'].filter(dash => dash.id == defaultDashboard).pop();
             if (default_db_item) {
@@ -120,7 +116,7 @@ function Dashboard() {
             }
           }
         })
-        .catch(error => console.log(error));
+        .catch(error => console.error(error));
     }
 
 
@@ -137,7 +133,7 @@ function Dashboard() {
           setFilterDBValue();
           setSelectDBInputValue(data?.title);
         })
-        .catch(error => console.log(error));
+        .catch(error => console.error(error));
     }
   }, [dashboard_id, selectedDB])
 
@@ -174,14 +170,14 @@ function Dashboard() {
         setIsNewDBOpen(false);
         onDashboardSelect(null, data);
       })
-      .catch(error => console.log(error));
+      .catch(error => console.error(error));
   }
 
   function onDeleteDashboard() {
     HttpClient.delete([Settings.serverUrl, 'dashboard', selectedDB.id])
         .then(response => HttpClient.handleResponse(response))
         .then(() => onDashboardClear()) // only run after successful delete, otherwise it's a race to remove from the dropdown
-        .catch(error => console.log(error));
+        .catch(error => console.error(error));
     setIsDeleteDBOpen(false);
 
   }
@@ -195,7 +191,7 @@ function Dashboard() {
     HttpClient.delete([Settings.serverUrl, 'widget-config', currentWidget])
         .then(response => HttpClient.handleResponse(response))
         .then(() => setIsDeleteWidgetOpen(false))
-        .catch(error => console.log(error));
+        .catch(error => console.error(error));
   }
 
   function onNewWidgetSave(widgetData) {
@@ -204,7 +200,7 @@ function Dashboard() {
     }
     HttpClient.post([Settings.serverUrl, 'widget-config'], widgetData)
       .then(()=> setIsNewWidgetOpen(false))  // wait to close modal until widget is saved
-      .catch(error => console.log(error));
+      .catch(error => console.error(error));
 
   }
 
@@ -214,7 +210,7 @@ function Dashboard() {
     }
     HttpClient.put([Settings.serverUrl, 'widget-config', currentWidget], '', editedData)
         .then(response => HttpClient.handleResponse(response))
-        .catch(error => console.log(error));
+        .catch(error => console.error(error));
     setIsEditModalOpen(false);
   }
 
@@ -228,7 +224,7 @@ function Dashboard() {
           setEditWidgetData(data);
         })
         .catch(error => {
-          console.log(error);
+          console.error(error);
           setIsEditModalOpen(false);
         });
 
@@ -274,7 +270,7 @@ function Dashboard() {
   )
 
   return (
-    <>
+    <React.Fragment>
       <PageSection variant={PageSectionVariants.light}>
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
           <Flex>
@@ -524,7 +520,7 @@ function Dashboard() {
           data={editWidgetData}
         />
       : ''}
-    </>
+    </React.Fragment>
   );
 }
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,14 +4,15 @@ import { createRoot } from 'react-dom/client';
 
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/patternfly/patternfly-theme-dark.css';
+import '@patternfly/patternfly/patternfly-charts.css';
 import './index.css';
-import { setTheme } from './utilities';
+import { setDocumentDarkTheme } from './utilities';
 
 import { Base } from './base';
 import * as serviceWorker from './serviceWorker';
 
 
-setTheme();
+setDocumentDarkTheme();
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(<Base/>);

--- a/frontend/src/pages/profile/tokens.js
+++ b/frontend/src/pages/profile/tokens.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { ToastContainer, toast } from 'react-toastify';
 
 import {
   Button,
@@ -19,6 +20,8 @@ import { HttpClient } from '../../services/http';
 import { Settings } from '../../settings';
 import { getSpinnerRow } from '../../utilities';
 import { FilterTable, AddTokenModal, DeleteModal } from '../../components';
+import ToastWrapper from '../../components/toast-wrapper';
+import { ALERT_TIMEOUT } from '../../constants';
 
 
 export class UserTokens extends React.Component {
@@ -59,16 +62,16 @@ export class UserTokens extends React.Component {
     };
   }
 
-  showNotification(type, title, message, action?, timeout?, key?) {
-    if (!this.eventEmitter) {
-      return;
-    }
-    this.eventEmitter.emit('showNotification', type, title, message, action, timeout, key);
-  }
 
   copyToClipboard = (text) => {
     navigator.clipboard.writeText(text);
-    this.showNotification('info', 'Copied to clipboard', 'Your token has been copied to the clipboard');
+    toast(<ToastWrapper />,
+      {
+        data: {
+          type: 'info',
+          title: 'Copied to clipboard',
+          message: 'Your token has been copied to the clipboard'
+    }});
   }
 
   tokenToRow(token) {
@@ -224,6 +227,7 @@ export class UserTokens extends React.Component {
           onDelete={this.onDeleteToken}
           onClose={this.onDeleteTokenClose}
         />
+        <ToastContainer autoClose={ALERT_TIMEOUT} stacked/>
       </React.Fragment>
     );
   }

--- a/frontend/src/pages/profile/user.js
+++ b/frontend/src/pages/profile/user.js
@@ -20,6 +20,9 @@ import { CheckIcon, PencilAltIcon, TimesIcon } from '@patternfly/react-icons';
 
 import { HttpClient } from '../../services/http';
 import { Settings } from '../../settings';
+import { toast } from 'react-toastify';
+import { getDarkTheme } from '../../utilities';
+import ToastWrapper from '../../components/toast-wrapper';
 
 
 export class UserProfile extends React.Component {
@@ -35,13 +38,6 @@ export class UserProfile extends React.Component {
       projects: null,
       isEditing: false
     };
-  }
-
-  showNotification(type, title, message, action?, timeout?, key?) {
-    if (!this.eventEmitter) {
-      return;
-    }
-    this.eventEmitter.emit('showNotification', type, title, message, action, timeout, key);
   }
 
   updateUserName(userName) {
@@ -87,12 +83,29 @@ export class UserProfile extends React.Component {
     let tempUser = Object.assign({}, user, {name: tempName});
     this.saveUser(tempUser).then(response => {
       if (response !== undefined) {
-        this.showNotification('success', 'Name Updated', 'Your name has been updated.');
+        toast(<ToastWrapper/>, {
+          data: {
+            type: 'success',
+            title: 'Name Updated',
+            message: 'Your name has been updated.'
+          },
+          type: 'success',
+          theme: getDarkTheme() ? 'dark' : 'light'
+        })
         this.setState({user: tempUser, isEditing: false});
         this.updateUserName(tempName);
       }
       else {
-        this.showNotification('danger', 'Error Updating', 'There was an error trying to save your name');
+        toast(ToastWrapper,
+          {
+            data: {
+              type: 'danger',
+              title: 'Error Updating',
+              message: 'Your name has NOT been updated.'
+            },
+          type: 'danger',
+          theme: getDarkTheme() ? 'dark' : 'light'
+        });
         this.setState({isEditing: false});
       }
     });

--- a/frontend/src/run.js
+++ b/frontend/src/run.js
@@ -55,7 +55,7 @@ import { Settings } from './settings';
 import {
   cleanPath,
   getSpinnerRow,
-  getTheme,
+  getDarkTheme,
   processPyTestPath,
   resultToRow,
   round
@@ -442,7 +442,7 @@ export class Run extends React.Component {
     let created = 0;
     let calculatePasses = true;
     const { run, columns, rows, classificationTable, artifactTabs } = this.state;
-    const jsonViewLightThemeOn = getTheme() === 'dark' ? false : true ;
+    const jsonViewLightThemeOn = !getDarkTheme();
     const jsonViewTheme = {
       scheme: 'monokai',
       author: 'wimer hazenberg (http://www.monokai.nl)',

--- a/frontend/src/services/context.js
+++ b/frontend/src/services/context.js
@@ -1,5 +1,6 @@
 import React, {createContext, useState} from 'react';
 import PropTypes from 'prop-types';
+import { getDarkTheme } from '../utilities';
 
 
 const IbutsuContext = createContext({primaryType: 'project'});
@@ -8,6 +9,7 @@ const IbutsuContextProvider = (props) => {
     const [primaryType, setPrimaryType] = useState();
     const [primaryObject, setPrimaryObject] = useState();
     const [defaultDashboard, setDefaultDashboard] = useState();
+    const [darkTheme, setDarkTheme] = useState(getDarkTheme());
 
     return (
         <IbutsuContext.Provider
@@ -18,6 +20,8 @@ const IbutsuContextProvider = (props) => {
                 setPrimaryObject: setPrimaryObject,
                 defaultDashboard: defaultDashboard,
                 setDefaultDashboard: setDefaultDashboard,
+                darkTheme: darkTheme,
+                setDarkTheme: setDarkTheme
             }}>
                 {props.children}
         </IbutsuContext.Provider>

--- a/frontend/src/utilities.js
+++ b/frontend/src/utilities.js
@@ -503,32 +503,27 @@ export function debounce(func, timeout = 500) {
   };
 }
 
-export function getTheme() {
-  // check local storage and default to browser theme
+export function getDarkTheme() {
+  // check local storage and browser theme for a preference
   const local_theme = localStorage.getItem(THEME_KEY)
   if (local_theme) {
-    return local_theme;
+    return local_theme === 'dark';
   }
   else {
     let browser_preference = window.matchMedia('(prefers-color-scheme: dark)');
-    return browser_preference.matches ? 'dark' : 'light';
+    return Boolean(browser_preference.matches);
   }
 }
 
-export function setTheme(theme) {
-  let target_theme = theme ? theme : getTheme();
-  if (!['dark', 'light'].includes(target_theme)) {
-    console.log('bad theme value passed, defaulting to dark');
-    target_theme = 'dark';
-  }
+export function setDocumentDarkTheme(theme=null) {
+  // Sets light theme on false, dark theme on true
+  let set_dark = theme !== null ? theme : getDarkTheme();
 
-  localStorage.setItem('theme', target_theme);
-  if (target_theme === 'dark') {
-    console.log('setting dark theme');
+  localStorage.setItem('theme', set_dark ? 'dark' : 'light');
+  if (set_dark) {
     document.firstElementChild.classList.add('pf-v5-theme-dark');
   }
   else {
-    console.log('setting light theme');
     document.firstElementChild.classList.remove('pf-v5-theme-dark');
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -59,10 +59,19 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/eslint-parser@^7.16.3", "@babel/eslint-parser@^7.24.7":
+"@babel/eslint-parser@^7.16.3":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz#603c68a63078796527bc9d0833f5e52dd5f9224c"
   integrity sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==
+  dependencies:
+    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.1"
+
+"@babel/eslint-parser@^7.24.7":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz#aa669f4d873f9cd617050cf3c40c19cd96307efb"
+  integrity sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==
   dependencies:
     "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
     eslint-visitor-keys "^2.1.0"
@@ -1284,10 +1293,10 @@
     debug "^4.3.1"
     minimatch "^3.1.2"
 
-"@eslint/core@^0.9.0":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.9.1.tgz#31763847308ef6b7084a4505573ac9402c51f9d1"
-  integrity sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==
+"@eslint/core@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.10.0.tgz#23727063c21b335f752dbb3a16450f6f9cbc9091"
+  integrity sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==
   dependencies:
     "@types/json-schema" "^7.0.15"
 
@@ -1326,21 +1335,22 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@eslint/js@9.17.0":
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.17.0.tgz#1523e586791f80376a6f8398a3964455ecc651ec"
-  integrity sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==
+"@eslint/js@9.18.0":
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.18.0.tgz#3356f85d18ed3627ab107790b53caf7e1e3d1e84"
+  integrity sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==
 
 "@eslint/object-schema@^2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.5.tgz#8670a8f6258a2be5b2c620ff314a1d984c23eb2e"
   integrity sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==
 
-"@eslint/plugin-kit@^0.2.3":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz#2b78e7bb3755784bb13faa8932a1d994d6537792"
-  integrity sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==
+"@eslint/plugin-kit@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz#ee07372035539e7847ef834e3f5e7b79f09e3a81"
+  integrity sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==
   dependencies:
+    "@eslint/core" "^0.10.0"
     levn "^0.4.1"
 
 "@greatsumini/react-facebook-login@^3.3.3":
@@ -1721,32 +1731,32 @@
   integrity sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA==
 
 "@patternfly/react-charts@^7.2.2":
-  version "7.4.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-7.4.7.tgz#a33fec6bfaf37cfbb11b5fb9f98ff31da183112a"
-  integrity sha512-mrIErPp7cz4/+MfpXIUEkKY52HPKbFUUljNuUfyAcN1320/3xt1n0wrf9yz43rN9yswR336guDJv96e4E+fn3g==
+  version "7.4.8"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-7.4.8.tgz#1708644ac20d9dfdcf577529a524524ef8a4916b"
+  integrity sha512-Rv2ajbb7kmwcrZIolcaH8RzIMx3+6ldtJlKQoChmNggXGgKFtg3/QBlc9Qj+14LW0LSQ12ZprmRvHZ/Viyq+Qw==
   dependencies:
     "@patternfly/react-styles" "^5.4.1"
     "@patternfly/react-tokens" "^5.4.1"
     hoist-non-react-statics "^3.3.2"
     lodash "^4.17.21"
     tslib "^2.7.0"
-    victory-area "^37.1.1"
-    victory-axis "^37.1.1"
-    victory-bar "^37.1.1"
-    victory-box-plot "^37.1.1"
-    victory-chart "^37.1.1"
-    victory-core "^37.1.1"
-    victory-create-container "^37.1.1"
-    victory-cursor-container "^37.1.1"
-    victory-group "^37.1.1"
-    victory-legend "^37.1.1"
-    victory-line "^37.1.1"
-    victory-pie "^37.1.1"
-    victory-scatter "^37.1.1"
-    victory-stack "^37.1.1"
-    victory-tooltip "^37.1.1"
-    victory-voronoi-container "^37.1.1"
-    victory-zoom-container "^37.1.1"
+    victory-area "^37.3.4"
+    victory-axis "^37.3.4"
+    victory-bar "^37.3.4"
+    victory-box-plot "^37.3.4"
+    victory-chart "^37.3.4"
+    victory-core "^37.3.4"
+    victory-create-container "^37.3.4"
+    victory-cursor-container "^37.3.4"
+    victory-group "^37.3.4"
+    victory-legend "^37.3.4"
+    victory-line "^37.3.4"
+    victory-pie "^37.3.4"
+    victory-scatter "^37.3.4"
+    victory-stack "^37.3.4"
+    victory-tooltip "^37.3.4"
+    victory-voronoi-container "^37.3.4"
+    victory-zoom-container "^37.3.4"
 
 "@patternfly/react-core@^5.2.3", "@patternfly/react-core@^5.4.12":
   version "5.4.12"
@@ -1771,9 +1781,9 @@
   integrity sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w==
 
 "@patternfly/react-table@^5.2.4":
-  version "5.4.13"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-5.4.13.tgz#f1930b92b7b9c12e8fe968ce21006fee5e52b646"
-  integrity sha512-cYw+pgpZXKGg3dZxudteUURqmj5O0ec7aNE80NLqFTcnI0MAOnfrFzCNApXJErn+MjD0VolMcC+H48eaRkT8TA==
+  version "5.4.14"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-5.4.14.tgz#9e2bd576271b2a11faf6039c32d7ad3cd61c58f3"
+  integrity sha512-F2EXhn3wURDFs5mOQQtYSQ1ltvPwN1n/5Iv2WgSehCkw9GzpcJlT7h8t+rnf59ZiWsRjhCFqUOU9l8APnM2+rA==
   dependencies:
     "@patternfly/react-core" "^5.4.12"
     "@patternfly/react-icons" "^5.4.2"
@@ -1815,10 +1825,10 @@
   resolved "https://registry.yarnpkg.com/@react-oauth/google/-/google-0.12.1.tgz#b76432c3a525e9afe076f787d2ded003fcc1bee9"
   integrity sha512-qagsy22t+7UdkYAiT5ZhfM4StXi9PPNvw0zuwNmabrWyMKddczMtBIOARflbaIj+wHiQjnMAsZmzsUYuXeyoSg==
 
-"@remix-run/router@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.21.0.tgz#c65ae4262bdcfe415dbd4f64ec87676e4a56e2b5"
-  integrity sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==
+"@remix-run/router@1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.21.1.tgz#bf15274d3856c395402719fa6b1dc8cc5245aaf7"
+  integrity sha512-KeBYSwohb8g4/wCcnksvKTYlg69O62sQeLynn2YE+5z7JWEj95if27kclW9QqbrlsQ2DINI8fjbV3zyuKfwjKg==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -2149,9 +2159,9 @@
     "@types/d3-time" "*"
 
 "@types/d3-shape@^3.1.0":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.6.tgz#65d40d5a548f0a023821773e39012805e6e31a72"
-  integrity sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.7.tgz#2b7b423dc2dfe69c8c93596e673e37443348c555"
+  integrity sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==
   dependencies:
     "@types/d3-path" "*"
 
@@ -3707,6 +3717,11 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4960,9 +4975,9 @@ es-module-lexer@^1.2.1:
   integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
 
 es-object-atoms@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.0.0.tgz#ddb55cd47ac2e240701260bc2a8e31ecb643d941"
-  integrity sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
 
@@ -5150,9 +5165,9 @@ eslint-plugin-jsx-a11y@^6.5.1:
     string.prototype.includes "^2.0.1"
 
 eslint-plugin-prettier@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz#d1c8f972d8f60e414c25465c163d16f209411f95"
-  integrity sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz#c4af01691a6fa9905207f0fbba0d7bea0902cce5"
+  integrity sha512-qJ+y0FfCp/mQYQ/vWQ3s7eUlFEL4PyKfAJxsnYTJ4YT73nsJBWqmEpFryxV9OeUiqmsTsYJ5Y+KDNaeP31wrRw==
   dependencies:
     prettier-linter-helpers "^1.0.0"
     synckit "^0.9.1"
@@ -5167,10 +5182,34 @@ eslint-plugin-react-hooks@^5.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz#3d34e37d5770866c34b87d5b499f5f0b53bf0854"
   integrity sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==
 
-eslint-plugin-react@^7.27.1, eslint-plugin-react@^7.37.2:
+eslint-plugin-react@^7.27.1:
   version "7.37.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz#567549e9251533975c4ea9706f986c3a64832031"
   integrity sha512-DomWuTQPFYZwF/7c9W2fkKkStqZmBd3uugfqBYLdkZ3Hii23WzZuOLUskGxB8qkSKqftxEeGL1TB2kMhrce0jA==
+  dependencies:
+    array-includes "^3.1.8"
+    array.prototype.findlast "^1.2.5"
+    array.prototype.flatmap "^1.3.3"
+    array.prototype.tosorted "^1.1.4"
+    doctrine "^2.1.0"
+    es-iterator-helpers "^1.2.1"
+    estraverse "^5.3.0"
+    hasown "^2.0.2"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.1.2"
+    object.entries "^1.1.8"
+    object.fromentries "^2.0.8"
+    object.values "^1.2.1"
+    prop-types "^15.8.1"
+    resolve "^2.0.0-next.5"
+    semver "^6.3.1"
+    string.prototype.matchall "^4.0.12"
+    string.prototype.repeat "^1.0.0"
+
+eslint-plugin-react@^7.37.2:
+  version "7.37.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz#1b6c80b6175b6ae4b26055ae4d55d04c414c7181"
+  integrity sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==
   dependencies:
     array-includes "^3.1.8"
     array.prototype.findlast "^1.2.5"
@@ -5298,17 +5337,17 @@ eslint@^8.3.0:
     text-table "^0.2.0"
 
 eslint@^9.17.0:
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.17.0.tgz#faa1facb5dd042172fdc520106984b5c2421bb0c"
-  integrity sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.18.0.tgz#c95b24de1183e865de19f607fda6518b54827850"
+  integrity sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.12.1"
     "@eslint/config-array" "^0.19.0"
-    "@eslint/core" "^0.9.0"
+    "@eslint/core" "^0.10.0"
     "@eslint/eslintrc" "^3.2.0"
-    "@eslint/js" "9.17.0"
-    "@eslint/plugin-kit" "^0.2.3"
+    "@eslint/js" "9.18.0"
+    "@eslint/plugin-kit" "^0.2.5"
     "@humanfs/node" "^0.16.6"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@humanwhocodes/retry" "^0.4.1"
@@ -5847,9 +5886,9 @@ fs-extra@^10.0.0:
     universalify "^2.0.0"
 
 fs-extra@^11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
-  integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
+  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -9448,19 +9487,19 @@ react-refresh@^0.11.0:
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
 react-router-dom@^6.28.0:
-  version "6.28.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.28.1.tgz#b78fe452d2cd31919b80e57047a896bfa1509f8c"
-  integrity sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==
+  version "6.28.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.28.2.tgz#9bc4f58b0cfe91d39d1a6be4beb0ef051ca9b06e"
+  integrity sha512-O81EWqNJWqvlN/a7eTudAdQm0TbI7hw+WIi7OwwMcTn5JMyZ0ibTFNGz+t+Lju0df4LcqowCegcrK22lB1q9Kw==
   dependencies:
-    "@remix-run/router" "1.21.0"
-    react-router "6.28.1"
+    "@remix-run/router" "1.21.1"
+    react-router "6.28.2"
 
-react-router@6.28.1:
-  version "6.28.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.28.1.tgz#f82317ab24eee67d7beb7b304c0378b2b48fa178"
-  integrity sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==
+react-router@6.28.2:
+  version "6.28.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.28.2.tgz#1ddea57c2de0d99e12d00af14d1499703f1378a9"
+  integrity sha512-BgFY7+wEGVjHCiqaj2XiUBQ1kkzfg6UoKYwEe0wv+FF+HNPCxtS/MVPvLAPH++EsuCMReZl9RYVGqcHLk5ms3A==
   dependencies:
-    "@remix-run/router" "1.21.0"
+    "@remix-run/router" "1.21.1"
 
 react-scripts@^5.0.1:
   version "5.0.1"
@@ -9521,6 +9560,13 @@ react-simple-oauth2-login@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/react-simple-oauth2-login/-/react-simple-oauth2-login-0.5.4.tgz#5d9b254fbc83484bd994f463c1f9e3643f0c639b"
   integrity sha512-BkVpgGVFGpZEDK6lr1ao+hJXuPvK56aSA0t8jKST0Q+Aya504bSLXNk9A0eU8XaF2GeQqW9n/M0aWNkezvS4Pg==
+
+react-toastify@^11.0.2:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-11.0.3.tgz#1684de60baf745e761d3c608bb29581657e2fe01"
+  integrity sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==
+  dependencies:
+    clsx "^2.1.1"
 
 react@^18.3.1:
   version "18.3.1"
@@ -11202,184 +11248,184 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-victory-area@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-37.3.5.tgz#11a87ada8366a2f67c91b4eff88122f2c6359d16"
-  integrity sha512-MP5+dm8ThQVsSDQhmU4K93mjPZ4hir1QkoM8kYT0PsJcoFYI6J2ceTxoyJUUgrgO0Kf63PcYChR5RLu34bhFlw==
+victory-area@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-37.3.6.tgz#968f1ae2e402c5afa426ec743b4045068b53be75"
+  integrity sha512-wVC8LKrZJLiSySNuJLRCB449qZTsPiRyzLlNoJwe21y+XA/a2HJbmJSeywmo8P153aX8viKe1H8ygDsTFXQhHw==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
-    victory-vendor "37.3.5"
+    victory-core "37.3.6"
+    victory-vendor "37.3.6"
 
-victory-axis@37.3.5, victory-axis@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-37.3.5.tgz#1bff3e41eed3024f1cbae05a2577404ae7464f1a"
-  integrity sha512-hd40FVZvWw26CHr6XfmVGhKgPd4I4Yqxtnl27P6aLVGv1gL46UuNVdDVFozr9rpxO+lGUepYz6Wh4OuzImpDEQ==
+victory-axis@37.3.6, victory-axis@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-37.3.6.tgz#29eee1a82d896507bfdf9f63fa1c6eecabc46e80"
+  integrity sha512-Vi0dZvgmXmnCdoqc49WckeG5cMXnl7FTtqVhXu9JweA9cgCnkZabBd5mRvAjblb3Lo4j0HZCSPKHYWUPW70qZg==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-bar@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-37.3.5.tgz#65e8a17e5cad9666c016be2a0599674a5ed8f092"
-  integrity sha512-9HXxM/+9jyv6SIcJv90yqyImgXLSEGhaPBnDJg5CvHcR1zdGAdQp2pDxDV6EivUrfxiIyj1NeSWyCZpM0ZJddQ==
+victory-bar@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-37.3.6.tgz#7adacc1c629d1355ab70fdfb91019e4c3a580ca4"
+  integrity sha512-jdATFRWL1LUW/yEpKWx/aId2BiU2o1pPF9+Kh1TFISBduJoI4ZqvZD90H1QK4f/z50PikqiqiDECaKoKM1jfOQ==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
-    victory-vendor "37.3.5"
+    victory-core "37.3.6"
+    victory-vendor "37.3.6"
 
-victory-box-plot@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-37.3.5.tgz#bd4cb2ad9b841a6c1a7e3af5e9858b2a1106fa15"
-  integrity sha512-jIV8k4XViLBWh5XvYBSELYGsWo55vYBoNqGkVUKhcXM4sS9mumc2XgDQ6nltTO88gs8uOyZpb2vBFp+1zOauyA==
+victory-box-plot@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-37.3.6.tgz#7f9632e7db69117f81d9ca199f4d3c5a29c61326"
+  integrity sha512-GOucnD63h14ScBuISC/nd1GBTEx6gIZfLE+0P0gyeH1poBKq0trTTvpQDvAMuGR8zICfEETG3ltmUMCwRrFyUg==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
-    victory-vendor "37.3.5"
+    victory-core "37.3.6"
+    victory-vendor "37.3.6"
 
-victory-brush-container@37.3.5:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-37.3.5.tgz#38f931ede6c129da19e74720f95261fee8f5a72a"
-  integrity sha512-n4Ozb5I/Pz/dcWnxAfqBhnsq6Q2gIC7Phjbau3cIBTPcq/rrkRIWzpiPPWhoAT+OTirgB9vOfe3JX4LBDk17FA==
-  dependencies:
-    lodash "^4.17.19"
-    react-fast-compare "^3.2.0"
-    victory-core "37.3.5"
-
-victory-chart@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-37.3.5.tgz#23cb31133e8017a4264e65dd7059594f6abffd74"
-  integrity sha512-Lsbmp5rG3ESzQAr76M4WJ0FKraltAzuQY1D3e7CmqzQlLKpsMS/j2Ty+5OCBDmC3qQ+PHObBLVavgn3TJSRJLg==
+victory-brush-container@37.3.6:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-37.3.6.tgz#f0316381620770233a82c7b118107e3c2237d978"
+  integrity sha512-LfZ2CgX1cYAqCtYxcSB68OfZS2v0T2VLXoEArd0lCXfRBY1Gya7GacCUcuo7GoK9XOXeslx7S/U95aVutt1VLg==
   dependencies:
     lodash "^4.17.19"
     react-fast-compare "^3.2.0"
-    victory-axis "37.3.5"
-    victory-core "37.3.5"
-    victory-polar-axis "37.3.5"
-    victory-shared-events "37.3.5"
+    victory-core "37.3.6"
 
-victory-core@37.3.5, victory-core@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-37.3.5.tgz#58ee98ee4b976dafc7d2e78cc48823b37fb0dc20"
-  integrity sha512-PXY+9Lx1ohCX+ZzkWdm+VY7T+2Pd/YKdv3yVkuflzMQ52kQMYbcgwGI49yPuzVqB3m1eBJ5dYdAD53ww53GTHw==
+victory-chart@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-37.3.6.tgz#66d67fbbf810f14e9873b19d8e067b23d85a139b"
+  integrity sha512-IkPo/W4AJ7bPu902TGER09OseR9ODm+FQAKfOBw4JsdEhZZ7BiG9zgd/25+x0r5EsTLu81CYGQVkBa+ZazcOlA==
+  dependencies:
+    lodash "^4.17.19"
+    react-fast-compare "^3.2.0"
+    victory-axis "37.3.6"
+    victory-core "37.3.6"
+    victory-polar-axis "37.3.6"
+    victory-shared-events "37.3.6"
+
+victory-core@37.3.6, victory-core@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-37.3.6.tgz#716c9cc2e6ff227692532db31aa14590be78ff7e"
+  integrity sha512-aFgO6KokxPbUCPznZP5UPhOdI22pMuwDXKDt6eoQOnkVim66Ia+K95TQar2nwVKGYV5j26aKVf/n9blwphGJRw==
   dependencies:
     lodash "^4.17.21"
     react-fast-compare "^3.2.0"
-    victory-vendor "37.3.5"
+    victory-vendor "37.3.6"
 
-victory-create-container@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-37.3.5.tgz#1cf9039a98d5870aed95070433ed8925db6d55e6"
-  integrity sha512-VcHhnw35e+xU96LWwAuCZQ7YLS9NSSlGU0pgtiUUx0ymCJDWtY8G+ZijZL+DKQ5byU/8+DvaK3iNUhxdpBAHQw==
+victory-create-container@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-37.3.6.tgz#80b1d3f0c5bac213e3f0f9dd06014a5c9a0bee3b"
+  integrity sha512-Uf5bFQvqUsXCjqpvBW4LhrdrHkM6dBqxYgub6FCsBb86f84xZQ3vY7jFkg/JfvF0oGKMoWXYYrYLC1sk+fcWVA==
   dependencies:
     lodash "^4.17.19"
-    victory-brush-container "37.3.5"
-    victory-core "37.3.5"
-    victory-cursor-container "37.3.5"
-    victory-selection-container "37.3.5"
-    victory-voronoi-container "37.3.5"
-    victory-zoom-container "37.3.5"
+    victory-brush-container "37.3.6"
+    victory-core "37.3.6"
+    victory-cursor-container "37.3.6"
+    victory-selection-container "37.3.6"
+    victory-voronoi-container "37.3.6"
+    victory-zoom-container "37.3.6"
 
-victory-cursor-container@37.3.5, victory-cursor-container@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-37.3.5.tgz#0847e6622794a70d6dd234797c68313b20a36493"
-  integrity sha512-/G9zpYkeJA0uBk3khGNJBUNHOZ25EPoFfVZqwSSjpVRRI3JLMVNvv1LWhZvFZDkK0KMrT8pi8AZr04jCZxCoPg==
+victory-cursor-container@37.3.6, victory-cursor-container@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-37.3.6.tgz#c84dbf1bda427f28a3fc04fb3afc69df5699df7c"
+  integrity sha512-+Oiw57d5nE+iq8As8RvepknzmNtKq1Gsc50u1X3IRd4jXtX8zqZrgXGlVZ+BP/tkLsWnGYVjKulwKBf2oaEUuw==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-group@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-37.3.5.tgz#833fca260b2158401daa7ae875fea077b2a4b1fb"
-  integrity sha512-0GEtrG2Vl7uv1fkmWlHRO6U8JBhXJ3cB1KJPP2k5QKblfYd0QgDCtlSeMuaTUB+yRnQR5OlUv6bvkwwRio4bSg==
+victory-group@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-37.3.6.tgz#d4b086d33e3a5a71476062d2b7d76edd571caefc"
+  integrity sha512-kgy/Azl5BxwlJAV0KDPGypv35TMrOD1J2ZxnJW2Wyyq+e8i0GGBIv5MoBzou64BRsDlS9V0CYRIjnkHgrBpB5w==
   dependencies:
     lodash "^4.17.19"
     react-fast-compare "^3.2.0"
-    victory-core "37.3.5"
-    victory-shared-events "37.3.5"
+    victory-core "37.3.6"
+    victory-shared-events "37.3.6"
 
-victory-legend@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-37.3.5.tgz#43960704b89374a053ea0d2b965b9e54ca75ea09"
-  integrity sha512-TW/OeKP8LgZp93nJVoAltTwl5T0q1MWeH1HqZim2oGqwqX0E8o0BeJXv+2TGkXdp5ITiWi2nxGGQ77vSg8KZhQ==
+victory-legend@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-37.3.6.tgz#95a3d16b80309aad27fb7d802418d9349be98ab4"
+  integrity sha512-vRRrhj3/ENqKVLdaBMzEmR83N6BOjox1bthYT1eJjN2H5SIK35bxn30IkiV/Pz3y627EqZe4TAWaxc0jiJlCiA==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-line@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-37.3.5.tgz#b4ab593ae42810e57718d23ee77aba921bdffb7d"
-  integrity sha512-q1L2aSG28Z7ousRckf8zut7HdLQ7kWiNakOatsdfAqnce/n52F0E8c3qSIwbRmkdHHSe3SHhTLNyzLtnDzYQjQ==
+victory-line@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-37.3.6.tgz#4228144e07362e8b6ccc0b1fbd45e84e95d32537"
+  integrity sha512-Ke817uf/qFbN9jU7Dba7CrcHXYO5wAZuKKnyeHJmLDeQeFST0773xejnIuC+dBgZipjFr4KIbSd+VcUafFNE1g==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
-    victory-vendor "37.3.5"
+    victory-core "37.3.6"
+    victory-vendor "37.3.6"
 
-victory-pie@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-37.3.5.tgz#6bfbf9e5111a74223407c218692ed46b514d538f"
-  integrity sha512-JjKE5QhlatZkl/YbiN2KrF+tXIHRZ0ZYua5yWl8JYcg5/UTE3IFn/Y+2HIQIGghzEa98ZMMC/lNfZ3CEwK1yaw==
+victory-pie@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-37.3.6.tgz#17a4ca211c1694e6eb922d042a49ec7ed07a81a2"
+  integrity sha512-tvdgAZ/HQWlo3KDDe0XAVbizHuaNMbgkkiF7zfA7Ww+3bHSs+0P9dsDtK2xP365D8gBCOv8pWmuzvKRhzNbqeA==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
-    victory-vendor "37.3.5"
+    victory-core "37.3.6"
+    victory-vendor "37.3.6"
 
-victory-polar-axis@37.3.5:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-37.3.5.tgz#d3fe6960a8e9d3c450b3731aa53c3be68e484ed2"
-  integrity sha512-6aZiaMGLtYDeh3uCB9wHKVVyvRsdbo5+WTp6S8lvyuHxyYOEn4JcxtpORzHHnGMWFkhZs4MmLSORrp/TBOi+7g==
+victory-polar-axis@37.3.6:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-37.3.6.tgz#cf1d2a4bf4c7784fb83afdf68cc779367d9e96e5"
+  integrity sha512-RpFsCkzHezJq5P+C/wtVdjEHX25JIFsSgs6qYSnfr/hayaFbWgK5HhRFpriQm5hg61cx47WxAOLyHvzf0nasvw==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-scatter@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-37.3.5.tgz#fcadc7073536f582394961150e6c3b1b1fc27625"
-  integrity sha512-YEXm9D1novmUjk44eFyj+UQIxUw50v3yAa/772nb8yzR9ys9xPjM9+yyIsJSbRwdSiEAPmcbj6qwcYlyvJz1bQ==
+victory-scatter@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-37.3.6.tgz#226e6e4b8242bc3af1c7207da970d02886b94dfd"
+  integrity sha512-fp95zMTPXgW1cmTowzDXhn+KxePMVDrzU0lotsHQMdBV7eB+ioXdu9hORlx4VHmMYg2ihsGwRTF+VAZ7rGxphA==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-selection-container@37.3.5:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-37.3.5.tgz#ae38d224cceda8880295c42c4099929a10fa66e9"
-  integrity sha512-cGqlZwV3HAWjrXjhGUsUkyFtWn+lsph2dcUzMlzTKs+e1sDFEHIVjpe3ZX4XsThu23dK//lrmIXFvbWtpLhy+Q==
+victory-selection-container@37.3.6:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-37.3.6.tgz#b50e04ff29da1bb35a60f8a0aed1d2134f08b045"
+  integrity sha512-gd3qODDlBtLEJM7+2jCXk2YcLBUmIpYEEHswytMhwc6zihxXipGBUHRulhLj/I05mKay2gaOAg5ewiJHd4Awgw==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-shared-events@37.3.5:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-37.3.5.tgz#a9ab7488df0ad013b3fc99dcdc7b2fbd070f69af"
-  integrity sha512-Juq/5Y9WsFaD/4ivk7/y786EwNgLUjp3hkhpIGhiQOM2VaL5H7Xb1pX4ASjibkCkWIQUMBM+JaprtNcKEDylpQ==
+victory-shared-events@37.3.6:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-37.3.6.tgz#7b04e1c480a0ccbaac3ca261c2f1adf38638cfad"
+  integrity sha512-ygrbOtzLUTbtKebacZKyQRekhSAROnAvMkVI/PKsAGsz0ClY9P7qDEJG7eTUUygjO6ax0tI6WNE6JogQzeD1gw==
   dependencies:
     json-stringify-safe "^5.0.1"
     lodash "^4.17.19"
     react-fast-compare "^3.2.0"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-stack@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-37.3.5.tgz#3056e18a73ff8b837c02864f8dc3ec7a3437618e"
-  integrity sha512-PL23dKKlr30Y77mw3JuIUYUhvOF66r3LhKQXqoymkV6DGMBhkQ2p7h+klek3xleRPBBTSz3o8EbfM8H2eZ/Umg==
+victory-stack@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-37.3.6.tgz#7a242f863a6a92bb8499cbd5f2f45aa73069bdbd"
+  integrity sha512-ldod04RdqGJGH5p5eWXCofdTkbhZqIp3iwW7NpxSbMDLs8zPQIVvDFVtuJgMwQiC5vnIpbhMmxVeFbr8m64ZKA==
   dependencies:
     lodash "^4.17.19"
     react-fast-compare "^3.2.0"
-    victory-core "37.3.5"
-    victory-shared-events "37.3.5"
+    victory-core "37.3.6"
+    victory-shared-events "37.3.6"
 
-victory-tooltip@37.3.5, victory-tooltip@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-37.3.5.tgz#6173ab6565b3abb7bfd9c27957de4498ee007197"
-  integrity sha512-IbvD37PGehP3K5BLL9xAK+6d/UEaNcLH/cdKKzeXeqOvoefQLIxxB1DJHYr542Ll8cxkeqtdsgtJ16pRCUgCSA==
+victory-tooltip@37.3.6, victory-tooltip@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-37.3.6.tgz#ef1ef2d4d221e6ce14ee989d68898c99ef46d927"
+  integrity sha512-vqaJS9noauOqDDBBAV9Ln9duOY/i17h1DCfCPAqhwPFyvFbwKvAub9zPTeYWAm/14VvWX5O/0yekFCVbcC7hjg==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
-victory-vendor@37.3.5:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-vendor/-/victory-vendor-37.3.5.tgz#750b634b8f91c04787928760f7ed766566c1bb4b"
-  integrity sha512-+K2VBMmB7peKG3Gjp79XjgsbfsYgD0eZRSmKz7p5a4V0NhYq43eM/b0gpSLq+Dhwag96QaWsU75/6bFVBjVE7A==
+victory-vendor@37.3.6:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-vendor/-/victory-vendor-37.3.6.tgz#401ac4b029a0b3d33e0cba8e8a1d765c487254da"
+  integrity sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==
   dependencies:
     "@types/d3-array" "^3.0.3"
     "@types/d3-ease" "^3.0.0"
@@ -11396,24 +11442,24 @@ victory-vendor@37.3.5:
     d3-time "^3.0.0"
     d3-timer "^3.0.1"
 
-victory-voronoi-container@37.3.5, victory-voronoi-container@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-37.3.5.tgz#20ffca0df4240e4f6d0443bb86e0e94c01abff9b"
-  integrity sha512-GF35HQn8ACMcr7yJAFmaSKAS6w9GOsxxWoR6gtuQtBUwSBciZ5LNWpR6718nFxeOYDhkk/FVn7tnKqQTBv6XUw==
+victory-voronoi-container@37.3.6, victory-voronoi-container@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-37.3.6.tgz#19073ea19035fb0a9d5a5cfc34011a60e1069816"
+  integrity sha512-qAAG0rMuK7A4EoJ4cyUk5wNdOW+HuCXNKPOko+hYK6wWOYXJvFhiglYyA85a695YyAXECc6JyJS/crm4IOEFag==
   dependencies:
     delaunay-find "0.0.6"
     lodash "^4.17.19"
     react-fast-compare "^3.2.0"
-    victory-core "37.3.5"
-    victory-tooltip "37.3.5"
+    victory-core "37.3.6"
+    victory-tooltip "37.3.6"
 
-victory-zoom-container@37.3.5, victory-zoom-container@^37.1.1:
-  version "37.3.5"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-37.3.5.tgz#50bf1fd0b0981bed30900b8997cb3724bb51dba1"
-  integrity sha512-LlRp2Ulodu3rhIrM1XilgR72223+qlhXE9mzBCYVoHQ+uo8uTKt27T0iOBkvY5kRwNiXQzshn01uxUAwxyBppw==
+victory-zoom-container@37.3.6, victory-zoom-container@^37.3.4:
+  version "37.3.6"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-37.3.6.tgz#49a43b3a086d030b333265758e234babb01066f5"
+  integrity sha512-AGL+k20mI44OL5b0VgIxlmnNSefIoFmbbim5NraPmIxbtns9qQW/56ivIncJcYomBungIx99gUpsEpcQaMNHgQ==
   dependencies:
     lodash "^4.17.19"
-    victory-core "37.3.5"
+    victory-core "37.3.6"
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Introduce react-toastify in addition to the migration, in order to get rid of the eventEmitter and improve the notifications pattern.

The ToastContainer has been placed in the IbutsuPage and ProfilePage, where the notifications are relevant.

Notification hooks have been moved from the header to the actual FileUpload that produces them. I left FileUpload as a class component but removed the beforeUpload and afterUpload hooks as I don't believe it makes sense to inject notification hooks through those function callbacks.

- [x] Theme toggle is too sticky for browser/OS preference, stays dark
- [x] yarn test failure, `    TypeError: window.matchMedia is not a function`, is occurring on an unmodified line of code in the utility function. It works locally.