### PR TITLE
Update to ubi9/python-39:9.5 tag

### DIFF
--- a/backend/docker/Dockerfile.backend
+++ b/backend/docker/Dockerfile.backend
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041,DL3059
-FROM registry.access.redhat.com/ubi9/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:9.5
 
 USER 0
 COPY . /app
@@ -9,8 +9,9 @@ WORKDIR /app
 RUN dnf install --nodocs -y --disableplugin=subscription-manager gcc libpq-devel && \
     dnf clean all
 
-RUN pip install -U --no-cache-dir setuptools pip wheel
-RUN pip install --no-cache-dir -U -r requirements-pinned.txt .
+RUN python -m pip install --no-cache-dir -U pip && \
+    pip install -U --no-cache-dir setuptools wheel && \
+    pip install --no-cache-dir -U -r requirements-pinned.txt .
 
 RUN chgrp -R 0 ibutsu_server && chmod -R g+rwX ibutsu_server
 

--- a/backend/docker/Dockerfile.flower
+++ b/backend/docker/Dockerfile.flower
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041
-FROM registry.access.redhat.com/ubi9/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:9.5
 ENV BROKER_URL=redis://localhost
 
 # add application sources with correct perms for OCP

--- a/backend/docker/Dockerfile.scheduler
+++ b/backend/docker/Dockerfile.scheduler
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041
-FROM registry.access.redhat.com/ubi9/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:9.5
 USER 0
 
 ENV UPGRADE_PIP_TO_LATEST=1

--- a/backend/docker/Dockerfile.worker
+++ b/backend/docker/Dockerfile.worker
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041
-FROM registry.access.redhat.com/ubi9/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:9.5
 
 ENV UPGRADE_PIP_TO_LATEST=1
 

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.6.0
+  version: 2.6.1
 servers:
   - url: /api
 tags:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2.6.0"
+version = "2.6.1"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the base image tag to ubi9/python-39:9.5 in the backend, flower, scheduler, and worker Dockerfiles.