### PR TITLE
Fix bug with setPage/onSetPage for usePagination

### DIFF
--- a/frontend/src/pages/admin/project-list.js
+++ b/frontend/src/pages/admin/project-list.js
@@ -29,8 +29,16 @@ import { filtersToAPIParams } from '../../utilities';
 const COLUMNS = ['Title', 'Name', 'Owner', ''];
 
 const ProjectList = () => {
-  const { page, setPage, pageSize, setPageSize, totalItems, setTotalItems } =
-    usePagination({});
+  const {
+    page,
+    setPage,
+    onSetPage,
+    pageSize,
+    setPageSize,
+    onSetPageSize,
+    totalItems,
+    setTotalItems,
+  } = usePagination({});
 
   const [anyProjects, setAnyProjects] = useState(true);
   const [filteredProjects, setFilteredProjects] = useState([]);
@@ -180,8 +188,8 @@ const ProjectList = () => {
             totalItems={totalItems}
             isError={isError}
             onClearFilters={clearFilters}
-            onSetPage={setPage}
-            onSetPageSize={setPageSize}
+            onSetPage={onSetPage}
+            onSetPageSize={onSetPageSize}
           />
         )}
         {!anyProjects && (

--- a/frontend/src/pages/admin/user-list.js
+++ b/frontend/src/pages/admin/user-list.js
@@ -24,8 +24,16 @@ const UserList = () => {
   const [rows, setRows] = useState([]);
   const [selectedUser, setSelectedUser] = useState();
 
-  const { page, setPage, pageSize, setPageSize, totalItems, setTotalItems } =
-    usePagination({});
+  const {
+    page,
+    setPage,
+    onSetPage,
+    pageSize,
+    setPageSize,
+    onSetPageSize,
+    totalItems,
+    setTotalItems,
+  } = usePagination({});
 
   const [isError, setIsError] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -54,9 +62,9 @@ const UserList = () => {
             )
             .filter(Boolean),
         );
-        setPage(data.pagination.page.toString());
-        setPageSize(data.pagination.pageSize.toString());
-        setTotalItems(data.pagination.totalItems.toString());
+        setPage(data.pagination.page);
+        setPageSize(data.pagination.pageSize);
+        setTotalItems(data.pagination.totalItems);
         setFetching(false);
       })
       .catch((error) => {
@@ -105,8 +113,8 @@ const UserList = () => {
           filters={<AdminFilter />}
           isError={isError}
           canSelectAll={false}
-          onSetPage={setPage}
-          onSetPageSize={setPageSize}
+          onSetPage={onSetPage}
+          onSetPageSize={onSetPageSize}
           page={page}
           pageSize={pageSize}
           totalItems={totalItems}

--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -62,8 +62,8 @@ const ResultList = () => {
         setRows(
           data.results.map((result) => resultToRow(result, updateFilters)),
         );
-        setPage(data.pagination.page.toString());
-        setPageSize(data.pagination.pageSize.toString());
+        setPage(data.pagination.page);
+        setPageSize(data.pagination.pageSize);
         setTotalItems(data.pagination.totalItems);
         setIsError(false);
         setFetching(false);

--- a/frontend/src/views/accessibilityanalysis.js
+++ b/frontend/src/views/accessibilityanalysis.js
@@ -34,6 +34,7 @@ import FilterTable from '../components/filtering/filtered-table-card';
 import { IbutsuContext } from '../components/contexts/ibutsuContext';
 import TabTitle from '../components/tabs';
 import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import usePagination from '../components/hooks/usePagination';
 
 const COLUMNS = ['Test', 'Run', 'Result', 'Duration', 'Started'];
 
@@ -44,8 +45,8 @@ const AccessibilityAnalysisView = ({ view }) => {
   const navigate = useNavigate();
   const params = useSearchParams();
 
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(20);
+  const { page, setPage, onSetPage, pageSize, setPageSize, onSetPageSize } =
+    usePagination({});
   const [filters] = useState({});
 
   const [run, setRun] = useState();
@@ -238,9 +239,9 @@ const AccessibilityAnalysisView = ({ view }) => {
       .then((response) => HttpClient.handleResponse(response))
       .then((data) => {
         setResults(data.results);
-        setRows(data.results.map((result) => resultToRow(result))); // TODO move to render
-        setPage(data.pagination.page.toString());
-        setPageSize(data.pagination.pageSize.toString());
+        setRows(data.results?.map((result) => resultToRow(result))); // TODO move to render
+        setPage(data.pagination.page);
+        setPageSize(data.pagination.pageSize);
         setTotalItems(data.pagination.totalItems);
       })
       .catch((error) => {
@@ -249,7 +250,7 @@ const AccessibilityAnalysisView = ({ view }) => {
         setResults([]);
         setIsError(true);
       });
-  }, [page, pageSize, id]);
+  }, [page, pageSize, id, setPage, setPageSize]);
 
   useEffect(() => {
     let { passes, violations } = run.metadata.accessibility_data;
@@ -387,11 +388,8 @@ const AccessibilityAnalysisView = ({ view }) => {
               page={page}
               totalItems={totalItems}
               isError={isError}
-              onSetPage={(_, value) => setPage(value)}
-              onSetPageSize={(_, newPageSize, newPage) => {
-                setPageSize(newPageSize);
-                setPage(newPage);
-              }}
+              onSetPage={onSetPage}
+              onSetPageSize={onSetPageSize}
               headerChildren={accessTableHeader}
               cardClass="pf-u-mt-lg"
             />

--- a/frontend/src/views/compareruns.js
+++ b/frontend/src/views/compareruns.js
@@ -26,6 +26,7 @@ import {
 } from '../utilities';
 import { IbutsuContext } from '../components/contexts/ibutsuContext';
 import ResultView from '../components/resultView';
+import usePagination from '../components/hooks/usePagination';
 
 const COLUMNS = [
   { title: 'Test', cellFormatters: [expandable] },
@@ -55,9 +56,16 @@ const CompareRunsView = () => {
 
   const [results, setResults] = useState([]);
   const [rows, setRows] = useState([getSpinnerRow(3)]);
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(20);
-  const [totalItems, setTotalItems] = useState(0);
+  const {
+    page,
+    setPage,
+    onSetPage,
+    pageSize,
+    onSetPageSize,
+    setPageSize,
+    totalItems,
+    setTotalItems,
+  } = usePagination({});
 
   const [isError, setIsError] = useState(false);
   const [includeSkipped, setIncludeSkipped] = useState(false);
@@ -148,7 +156,7 @@ const CompareRunsView = () => {
     }
 
     setIsLoading(false);
-  }, [filters, primaryObject]);
+  }, [filters, primaryObject, setPage, setPageSize, setTotalItems]);
 
   const onCollapse = (_, rowIndex, isOpen) => {
     // handle row expansion with ResultView
@@ -205,11 +213,11 @@ const CompareRunsView = () => {
   };
 
   // Remove all active filters and clear table
-  const clearFilters = () => {
+  const clearFilters = useCallback(() => {
     setFilters(DEFAULT_FILTER);
     setPage(1);
     setTotalItems(0);
-  };
+  }, [setPage, setTotalItems]);
 
   const resultFilters = [
     <Flex
@@ -281,7 +289,7 @@ const CompareRunsView = () => {
         </FlexItem>
       </Flex>
     );
-  }, [includeSkipped, isLoading, onSkipCheck]);
+  }, [clearFilters, includeSkipped, isLoading, onSkipCheck]);
 
   // Compare runs work only when project is selected
   // TODO Apply Filters button needs to trigger table render
@@ -295,11 +303,8 @@ const CompareRunsView = () => {
         totalItems={totalItems}
         isError={isError}
         onCollapse={onCollapse}
-        onSetPage={(_, value) => setPage(value)}
-        onSetPageSize={(_, newPageSize, newPage) => {
-          setPageSize(newPageSize);
-          setPage(newPage);
-        }}
+        onSetPage={onSetPage}
+        onSetPageSize={onSetPageSize}
         canSelectAll={false}
         variant={TableVariant.compact}
         filters={resultFilters}


### PR DESCRIPTION
## Summary by Sourcery

Use the usePagination hook to unify pagination state and callbacks across multiple components and refactor UserTokens data fetching to async/await.

Bug Fixes:
- Replace inline setPage/setPageSize handlers in table components with onSetPage and onSetPageSize callbacks from usePagination to fix pagination bugs

Enhancements:
- Swap out manual page, pageSize, and totalItems state in UserTokens, CompareRunsView, UserList, AccessibilityAnalysisView, ProjectList, and ResultList for the usePagination hook
- Refactor UserTokens fetch logic to async/await, map tokens directly to rows, and centralize loading and error handling
- Add necessary hook setter functions to effect dependencies to ensure correct re-fetching

Chores:
- Add console.log in usePagination’s onSetPageSize for debugging