### PR TITLE
fix(Runs): Make set pagination work correctly

### DIFF
--- a/frontend/src/run-list.js
+++ b/frontend/src/run-list.js
@@ -531,8 +531,8 @@ const RunList = () => {
                   `/project/${params.project_id}/reports?${buildParams(filters).join('&')}`,
                 )
               }
-              onSetPage={setPage}
-              onSetPageSize={setPageSize}
+              onSetPage={(_, value) => setPage(value)}
+              onSetPageSize={(_, value) => setPageSize(value)}
               hideFilters={['project_id']}
             />
           </CardBody>


### PR DESCRIPTION
## Summary by Sourcery

Fix pagination in the Runs list by updating the onSetPage and onSetPageSize handlers to forward the correct page values

Bug Fixes:
- Correct onSetPage callback to extract and pass the page value
- Correct onSetPageSize callback to extract and pass the page size value