### PR TITLE
Redid removing /auth endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
 
 ## PYTHON
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -11,7 +11,7 @@ repos:
   - id: debug-statements
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.8
+  rev: v0.11.2
   hooks:
     - id: ruff
       args:
@@ -31,7 +31,7 @@ repos:
 
 ## ES
 - repo: https://github.com/pre-commit/mirrors-eslint
-  rev: v9.4.0
+  rev: v9.23.0
   hooks:
   - id: eslint
     additional_dependencies:

--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -116,7 +116,7 @@ WIDGET_TYPES = {
         "params": [
             {
                 "name": "filters",
-                "description": "The filters for the runs to be included" " in the query.",
+                "description": "The filters for the runs to be included in the query.",
                 "type": "string",
                 "required": True,
             },

--- a/backend/ibutsu_server/util/keycloak.py
+++ b/backend/ibutsu_server/util/keycloak.py
@@ -17,8 +17,12 @@ def get_keycloak_config(is_private=False):
     if not backend_url.endswith("/api"):
         backend_url += "/api"
     server_url = current_app.config["KEYCLOAK_BASE_URL"]
-    if not server_url.endswith("auth"):
-        server_url = build_url(server_url, "auth")
+<<<<<<< HEAD
+    # if not server_url.endswith("auth"):
+=======
+    #if not server_url.endswith("auth"):
+>>>>>>> 2ff9f1a (Redid removing /auth endpoint)
+    #    server_url = build_url(server_url, "auth")
     realm = current_app.config.get("KEYCLOAK_REALM")
     realm_base_url = build_url(server_url, "realms", realm)
     config = {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Removes the addition of `/auth` to the Keycloak base URL.