### PR TITLE
Convert RunList to functional

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -7,7 +7,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 
 import Dashboard from './dashboard';
 import ReportBuilder from './report-builder';
-import { RunList } from './run-list';
+import RunList from './run-list';
 import { Run } from './run';
 import { ResultList } from './result-list';
 import { Result } from './result';

--- a/frontend/src/run-list.js
+++ b/frontend/src/run-list.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useContext, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -21,7 +21,7 @@ import {
 } from '@patternfly/react-core';
 import { ChevronRightIcon, TimesIcon } from '@patternfly/react-icons';
 
-import { Link } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { HttpClient } from './services/http';
 import { Settings } from './settings';
@@ -32,7 +32,6 @@ import {
   getOperationMode,
   getOperationsFromField,
   getSpinnerRow,
-  parseFilter,
   round
 } from './utilities';
 
@@ -44,7 +43,7 @@ import { OPERATIONS, RUN_FIELDS } from './constants';
 import { IbutsuContext } from './services/context';
 
 
-function runToRow (run, filterFunc) {
+const runToRow = (run, filterFunc) => {
   let badges = [];
   let created = 0;
   let componentBadge;
@@ -86,519 +85,385 @@ function runToRow (run, filterFunc) {
       {title: <Link to={`../results?run_id=${run.id}`} relative="Path">See results <ChevronRightIcon /></Link>}
     ]
   };
-}
+};
 
