### PR TITLE
fix(IQE-3502): Be able to trim slashes from both begging and end in URL building

### DIFF
--- a/frontend/src/services/http.js
+++ b/frontend/src/services/http.js
@@ -3,10 +3,10 @@ import { AuthService } from './auth';
 
 const trim = (string) => {
   if (string.startsWith('/')) {
-    return string.slice(1);
+    string = string.slice(1);
   }
   if (string.endsWith('/')) {
-    return string.slice(0, -1);
+    string = string.slice(0, -1);
   }
   return string;
 };


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Update trim function to correctly remove leading and trailing slashes from URLs by modifying the input string in-place