### PR TITLE
fix(IQE-3462): Add skeleton loading to the edit widget modal

### DIFF
--- a/frontend/src/components/edit-widget-modal.js
+++ b/frontend/src/components/edit-widget-modal.js
@@ -10,6 +10,7 @@ import {
   HelperTextItem,
   Modal,
   ModalVariant,
+  Skeleton,
   TextInput,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
@@ -127,31 +128,38 @@ const EditWidgetModal = ({ onSave, onClose, isOpen, data }) => {
         <Button key="cancel" variant="link" onClick={onCloseModal}>Cancel</Button>
       ]}
     >
-      <Form>
-        <FormGroup label="Title" fieldId="widget-title" validated={isTitleValid.toString()} isRequired>
-          <TextInput type="text" id="widget-title" name="widget-title" value={title} onChange={(_, value) => setTitle(value)} validated={isTitleValid.toString()} isRequired />
-          {isTitleValid !== true && (
+      {componentLoaded ? (
+        <Form>
+          <FormGroup label="Title" fieldId="widget-title" validated={isTitleValid.toString()} isRequired>
+            <TextInput type="text" id="widget-title" name="widget-title" value={title} onChange={(_, value) => setTitle(value)} validated={isTitleValid.toString()} isRequired />
+            {isTitleValid !== true && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
+                  Please enter a title for this widget
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
+          </FormGroup>
+          <FormGroup label="Weight" fieldId="widget-weight">
+            <TextInput type="number" id="widget-weight" name="widget-weight" value={weight} onChange={(_, value) => setWeight(value)} />
             <FormHelperText>
               <HelperText>
-                <HelperTextItem icon={<ExclamationCircleIcon />} variant="error">
-                  Please enter a title for this widget
+                <HelperTextItem variant="default">
+                How widgets are ordered on the dashboard
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>
-          )}
-        </FormGroup>
-        <FormGroup label="Weight" fieldId="widget-weight">
-          <TextInput type="number" id="widget-weight" name="widget-weight" value={weight} onChange={(_, value) => setWeight(value)} />
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem variant="default">
-                How widgets are ordered on the dashboard
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        </FormGroup>
-        {widgetParams}
-      </Form>
+          </FormGroup>
+          {widgetParams}
+        </Form>
+      ) : (
+        <div>
+          <Skeleton width="10%" height="15px" style={{ marginBottom: '5px' }} />
+          <Skeleton width="100%" height="30px" />
+        </div>
+      )}
     </Modal>
   );
 };


### PR DESCRIPTION
This PR adds skeleton loading to the Edit modal for widgets - it shows only skeleton until everything is loaded.
![image](https://github.com/user-attachments/assets/faf56388-e043-4298-a5d6-d11231c1932e)
