### PR TITLE
Modified keycloak auth path logic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.6
+  rev: v0.9.9
   hooks:
     - id: ruff
       args:

--- a/backend/ibutsu_server/test/__init__.py
+++ b/backend/ibutsu_server/test/__init__.py
@@ -49,6 +49,7 @@ class BaseTestCase(TestCase):
             "JWT_SECRET": "89807erkjhdfgu768dfsgdsfg345r",
             "KEYCLOAK_BASE_URL": None,
             "KEYCLOAK_CLIENT_ID": None,
+            "KEYCLOAK_AUTH_PATH": "auth",
         }
         app = get_app(**extra_config)
         create_celery_app(app)

--- a/backend/ibutsu_server/util/keycloak.py
+++ b/backend/ibutsu_server/util/keycloak.py
@@ -17,8 +17,8 @@ def get_keycloak_config(is_private=False):
     if not backend_url.endswith("/api"):
         backend_url += "/api"
     server_url = current_app.config["KEYCLOAK_BASE_URL"]
-    if not server_url.endswith("auth"):
-        server_url = build_url(server_url, "auth")
+    if current_app.config.get("KEYCLOAK_AUTH_PATH"):
+        server_url = build_url(server_url, current_app.config.get("KEYCLOAK_AUTH_PATH"))
     realm = current_app.config.get("KEYCLOAK_REALM")
     realm_base_url = build_url(server_url, "realms", realm)
     config = {
@@ -26,8 +26,7 @@ def get_keycloak_config(is_private=False):
         "authorization_url": build_url(realm_base_url, "protocol/openid-connect/auth"),
         "realm": realm,
         "client_id": current_app.config.get("KEYCLOAK_CLIENT_ID"),
-        "redirect_uri": backend_url
-        + current_app.config.get("KEYCLOAK_AUTH_PATH", "/login/auth/keycloak"),
+        "redirect_uri": backend_url + "/login/auth/keycloak",
     }
     if current_app.config.get("KEYCLOAK_ICON"):
         config["icon"] = current_app.config["KEYCLOAK_ICON"]

--- a/frontend/src/services/keycloak.js
+++ b/frontend/src/services/keycloak.js
@@ -6,6 +6,6 @@ export class KeycloakService {
   static login(url, realm, client_id) {
     const keycloakInstance = new Keycloak({url: url, realm: realm, clientId: client_id});
     keycloakInstance.init({onLoad: 'login-required', checkLoginIframe: false, responseMode: 'query',
-       redirectUri: Settings.serverUrl + (Settings.keycloakAuthPath || '/login/auth/keycloak') });
+       redirectUri: Settings.serverUrl + '/login/auth/keycloak' });
   }
 }


### PR DESCRIPTION
Redid the keycloak auth logic.  Originally I was changing the internal keycloak authentication path that Ibutsu itself uses.  Whereas in the updated version of keycloak, the auth path used to Keycloak itself has been updated. Additionally removed references to keycloak auth path for the frontend deployment because that is not needed.