### PR TITLE
Added logic for different keycloak auth paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.2
+  rev: v0.9.6
   hooks:
     - id: ruff
       args:

--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -118,7 +118,7 @@ WIDGET_TYPES = {
         "params": [
             {
                 "name": "filters",
-                "description": "The filters for the runs to be included" " in the query.",
+                "description": "The filters for the runs to be included in the query.",
                 "type": "string",
                 "required": True,
             },

--- a/backend/ibutsu_server/util/keycloak.py
+++ b/backend/ibutsu_server/util/keycloak.py
@@ -26,7 +26,8 @@ def get_keycloak_config(is_private=False):
         "authorization_url": build_url(realm_base_url, "protocol/openid-connect/auth"),
         "realm": realm,
         "client_id": current_app.config.get("KEYCLOAK_CLIENT_ID"),
-        "redirect_uri": backend_url + current_app.config.get("KEYCLOAK_AUTH_PATH", "/login/auth/keycloak")
+        "redirect_uri": backend_url
+        + current_app.config.get("KEYCLOAK_AUTH_PATH", "/login/auth/keycloak"),
     }
     if current_app.config.get("KEYCLOAK_ICON"):
         config["icon"] = current_app.config["KEYCLOAK_ICON"]

--- a/backend/ibutsu_server/util/keycloak.py
+++ b/backend/ibutsu_server/util/keycloak.py
@@ -26,14 +26,12 @@ def get_keycloak_config(is_private=False):
         "authorization_url": build_url(realm_base_url, "protocol/openid-connect/auth"),
         "realm": realm,
         "client_id": current_app.config.get("KEYCLOAK_CLIENT_ID"),
-        "redirect_uri": backend_url + "/login/auth/keycloak",
+        "redirect_uri": backend_url + current_app.config.get("KEYCLOAK_AUTH_PATH", "/login/auth/keycloak")
     }
     if current_app.config.get("KEYCLOAK_ICON"):
         config["icon"] = current_app.config["KEYCLOAK_ICON"]
     if current_app.config.get("KEYCLOAK_NAME"):
         config["display_name"] = current_app.config["KEYCLOAK_NAME"]
-    if current_app.config.get("KEYCLOAK_AUTH_PATH"):
-        config["redirect_uri"] = backend_url + current_app.config["KEYCLOAK_AUTH_PATH"]
     if current_app.config.get("KEYCLOAK_VERIFY_SSL"):
         config["verify_ssl"] = current_app.config["KEYCLOAK_VERIFY_SSL"].lower()[0] in [
             "y",

--- a/backend/ibutsu_server/util/keycloak.py
+++ b/backend/ibutsu_server/util/keycloak.py
@@ -32,6 +32,8 @@ def get_keycloak_config(is_private=False):
         config["icon"] = current_app.config["KEYCLOAK_ICON"]
     if current_app.config.get("KEYCLOAK_NAME"):
         config["display_name"] = current_app.config["KEYCLOAK_NAME"]
+    if current_app.config.get("KEYCLOAK_AUTH_PATH"):
+        config["redirect_uri"] = backend_url + current_app.config["KEYCLOAK_AUTH_PATH"]
     if current_app.config.get("KEYCLOAK_VERIFY_SSL"):
         config["verify_ssl"] = current_app.config["KEYCLOAK_VERIFY_SSL"].lower()[0] in [
             "y",

--- a/frontend/src/services/keycloak.js
+++ b/frontend/src/services/keycloak.js
@@ -6,6 +6,6 @@ export class KeycloakService {
   static login(url, realm, client_id) {
     const keycloakInstance = new Keycloak({url: url, realm: realm, clientId: client_id});
     keycloakInstance.init({onLoad: 'login-required', checkLoginIframe: false, responseMode: 'query',
-                           redirectUri: Settings.serverUrl + '/login/auth/keycloak'});
+       redirectUri: Settings.keycloakAuthPath ? Settings.serverUrl + Settings.keycloakAuthPath : Settings.serverUrl  + '/login/auth/keycloak'});
   }
 }

--- a/frontend/src/services/keycloak.js
+++ b/frontend/src/services/keycloak.js
@@ -6,6 +6,6 @@ export class KeycloakService {
   static login(url, realm, client_id) {
     const keycloakInstance = new Keycloak({url: url, realm: realm, clientId: client_id});
     keycloakInstance.init({onLoad: 'login-required', checkLoginIframe: false, responseMode: 'query',
-       redirectUri: Settings.keycloakAuthPath ? Settings.serverUrl + Settings.keycloakAuthPath : Settings.serverUrl  + '/login/auth/keycloak'});
+       redirectUri: Settings.serverUrl + (Settings.keycloakAuthPath || '/login/auth/keycloak') });
   }
 }


### PR DESCRIPTION
In the itless environment, the Keycloak authentication instance was upgraded.  In this upgrade the "/auth" endpoint was deprecated.  This logic keeps the existing logic with the hardcoded "login/auth/keycloak" endpoint, but also adds in the availability to overwrite that by using the keycloakAuthPath (in the frontend) and KEYCLOAK_AUTH_PATH (foir backend) environment variables.