### PR TITLE
fix(IQE-3448): Show loading state when accessing the Run's details page

### DIFF
--- a/frontend/src/result.js
+++ b/frontend/src/result.js
@@ -4,7 +4,8 @@ import {
   PageSection,
   PageSectionVariants,
   TextContent,
-  Text
+  Text,
+  Skeleton
 } from '@patternfly/react-core';
 
 import { HttpClient } from './services/http';
@@ -52,9 +53,13 @@ const Result = () => {
         </TextContent>
       </PageSection>
       <PageSection>
-        {isResultValid ?
-          <ResultView testResult={testResult} /> :
-          <EmptyObject headingText="Result not found" returnLink="/results" returnLinkText="Return to results list"/>}
+        {!testResult ? (
+          <Skeleton />
+        ) : (
+          isResultValid ?
+            <ResultView testResult={testResult} /> :
+            <EmptyObject headingText="Result not found" returnLink="/results" returnLinkText="Return to results list"/>
+        )}
       </PageSection>
     </React.Fragment>
   );


### PR DESCRIPTION
Adding skeleton that appears when run details are loading.
![image](https://github.com/user-attachments/assets/ee63362c-ee73-4d06-b428-a3164078f4fe)

## Summary by Sourcery

Bug Fixes:
- Display a loading state when accessing the Run's details page.