### PR TITLE
Convert TabTitle

### DIFF
--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -10,7 +10,6 @@ export { NewWidgetWizard } from './new-widget-wizard';
 export { ParamDropdown } from './widget-components';
 export { ResultView } from './result';
 export { RunSummary } from './runsummary';
-export { TabTitle } from './tabs';
 export { TableEmptyState, TableErrorState } from './tablestates';
 export { UserDropdown } from './user-dropdown';
 export { View } from './view';

--- a/frontend/src/components/result.js
+++ b/frontend/src/components/result.js
@@ -28,7 +28,7 @@ import { DownloadButton } from './download-button';
 import { linkifyDecorator } from './decorators'
 import { Settings } from '../settings';
 import { getIconForResult, getDarkTheme, round } from '../utilities';
-import { TabTitle } from './tabs';
+import TabTitle from './tabs';
 import { TestHistoryTable } from './test-history';
 
 const MockTest = {
@@ -150,7 +150,7 @@ export class ResultView extends React.Component {
               if (contentType.includes('text')) {
                 response.text().then(text => {
                   artifactTabs.push(
-                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={FileAltIcon} text={artifact.filename} />}>
+                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={<FileAltIcon/>} text={artifact.filename} />}>
                       <Card>
                         <CardBody>
                           <Editor fontFamily="Noto Sans Mono, Hack, monospace" theme="vs-dark" value={text} height="40rem" options={{readOnly: true}} />
@@ -168,7 +168,7 @@ export class ResultView extends React.Component {
                 response.blob().then(blob => {
                   let imageUrl = URL.createObjectURL(blob);
                   artifactTabs.push(
-                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={FileImageIcon} text={artifact.filename} />}>
+                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={<FileImageIcon/>} text={artifact.filename} />}>
                       <Card>
                         <CardBody>
                           <img src={imageUrl} alt={artifact.filename}/>
@@ -266,7 +266,7 @@ export class ResultView extends React.Component {
         {this.state.testResult &&
         <Tabs activeKey={activeTab} onSelect={this.onTabSelect} isBox>
           {!this.props.hideSummary &&
-          <Tab eventKey="summary" title={<TabTitle icon={InfoCircleIcon} text="Summary" />}>
+          <Tab eventKey="summary" title={<TabTitle icon={<InfoCircleIcon/>} text="Summary" />}>
             <Card>
               <CardBody style={{padding: 0}}>
                 <DataList selectedDataListItemId={null} aria-label="Test Result" style={{borderBottom: 'none', borderTop: 'none'}}>
@@ -535,12 +535,12 @@ export class ResultView extends React.Component {
           }
           {!this.props.hideArtifact && artifactTabs}
           {!this.props.hideTestHistory &&
-          <Tab eventKey="test-history" title={<TabTitle icon={SearchIcon} text="Test History"/>}>
+          <Tab eventKey="test-history" title={<TabTitle icon={<SearchIcon/>} text="Test History"/>}>
           {testHistoryTable}
           </Tab>
           }
           {!this.props.hideTestObject &&
-          <Tab eventKey="test-object" title={<TabTitle icon={CodeIcon} text="Test Object" />}>
+          <Tab eventKey="test-object" title={<TabTitle icon={<CodeIcon/>} text="Test Object" />}>
             <Card>
               <CardBody>
                 <JSONTree data={testResult} theme={jsonViewTheme} invertTheme={jsonViewLightThemeOn} hideRoot shouldExpandNodeInitially={() => true}/>

--- a/frontend/src/components/tabs.js
+++ b/frontend/src/components/tabs.js
@@ -2,19 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TabTitleIcon, TabTitleText } from '@patternfly/react-core';
 
-export class TabTitle extends React.Component {
-  static propTypes = {
-    icon: PropTypes.elementType,
-    text: PropTypes.string
-  }
-
-  render() {
-    const Icon = this.props.icon;
-    return (
-      <React.Fragment>
-        <TabTitleIcon><Icon /></TabTitleIcon>
-        <TabTitleText>{this.props.text}</TabTitleText>
-      </React.Fragment>
-    );
-  }
+const TabTitle = (props) => {
+  const {icon, text} = props;
+  return(
+    <>
+      <TabTitleIcon>{icon}</TabTitleIcon>
+      <TabTitleText>{text?.toString()}</TabTitleText>
+    </>
+  )
 }
+
+TabTitle.propTypes ={
+  icon: PropTypes.object,
+  text: PropTypes.string
+}
+
+export default TabTitle;

--- a/frontend/src/run.js
+++ b/frontend/src/run.js
@@ -66,8 +66,9 @@ import {
   FilterTable,
   ClassifyFailuresTable,
   ResultView,
-  TabTitle
 } from './components';
+
+import TabTitle from './components/tabs';
 
 const MockRun = {
   id: null,
@@ -244,7 +245,7 @@ export class Run extends React.Component {
               if (contentType.includes('text')) {
                 response.text().then(text => {
                   artifactTabs.push(
-                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={FileAltIcon} text={artifact.filename} />}>
+                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={<FileAltIcon/>} text={artifact.filename} />}>
                       <Card>
                         <CardBody>
                           <Editor fontFamily="Noto Sans Mono, Hack, monospace" theme="vs-dark" value={text} height="40rem" options={{readOnly: true}} />
@@ -262,7 +263,7 @@ export class Run extends React.Component {
                 response.blob().then(blob => {
                   let imageUrl = URL.createObjectURL(blob);
                   artifactTabs.push(
-                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={FileImageIcon} text={artifact.filename} />}>
+                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={<FileImageIcon/>} text={artifact.filename} />}>
                       <Card>
                         <CardBody>
                           <img src={imageUrl} alt={artifact.filename}/>
@@ -523,7 +524,7 @@ export class Run extends React.Component {
           }
           {this.state.isRunValid &&
             <Tabs activeKey={this.state.activeTab} onSelect={this.onTabSelect} isBox>
-              <Tab eventKey="summary" title={<TabTitle icon={InfoCircleIcon} text="Summary" />}>
+              <Tab eventKey="summary" title={<TabTitle icon={<InfoCircleIcon/>} text="Summary" />}>
                 <Card>
                   <CardBody style={{padding: 0}} id="run-detail">
                     <Grid>
@@ -717,7 +718,7 @@ export class Run extends React.Component {
                   </CardBody>
                 </Card>
               </Tab>
-              <Tab eventKey="results-list" title={<TabTitle icon={CatalogIcon} text="Results List" />}>
+              <Tab eventKey="results-list" title={<TabTitle icon={<CatalogIcon/>} text="Results List" />}>
                 <Card className="pf-u-mt-lg">
                   <CardHeader>
                     <Flex style={{ width: '100%' }}>
@@ -747,7 +748,7 @@ export class Run extends React.Component {
                   </CardBody>
                 </Card>
               </Tab>
-              <Tab eventKey="results-tree" title={<TabTitle icon={RepositoryIcon} text="Results Tree" />}>
+              <Tab eventKey="results-tree" title={<TabTitle icon={<RepositoryIcon/>} text="Results Tree" />}>
                 <Card className="pf-u-mt-lg">
                   <CardBody>
                     <Grid gutter="sm">
@@ -784,11 +785,11 @@ export class Run extends React.Component {
                   </CardBody>
                 </Card>
               </Tab>
-              <Tab eventKey="classify-failures" title={<TabTitle icon={MessagesIcon} text="Classify Failures" />}>
+              <Tab eventKey="classify-failures" title={<TabTitle icon={<MessagesIcon/>} text="Classify Failures" />}>
                 {classificationTable}
               </Tab>
               {artifactTabs}
-              <Tab eventKey="run-object" title={<TabTitle icon={CodeIcon} text="Run Object" />}>
+              <Tab eventKey="run-object" title={<TabTitle icon={<CodeIcon/>} text="Run Object" />}>
                 <Card>
                   <CardBody>
                     <JSONTree data={run} theme={jsonViewTheme} invertTheme={jsonViewLightThemeOn} hideRoot shouldExpandNodeInitially={() => true}/>

--- a/frontend/src/views/accessibilityanalysis.js
+++ b/frontend/src/views/accessibilityanalysis.js
@@ -36,8 +36,9 @@ import {
   getSpinnerRow,
   resultToRow,
 } from '../utilities';
-import { FilterTable, TabTitle } from '../components';
+import { FilterTable } from '../components';
 import { IbutsuContext } from '../services/context';
+import TabTitle from '../components/tabs';
 const MockRun = {
   id: null,
   duration: null,
@@ -184,7 +185,7 @@ export class AccessibilityAnalysisView extends React.Component {
               if (contentType.includes('text')) {
                 response.text().then(text => {
                   artifactTabs.push(
-                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={FileAltIcon} text={artifact.filename} />} style={{backgroundColor: 'white'}}>
+                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={<FileAltIcon/>} text={artifact.filename} />} style={{backgroundColor: 'white'}}>
                       <Card>
                         <CardBody>
                           <Editor fontFamily="Hack, monospace" theme="vs-dark" value={text} height="40rem" options={{readOnly: true}} />
@@ -202,7 +203,7 @@ export class AccessibilityAnalysisView extends React.Component {
                 response.blob().then(blob => {
                   let imageUrl = URL.createObjectURL(blob);
                   artifactTabs.push(
-                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={FileImageIcon} text={artifact.filename} />} style={{backgroundColor: 'white'}}>
+                    <Tab key={artifact.id} eventKey={artifact.id} title={<TabTitle icon={<FileImageIcon/>} text={artifact.filename} />} style={{backgroundColor: 'white'}}>
                       <Card>
                         <CardBody>
                           <img src={imageUrl} alt={artifact.filename}/>
@@ -421,7 +422,7 @@ export class AccessibilityAnalysisView extends React.Component {
       <React.Fragment>
         <PageSection>
           <Tabs activeKey={this.state.activeTab} onSelect={this.onTabSelect} isBox>
-            <Tab eventKey="overview" title={<TabTitle icon={CatalogIcon} text="Overview" />} style={{backgroundColor: 'white'}}>
+            <Tab eventKey="overview" title={<TabTitle icon={<CatalogIcon/>} text="Overview" />} style={{backgroundColor: 'white'}}>
               <div style={{ height: '1000px', width: '1250px', backgroundColor: 'white' }}>
                   <ChartDonut
                     ariaDesc="Accessibility results donut chart"
@@ -464,14 +465,14 @@ export class AccessibilityAnalysisView extends React.Component {
                   />
               </div>
             </Tab>
-            <Tab eventKey="run-object" title={<TabTitle icon={CodeIcon} text="Run Object" />} style={{backgroundColor: 'white'}}>
+            <Tab eventKey="run-object" title={<TabTitle icon={<CodeIcon/>} text="Run Object" />} style={{backgroundColor: 'white'}}>
               <Card>
                 <CardBody>
                   <JSONTree data={run} theme={jsonViewTheme} invertTheme hideRoot shouldExpandNodeInitially={() => true}/>
                 </CardBody>
               </Card>
             </Tab>
-            <Tab eventKey="results-list" title={<TabTitle icon={CatalogIcon} text="Results List" />} style={{backgroundColor: 'white'}}>
+            <Tab eventKey="results-list" title={<TabTitle icon={<CatalogIcon/>} text="Results List" />} style={{backgroundColor: 'white'}}>
               <Card className="pf-u-mt-lg">
                 <CardHeader>
                   <Flex style={{ width: '100%' }}>


### PR DESCRIPTION
The Run view is rendering multiple tabs for requirements report artifacts, but this diff is not changing the tab/artifact mapping in the run component. It's only changing the icon to be passed as a react node instead of the object.

The run component will be converted in the feature branch in a separate PR, and the behavior for artifact iteration will be addressed there. 