### PR TITLE
Don't render TableEmptyState when fetching

### DIFF
--- a/frontend/src/components/filtering/filtered-table-card.js
+++ b/frontend/src/components/filtering/filtered-table-card.js
@@ -51,7 +51,7 @@ const FilterTable = ({
     <Card ouiaId="filter-table-card" className={cardClass}>
       {headerChildren ? <CardHeader>{headerChildren}</CardHeader> : null}
       {filters || null}
-      {populatedRows && !isError && !fetching && (
+      {populatedRows && !isError && (
         <CardBody key="table">
           <Flex
             alignSelf={{ default: 'alignSelfFlexEnd' }}
@@ -98,7 +98,7 @@ const FilterTable = ({
           />
         </CardBody>
       )}
-      {!populatedRows && !isError && (
+      {!populatedRows && !isError && !fetching && (
         <CardBody key="empty-table">
           <TableEmptyState onClearFilters={onClearFilters} />
         </CardBody>

--- a/frontend/src/views/jenkinsjob.js
+++ b/frontend/src/views/jenkinsjob.js
@@ -127,6 +127,7 @@ const JenkinsJobView = ({ view }) => {
         filter: filtersToAPIParams(activeFilters),
       };
       setIsError(false);
+      setFetching(true);
 
       if (primaryObject) {
         params['project'] = primaryObject.id;


### PR DESCRIPTION
FilterTable was rendering the empty state though no filters were applied and data was yet to be fetched

## Summary by Sourcery

Prevent the table empty state from displaying during data fetch by introducing a fetching flag and gating the render logic, and set the fetching flag when initiating Jenkins job data retrieval.

Bug Fixes:
- Suppress the empty table state while data is still being fetched
- Set the fetching flag at the start of the Jenkins job API call to control table rendering