### PR TITLE
FilterTable update to use Skeleton

### DIFF
--- a/frontend/src/components/filtering/filtered-table-card.js
+++ b/frontend/src/components/filtering/filtered-table-card.js
@@ -9,6 +9,7 @@ import {
   FlexItem,
   Pagination,
   PaginationVariant,
+  Skeleton,
 } from '@patternfly/react-core';
 
 import {
@@ -51,7 +52,12 @@ const FilterTable = ({
     <Card ouiaId="filter-table-card" className={cardClass}>
       {headerChildren ? <CardHeader>{headerChildren}</CardHeader> : null}
       {filters || null}
-      {populatedRows && !isError && (
+      {fetching && (
+        <CardBody key="loading-table">
+          <Skeleton />
+        </CardBody>
+      )}
+      {!fetching && !isError && populatedRows && (
         <CardBody key="table">
           <Flex
             alignSelf={{ default: 'alignSelfFlexEnd' }}
@@ -98,17 +104,17 @@ const FilterTable = ({
           />
         </CardBody>
       )}
-      {!populatedRows && !isError && !fetching && (
+      {!fetching && !isError && !populatedRows && (
         <CardBody key="empty-table">
           <TableEmptyState onClearFilters={onClearFilters} />
         </CardBody>
       )}
-      {isError && (
+      {!fetching && isError && (
         <CardBody key="error-table">
           <TableErrorState onClearFilters={onClearFilters} />
         </CardBody>
       )}
-      {footerChildren ? (
+      {!fetching && footerChildren ? (
         <CardFooter key="footer">{footerChildren}</CardFooter>
       ) : null}
     </Card>

--- a/frontend/src/result-list.js
+++ b/frontend/src/result-list.js
@@ -28,6 +28,7 @@ const ResultList = () => {
   const [runs, setRuns] = useState([]);
 
   const [fetching, setFetching] = useState(true);
+  const [isError, setIsError] = useState(false);
 
   const {
     page,
@@ -40,13 +41,10 @@ const ResultList = () => {
     setTotalItems,
   } = usePagination({});
 
-  const [isError, setIsError] = useState(false);
-
   // fetch result data
   useEffect(() => {
     const fetchData = async () => {
       setIsError(false);
-      setFetching(true);
       const apiParams = {
         estimate: true,
         page: page,
@@ -66,13 +64,12 @@ const ResultList = () => {
         setPageSize(data.pagination.pageSize);
         setTotalItems(data.pagination.totalItems);
         setIsError(false);
-        setFetching(false);
       } catch (error) {
         console.error('Error fetching result data:', error);
         setRows([]);
         setIsError(true);
-        setFetching(false);
       }
+      setFetching(false);
     };
 
     const debouncer = setTimeout(() => {

--- a/frontend/src/run-list.js
+++ b/frontend/src/run-list.js
@@ -39,8 +39,8 @@ const RunList = () => {
     setTotalItems,
   } = usePagination({});
 
-  const [isError, setIsError] = useState(false);
   const [fetching, setFetching] = useState(true);
+  const [isError, setIsError] = useState(false);
 
   // Fetch runs based on active filters
   useEffect(() => {

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -10,7 +10,7 @@ CREATE_PROJECT=false
 POSTGRES_EXTRA_ARGS=
 REDIS_EXTRA_ARGS=
 BACKEND_EXTRA_ARGS=
-PYTHON_IMAGE=registry.access.redhat.com/ubi8/python-39:latest
+PYTHON_IMAGE=registry.access.redhat.com/ubi9/python-39:latest
 
 function print_usage() {
     echo "Usage: ibutsu-pod.sh [-h|--help] [-p|--persistent] [-V|--use-volumes] [-A|--create-admin] [-P|--create-project] [POD_NAME]"


### PR DESCRIPTION
This also stops double-loading by handling `fetching` state consistently.

## Summary by Sourcery

Unify fetching state management across multiple views, introduce consistent Skeleton loading indicators in tables, refactor JenkinsJobView network logic to async/await with improved error handling, and bump the Python image version in the pod script.

Enhancements:
- Refactor JenkinsJobView to use async/await and log errors when the analysis view ID is missing
- Ensure setFetching calls are relocated to prevent double-loading in JenkinsJobView and ResultList
- Show a Skeleton loader in FilterTable while data is being fetched
- Update ResultList to finalize fetching state after data retrieval

Chores:
- Upgrade PYTHON_IMAGE in ibutsu-pod.sh from ubi8 to ubi9