-export class RunList extends React.Component {
-  static contextType = IbutsuContext;
+const COLUMNS = ['Run', 'Duration', 'Summary', 'Started', ''];
 
-  static propTypes = {
-    location: PropTypes.object,
-    navigate: PropTypes.func,
-    eventEmitter: PropTypes.object,
-    params: PropTypes.object,
-  };
+const RunList = () => {
+  const navigate = useNavigate();
+  const params = useParams();
 
-  constructor (props) {
-    super(props);
-    const params = new URLSearchParams(props.location.search);
-    let page = 1, pageSize = 20, filters = {};
-    if (params.toString() !== '') {
-      for(let pair of params) {
-        if (pair[0] === 'page') {
-          page = parseInt(pair[1]);
-        }
-        else if (pair[0] === 'pageSize') {
-          pageSize = parseInt(pair[1]);
-        }
-        else {
-          const combo = parseFilter(pair[0]);
-          filters[combo['key']] = {
-            'op': combo['op'],
-            'val': pair[1]
-          };
-        }
+  const { primaryObject } = useContext(IbutsuContext);
+
+  const [rows, setRows] = useState([getSpinnerRow(5)]);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [totalItems, setTotalItems] = useState(0);
+
+  const [filters, setFilters] = useState({});
+
+  const [fieldSelection, setFieldSelection] = useState(null);
+  const [filteredFieldOptions, setFilteredFieldOptions] = useState(RUN_FIELDS);
+  const [fieldOptions] = useState(RUN_FIELDS);
+  const [fieldInputValue, setFieldInputValue] = useState('');
+  const [fieldFilterValue, setFieldFilterValue] = useState('');
+  const [isFieldOpen, setIsFieldOpen] = useState(false);
+
+  const [operationSelection, setOperationSelection] = useState('eq');
+  const [isOperationOpen, setIsOperationOpen] = useState(false);
+
+  const [textFilter, setTextFilter] = useState('');
+
+  const [isError, setIsError] = useState(false);
+  const [inValues, setInValues] = useState([]);
+  const [boolSelection, setBoolSelection] = useState(null);
+  const [isBoolOpen, setIsBoolOpen] = useState(false);
+
+  const updateFilters = useCallback((name, operator, value, callback) => {
+    setFilters(prev => {
+      const newFilters = { ...prev };
+      if (!value) {
+        delete newFilters[name];
+      } else {
+        newFilters[name] = { 'op': operator, 'val': value };
       }
-    }
-    this.state = {
-      columns: ['Run', 'Duration', 'Summary', 'Started', ''],
-      rows: [getSpinnerRow(5)],
-      page: page,
-      pageSize: pageSize,
-      totalItems: 0,
-      totalPages: 0,
-      filters: filters,
-      fieldSelection: null,
-      filteredFieldOptions: RUN_FIELDS,
-      fieldOptions: RUN_FIELDS,
-      fieldInputValue: '',
-      fieldFilterValue: '',
-      isFieldOpen: false,
-      operationSelection: 'eq',
-      isOperationOpen: false,
-      textFilter: '',
-      isError: false,
-      isEmpty: false,
-      inValues: [],
-      boolSelection: null,
-      isBoolOpen: false,
-    };
-    this.params = new URLSearchParams(props.location.search);
-    props.eventEmitter.on('projectChange', (value) => {
-      this.getRuns(value);
+      return newFilters;
     });
-  }
+    setPage(1);
+    callback();
+  }, []);
 
-  applyReport = () => {
-    this.props.navigate('/project/' + this.props.params.project_id + '/reports?' + buildParams(this.state.filters).join('&'));
-  };
-
-  onFieldToggle = () => {
-    this.setState({isFieldOpen: !this.state.isFieldOpen});
-  };
-
-  onFieldSelect = (_event, selection) => {
-    const fieldFilterValue = this.state.fieldFilterValue;
-    if (selection == `Create "${fieldFilterValue}"`) {
-      this.setState({
-        filteredFieldOptions: [...this.state.fieldOptions, fieldFilterValue],
-        fieldSelection: fieldFilterValue,
-        fieldInputValue: fieldFilterValue,
-        operationSelection: 'eq',
-      });
-    }
-    else {
-      this.setState({
-        fieldSelection: selection,
-        fieldInputValue: selection,
-        isFieldOpen: false,
-        operationSelection: 'eq',
-      });
-    }
-  };
-
-  onFieldTextInputChange = (_event, value) => {
-    this.setState({fieldInputValue: value});
-    this.setState({fieldFilterValue: value});
-  };
-
-  onFieldClear = () => {
-    this.setState({
-      fieldSelection: null,
-      fieldFilterValue: '',
-      fieldInputValue: '',
-    });
-  };
-
-  onFieldCreate = newValue => {
-    this.setState({filteredFieldOptions: [...this.state.filteredFieldOptions, newValue]});
-  };
-
-  onOperationToggle = () => {
-    this.setState({isOperationOpen: !this.state.isOperationOpen});
-  };
-
-  onOperationSelect = (event, selection) => {
-    this.setState({
-      operationSelection: selection,
-      isOperationOpen: false,
-      isMultiSelect: selection === 'in',
-    });
-  };
-
-  onOperationClear = () => {
-    this.setState({
-      operationSelection: null,
-      isOperationOpen: false
-    });
-  };
-
-  onTextChanged = newValue => {
-    this.setState({textFilter: newValue});
-  };
-
-  onInValuesChange = (values) => {
-    this.setState({inValues: values});
-  };
-
-  onBoolSelect = (event, selection) => {
-    this.setState({
-      boolSelection: selection,
-      isBoolOpen: false
-    });
-  };
-
-  onBoolToggle = () => {
-    this.setState({isBoolOpen: !this.state.isBoolOpen});
-  };
-
-  onBoolClear = () => {
-    this.setState({
-      boolSelection: null,
-      isBoolOpen: false
-    });
-  };
-
-  applyFilter = () => {
-    const field = this.state.fieldSelection;
-    const operator = this.state.operationSelection;
+  const applyFilter = useCallback(() => {
+    const field = fieldSelection;
+    const operator = operationSelection;
     const operationMode = getOperationMode(operator);
-    let value = this.state.textFilter.trim();
+    let value = textFilter.trim();
     if (operationMode === 'multi') {
-      // translate list to ;-separated string for BE
-      value = this.state.inValues.map(item => item.trim()).join(';');
+      value = inValues.map(item => item.trim()).join(';');
+    } else if (operationMode === 'bool') {
+      value = boolSelection;
     }
-    else if (operationMode === 'bool') {
-      value = this.state.boolSelection;
-    }
-    this.updateFilters(field, operator, value, () => {
-      this.updateUrl();
-      this.getRuns();
-      this.setState({
-        fieldSelection: null,
-        fieldInputValue: '',
-        fieldFilterValue: '',
-        operationSelection: 'eq',
-        textFilter: '',
-        inValues: [],
-        boolSelection: null,
-      });
+    updateFilters(field, operator, value, () => {
+      setFieldSelection(null);
+      setFieldInputValue('');
+      setFieldFilterValue('');
+      setOperationSelection('eq');
+      setTextFilter('');
+      setInValues([]);
+      setBoolSelection(null);
     });
-  };
+  }, [fieldSelection, operationSelection, textFilter, updateFilters, inValues, boolSelection]);
 
-  updateFilters (name, operator, value, callback) {
-    let filters = this.state.filters;
-    if (!value) {
-      delete filters[name];
-    }
-    else {
-      filters[name] = {'op': operator, 'val': value};
-    }
-    this.setState({filters: filters, page: 1}, callback);
-  }
-
-  setFilter = (field, value) => {
-    this.updateFilters(field, 'eq', value, () => {
-      this.updateUrl();
-      this.getRuns();
-      this.setState({
-        fieldSelection: null,
-        operationSelection: 'eq',
-        textFilter: '',
-        boolSelection: null,
-        inValues: []
-      });
+  const setFilter = useCallback((field, value) => {
+    updateFilters(field, 'eq', value, () => {
+      setFieldSelection(null);
+      setOperationSelection('eq');
+      setTextFilter('');
+      setBoolSelection(null);
+      setInValues([]);
     });
-  };
+  }, [updateFilters]);
 
-  removeFilter = id => {
-    this.updateFilters(id, null, null, () => {
-      this.updateUrl();
-      this.setState({page: 1}, this.getRuns);
-    });
-  };
+  const removeFilter = useCallback(id => {
+    updateFilters(id, null, null, () => {});
+  }, [updateFilters]);
 
-  updateUrl () {
-    let params = buildParams(this.state.filters);
-    params.push('page=' + this.state.page);
-    params.push('pageSize=' + this.state.pageSize);
-    this.props.navigate('?' + params.join('&'));
-  }
-
-  setPage = (_event, pageNumber) => {
-    this.setState({page: pageNumber}, () => {
-      this.updateUrl();
-      this.getRuns();
-    });
-  };
-
-  setPageSize = (_event, perPage) => {
-    this.setState({pageSize: perPage}, () => {
-      this.updateUrl();
-      this.getRuns();
-    });
-  };
-
-  getRuns = (handledOject = null) => {
-    // First, show a spinner
-    this.setState({rows: [getSpinnerRow(5)], isEmpty: false, isError: false});
-    let params = {filter: []};
-    let filters = this.state.filters;
-    const { primaryObject } = this.context;
-    const targetObject = handledOject ?? primaryObject;
-    if (targetObject) {
-      filters['project_id'] = {'val': targetObject.id, 'op': 'eq'};
+  useEffect(() => {
+    setIsError(false);
+    const apiParams = { filter: [] };
+    const apiFilters = {...filters};
+    if (primaryObject) {
+      apiFilters['project_id'] = { 'val': primaryObject.id, 'op': 'eq' };
+    } else if (Object.prototype.hasOwnProperty.call(apiFilters, 'project_id')) {
+      delete apiFilters['project_id'];
     }
-    else if (Object.prototype.hasOwnProperty.call(filters, 'project_id')) {
-      delete filters['project_id'];
-    }
-    params['estimate'] = true;
-    params['pageSize'] = this.state.pageSize;
-    params['page'] = this.state.page;
-    // Convert UI filters to API filters
-    for (let key in filters) {
-      if (Object.prototype.hasOwnProperty.call(filters, key) && !!filters[key]) {
-        const val = filters[key]['val'];
-        const op = OPERATIONS[filters[key]['op']];
-        params.filter.push(key + op + val);
+    apiParams['estimate'] = true;
+    apiParams['pageSize'] = pageSize;
+    apiParams['page'] = page;
+    for (let key in apiFilters) {
+      if (Object.prototype.hasOwnProperty.call(apiFilters, key) && !!apiFilters[key]) {
+        const val = apiFilters[key]['val'];
+        const op = OPERATIONS[apiFilters[key]['op']];
+        apiParams.filter.push(key + op + val);
       }
     }
-    HttpClient.get([Settings.serverUrl, 'run'], params)
+    HttpClient.get([Settings.serverUrl, 'run'], apiParams)
       .then(response => HttpClient.handleResponse(response))
-      .then(data => this.setState({
-        rows: data.runs.map((run) => runToRow(run, this.setFilter)),
-        page: data.pagination.page,
-        pageSize: data.pagination.pageSize,
-        totalItems: data.pagination.totalItems,
-        totalPages: data.pagination.totalPages,
-        isEmpty: data.pagination.totalItems === 0
-      }))
+      .then(data => {
+        setRows(data.runs.map((run) => runToRow(run, setFilter)));
+        setPage(data.pagination.page);
+        setPageSize(data.pagination.pageSize);
+        setTotalItems(data.pagination.totalItems);
+      })
       .catch((error) => {
         console.error('Error fetching run data:', error);
-        this.setState({rows: [], isEmpty: false, isError: true});
+        setRows([]);
+        setIsError(true);
       });
-  };
+  }, [pageSize, page, primaryObject, setFilter, filters, boolSelection]);
 
-  clearFilters = () => {
-    this.setState({
-      filters: [],
-      page: 1,
-      pageSize: 20,
-      fieldSelection: null,
-      operationSelection: 'eq',
-      textFilter: '',
-      inValues: [],
-      boolSelection: null,
-    });
-    this.updateUrl();
-  };
-
-  componentDidMount () {
-    this.getRuns();
-  }
-
-  componentDidUpdate (prevProps, prevState) {
-    if (
-      prevState.fieldFilterValue !== this.state.fieldFilterValue
-    ) {
-      let newSelectOptionsField = this.state.fieldOptions;
-      if (this.state.fieldInputValue) {
-        newSelectOptionsField = this.state.fieldOptions.filter(menuItem =>
-          menuItem.toLowerCase().includes(this.state.fieldFilterValue.toLowerCase())
-        );
-        if (newSelectOptionsField.length !== 1 && !newSelectOptionsField.includes(this.state.fieldFilterValue) ) {
-          newSelectOptionsField.push(`Create "${this.state.fieldFilterValue}"`);
-        }
-
-        if (!this.state.isFieldOpen) {
-          this.setState({ isFieldOpen: true });
-        }
-      }
-
-      this.setState({
-        filteredFieldOptions: newSelectOptionsField,
-      });
+  const onFieldSelect = useCallback((_, selection) => {
+    if (selection === `Create "${fieldFilterValue}"`) {
+      setFilteredFieldOptions(prev => [...prev, fieldFilterValue]);
+      setFieldSelection(fieldFilterValue);
+      setFieldInputValue(fieldFilterValue);
+      setOperationSelection('eq');
+    } else {
+      setFieldSelection(selection);
+      setFieldInputValue(selection);
     }
-  }
 
-  render () {
-    document.title = 'Test Runs | Ibutsu';
-    const {
-      columns,
-      rows,
-      fieldSelection,
-      isFieldOpen,
-      filteredFieldOptions,
-      fieldInputValue,
-      isOperationOpen,
-      operationSelection,
-      textFilter,
-      boolSelection,
-      isBoolOpen,
-    } = this.state;
-    const filterMode = getFilterMode(fieldSelection);
-    const operationMode = getOperationMode(operationSelection);
-    const operations = getOperationsFromField(fieldSelection);
+    setIsFieldOpen(false);
+    setOperationSelection('eq');
+  }, [fieldFilterValue]);
 
-    const fieldToggle = toggleRef => (
-      <MenuToggle
-        variant="typeahead"
-        aria-label="Typeahead creatable menu toggle"
-        onClick={this.onFieldToggle}
-        isExpanded={this.state.isFieldOpen}
-        isFullWidth
-        innerRef={toggleRef}
-      >
-        <TextInputGroup isPlain>
-          <TextInputGroupMain
-            value={fieldInputValue}
-            onClick={this.onFieldToggle}
-            onChange={this.onFieldTextInputChange}
-            id="create-typeahead-select-input"
-            autoComplete="off"
-            placeholder="Select a field"
-            role="combobox"
-            isExpanded={this.state.isFieldOpen}
-            aria-controls="select-create-typeahead-listbox"
-          />
-          <TextInputGroupUtilities>
-            {!!fieldInputValue && (
-              <Button
-                variant="plain"
-                onClick={() => {this.onFieldClear();}}
-                aria-label="Clear input value"
-              >
-                <TimesIcon aria-hidden />
-              </Button>
-            )}
-          </TextInputGroupUtilities>
-        </TextInputGroup>
-      </MenuToggle>
-    );
+  const onFieldTextInputChange = useCallback((_, value) => {
+    setFieldInputValue(value);
+    setFieldFilterValue(value);
+  }, []);
 
-    const operationToggle = toggleRef => (
-      <MenuToggle
-        onClick={this.onOperationToggle}
-        isExpanded={isOperationOpen}
-        isFullWidth
-        ref={toggleRef}
-      >
-        {this.state.operationSelection}
-      </MenuToggle>
-    );
+  const onFieldClear = useCallback(() => {
+    setFieldSelection(null);
+    setFieldFilterValue('');
+    setFieldInputValue('');
+  }, []);
 
-    const boolToggle = toggleRef => (
-      <MenuToggle
-        onClick={this.onBoolToggle}
-        isExpanded={isBoolOpen}
-        isFullWidth
-        ref={toggleRef}
-        style={{maxHeight: '36px'}}
-      >
-        <TextInputGroup isPlain>
-          <TextInputGroupMain
-            value={boolSelection}
-            onClick={this.onBoolToggle}
-            autoComplete="off"
-            placeholder="Select True/False"
-            role="combobox"
-            isExpanded={isBoolOpen}
-          />
-          <TextInputGroupUtilities>
-            {!!boolSelection && (
-              <Button variant="plain" onClick={() => {
-                this.onBoolClear();
-              }} aria-label="Clear input value">
-                <TimesIcon aria-hidden />
-              </Button>
-            )}
-          </TextInputGroupUtilities>
-        </TextInputGroup>
-      </MenuToggle>
-    );
+  const onOperationSelect = useCallback((event, selection) => {
+    setOperationSelection(selection);
+    setIsOperationOpen(false);
+  }, []);
 
-    const filters = [
-      <Select
-        id="typeahead-select"
-        selected={fieldSelection}
-        isOpen={isFieldOpen}
-        onSelect={this.onFieldSelect}
-        key="field"
-        onOpenChange={() => this.setState({isFieldOpen: false})}
-        toggle={fieldToggle}
-      >
-        <SelectList id="select-typeahead-listbox">
-          {filteredFieldOptions.map((option, index) => (
-            <SelectOption key={index} value={option}>
-              {option}
-            </SelectOption>
-          ))}
-        </SelectList>
-      </Select>,
-      <Select
-        id="single-select"
-        isOpen={isOperationOpen}
-        selected={operationSelection}
-        onSelect={this.onOperationSelect}
-        onOpenChange={() => this.setState({isOperationOpen: false})}
-        key="operation"
-        toggle={operationToggle}
-      >
-        <SelectList>
-          {Object.keys(operations).map((option, index) => (
-            <SelectOption key={index} value={option}>
-              {option}
-            </SelectOption>
-          ))}
-        </SelectList>
-      </Select>,
-      <React.Fragment key="value">
-        {(operationMode === 'bool') &&
-          <Select
-            id="single-select"
-            isOpen={isBoolOpen}
-            selected={boolSelection}
-            onSelect={this.onBoolSelect}
-            onOpenChange={() => this.setState({isBoolOpen: false})}
-            toggle={boolToggle}
-          >
-            <SelectList>
-              {['True', 'False'].map((option, index) => (
-                <SelectOption key={index} value={option}>
-                  {option}
-                </SelectOption>
-              ))}
-            </SelectList>
-          </Select>
-        }
-        {(filterMode === 'text' && operationMode === 'single') &&
-          <TextInput type="text" id="textSelection" placeholder="Type in value" value={textFilter || ''} onChange={(_event, newValue) => this.onTextChanged(newValue)} style={{height: 'inherit'}}/>
-        }
-        {(operationMode === 'multi') &&
-          <MultiValueInput onValuesChange={this.onInValuesChange} style={{height: 'inherit'}}/>
-        }
-      </React.Fragment>
-    ];
-    const pagination = {
-      pageSize: this.state.pageSize,
-      page: this.state.page,
-      totalItems: this.state.totalItems
-    };
-    return (
-      <React.Fragment>
-        <PageSection id="page" variant={PageSectionVariants.light}>
-          <TextContent>
-            <Text className="title" component="h1">Test runs</Text>
-          </TextContent>
-        </PageSection>
-        <PageSection>
-          <Card>
-            <CardBody className="pf-u-p-0">
-              <FilterTable
-                columns={columns}
-                rows={rows}
-                filters={filters}
-                activeFilters={this.state.filters}
-                pagination={pagination}
-                isEmpty={this.state.isEmpty}
-                isError={this.state.isError}
-                onApplyFilter={this.applyFilter}
-                onRemoveFilter={this.removeFilter}
-                onClearFilters={this.clearFilters}
-                onApplyReport={this.applyReport}
-                onSetPage={this.setPage}
-                onSetPageSize={this.setPageSize}
-                hideFilters={['project_id']}
-              />
-            </CardBody>
-            <CardFooter>
-              <Text className="disclaimer" component="h4">
-                * Note: for performance reasons, the total number of items is an approximation.
-                Use the API with &lsquo;estimate=false&rsquo; if you need an accurate count.
-              </Text>
-            </CardFooter>
-          </Card>
-        </PageSection>
-      </React.Fragment>
-    );
-  }
-}
+  const onBoolSelect = useCallback((event, selection) => {
+    setBoolSelection(selection);
+    setIsBoolOpen(false);
+  }, []);
+
+  const onBoolClear = useCallback(() => {
+    setBoolSelection(null);
+    setIsBoolOpen(false);
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setFilters({});
+    setPage(1);
+    setPageSize(20);
+    setFieldSelection(null);
+    setOperationSelection('eq');
+    setTextFilter('');
+    setInValues([]);
+    setBoolSelection(null);
+  }, []);
+
+  useEffect(() => {
+    let newSelectOptionsField = fieldOptions;
+    if (fieldInputValue) {
+      newSelectOptionsField = fieldOptions.filter(menuItem =>
+        menuItem.toLowerCase().includes(fieldFilterValue.toLowerCase())
+      );
+      if (newSelectOptionsField.length !== 1 && !newSelectOptionsField.includes(fieldFilterValue)) {
+        newSelectOptionsField.push(`Create "${fieldFilterValue}"`);
+      }
+    }
+    setFilteredFieldOptions(newSelectOptionsField);
+  }, [fieldFilterValue, fieldInputValue, fieldOptions, isFieldOpen]);
+
+  document.title = 'Test Runs | Ibutsu';
+  const filterMode = getFilterMode(fieldSelection);
+  const operationMode = getOperationMode(operationSelection);
+  const operations = getOperationsFromField(fieldSelection);
+
+  const fieldToggle = useCallback(toggleRef => (
+    <MenuToggle
+      variant="typeahead"
+      aria-label="Typeahead creatable menu toggle"
+      onClick={() => setIsFieldOpen(!isFieldOpen)}
+      isExpanded={isFieldOpen}
+      isFullWidth
+      innerRef={toggleRef}
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={fieldInputValue}
+          onClick={() => setIsFieldOpen(!isFieldOpen)}
+          onChange={onFieldTextInputChange}
+          id="create-typeahead-select-input"
+          autoComplete="off"
+          placeholder="Select a field"
+          role="combobox"
+          isExpanded={isFieldOpen}
+          aria-controls="select-create-typeahead-listbox"
+        />
+        <TextInputGroupUtilities>
+          {!!fieldInputValue && (
+            <Button
+              variant="plain"
+              onClick={onFieldClear}
+              aria-label="Clear input value"
+            >
+              <TimesIcon aria-hidden />
+            </Button>
+          )}
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  ), [fieldInputValue, isFieldOpen, onFieldClear, onFieldTextInputChange]);
+
+  const operationToggle = useCallback(toggleRef => (
+    <MenuToggle
+      onClick={() => setIsOperationOpen(!isOperationOpen)}
+      isExpanded={isOperationOpen}
+      isFullWidth
+      ref={toggleRef}
+    >
+      {operationSelection}
+    </MenuToggle>
+  ), [isOperationOpen, operationSelection]);
+
+  const boolToggle = useCallback(toggleRef => (
+    <MenuToggle
+      onClick={() => setIsBoolOpen(!isBoolOpen)}
+      isExpanded={isBoolOpen}
+      isFullWidth
+      ref={toggleRef}
+      style={{ maxHeight: '36px' }}
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={boolSelection}
+          onClick={() => setIsBoolOpen(!isBoolOpen)}
+          autoComplete="off"
+          placeholder="Select True/False"
+          role="combobox"
+          isExpanded={isBoolOpen}
+        />
+        <TextInputGroupUtilities>
+          {!!boolSelection && (
+            <Button variant="plain" onClick={onBoolClear} aria-label="Clear input value">
+              <TimesIcon aria-hidden />
+            </Button>
+          )}
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  ), [boolSelection, isBoolOpen, onBoolClear]);
+
+  const filtersComponents = useMemo(() => [
+    <Select
+      id="typeahead-select"
+      selected={fieldSelection}
+      isOpen={isFieldOpen}
+      onSelect={onFieldSelect}
+      key="field"
+      onOpenChange={() => setIsFieldOpen(false)}
+      toggle={fieldToggle}
+    >
+      <SelectList id="select-typeahead-listbox">
+        {filteredFieldOptions.map((option, index) => (
+          <SelectOption key={index} value={option}>
+            {option}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>,
+    <Select
+      id="single-select"
+      isOpen={isOperationOpen}
+      selected={operationSelection}
+      onSelect={onOperationSelect}
+      onOpenChange={() => setIsOperationOpen(false)}
+      key="operation"
+      toggle={operationToggle}
+    >
+      <SelectList>
+        {Object.keys(operations).map((option, index) => (
+          <SelectOption key={index} value={option}>
+            {option}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>,
+    <React.Fragment key="value">
+      {(operationMode === 'bool') &&
+        <Select
+          id="single-select"
+          isOpen={isBoolOpen}
+          selected={boolSelection}
+          onSelect={onBoolSelect}
+          onOpenChange={() => setIsBoolOpen(false)}
+          toggle={boolToggle}
+        >
+          <SelectList>
+            {['True', 'False'].map((option, index) => (
+              <SelectOption key={index} value={option}>
+                {option}
+              </SelectOption>
+            ))}
+          </SelectList>
+        </Select>
+      }
+      {(filterMode === 'text' && operationMode === 'single') &&
+        <TextInput
+          type="text"
+          id="textSelection"
+          placeholder="Type in value"
+          value={textFilter}
+          onChange={(_, newValue) => setTextFilter(newValue)} style={{ height: 'inherit' }} />
+      }
+      {(operationMode === 'multi') &&
+        <MultiValueInput onValuesChange={(values) => setInValues(values)} style={{ height: 'inherit' }} />
+      }
+    </React.Fragment>
+  ], [fieldSelection, isFieldOpen, onFieldSelect, fieldToggle, filteredFieldOptions, isOperationOpen, operationSelection, onOperationSelect, operationToggle, operations, operationMode, isBoolOpen, boolSelection, onBoolSelect, boolToggle, filterMode, textFilter]);
+
+  const pagination = useMemo(() => ({
+    pageSize: pageSize,
+    page: page,
+    totalItems: totalItems
+  }), [pageSize, page, totalItems]);
+
+  return (
+    <React.Fragment>
+      <PageSection id="page" variant={PageSectionVariants.light}>
+        <TextContent>
+          <Text className="title" component="h1">Test runs</Text>
+        </TextContent>
+      </PageSection>
+      <PageSection>
+        <Card>
+          <CardBody className="pf-u-p-0">
+            <FilterTable
+              columns={COLUMNS}
+              rows={rows}
+              filters={filtersComponents}
+              activeFilters={filters}
+              pagination={pagination}
+              isEmpty={rows.length === 0}
+              isError={isError}
+              onApplyFilter={applyFilter}
+              onRemoveFilter={removeFilter}
+              onClearFilters={clearFilters}
+              onApplyReport={() => navigate('/project/' + params.project_id + '/reports?' + buildParams(filters).join('&'))}
+              onSetPage={setPage}
+              onSetPageSize={setPageSize}
+              hideFilters={['project_id']}
+            />
+          </CardBody>
+          <CardFooter>
+            <Text className="disclaimer" component="h4">
+              * Note: for performance reasons, the total number of items is an approximation.
+              Use the API with &lsquo;estimate=false&rsquo; if you need an accurate count.
+            </Text>
+          </CardFooter>
+        </Card>
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+RunList.propTypes = {
+  location: PropTypes.object,
+  navigate: PropTypes.func,
+  params: PropTypes.object,
+};
+
+export default RunList;


### PR DESCRIPTION
Use callbacks and effects for page behavior, flatten some element functions.

Remove search param connection to pagination and filtering, it's triggering re-renders and was removed from similar components.

It should be reintroduced with the PF6 upgrade

## Summary by Sourcery

Refactors the RunList component to a functional component using hooks for state management and effects for data fetching and updates. Removes the direct connection between search parameters and pagination/filtering to prevent unnecessary re-renders, with plans to reintroduce this functionality in a future upgrade.

Enhancements:
- Converts the RunList component to a functional component using React hooks.
- Improves performance by removing search param connection to pagination and filtering.