### PR TITLE
Update eslint config

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -3,16 +3,13 @@ import reactPlugin from 'eslint-plugin-react';
 import unusedImports from 'eslint-plugin-unused-imports';
 import globals from 'globals';
 import babelParser from '@babel/eslint-parser';
-import {defineConfig} from 'eslint/config';
+import {defineConfig, globalIgnores} from 'eslint/config';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import js from '@eslint/js';
 import pluginCypress from 'eslint-plugin-cypress/flat';
 
 export default defineConfig([
-  {
-    files: ['src/*', 'cypress/*', 'bin/*'],
-    ignores: ['node_modules/*', 'build/*'],
-  },
+  globalIgnores(['build/**/*', 'node_modules/'], 'Ignore build dir and node_modules'),
   pluginCypress.configs.recommended,
   reactHooksPlugin.configs['recommended-latest'],
   reactPlugin.configs.flat.recommended,
@@ -21,10 +18,12 @@ export default defineConfig([
   pluginCypress.configs.recommended,
   // prettier.configs.recommended
   {
+    files: ['src/*', 'cypress/*', 'bin/*'],
     plugins: {
       'unused-imports': unusedImports, // not flat config compatible
       reactPlugin,
       reactHooksPlugin,
+      pluginCypress,
     },
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
@@ -69,15 +68,11 @@ export default defineConfig([
         },
       ],
       'react/react-in-jsx-scope': 'off',
-      'arrow-body-style': ['error', 'as-needed'],
       camelcase: 'off',
-      'spaced-comment': 'error',
       quotes: ['warn', 'single'],
       'no-duplicate-imports': 'error',
       'unused-imports/no-unused-imports': 'error',
-      'semi': ['error'],
-      'indent': ['error', 2],
-      'space-before-function-paren': ['error', 'always'],
+      'unused-imports/no-unused-vars': ['warn'],
     },
     settings: {
       react:{

--- a/frontend/jest.polyfills.cjs
+++ b/frontend/jest.polyfills.cjs
@@ -1,2 +1,2 @@
-// jest.polyfills.js
+// jest.polyfills.cjs
 global.TextEncoder = require('util').TextEncoder;

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,2 +1,2 @@
 // src/setupTests.js
-import '../jest.polyfills.js';
+import '../jest.polyfills.cjs';


### PR DESCRIPTION
remove deprecated rules

`yarn lint --inspect-config` was used to identify deprecated rules. 

## Summary by Sourcery

Update ESLint configuration to use the latest flat config syntax and remove deprecated rules

Bug Fixes:
- Adjust plugin configurations to be compatible with the new flat config syntax

Enhancements:
- Migrate ESLint configuration to use the new flat config format
- Simplify global ignore configuration using globalIgnores

Chores:
- Remove deprecated ESLint rules
- Update file extension for jest polyfills from .js to .cjs