### PR TITLE
Move TestHistory to useTableFilters

### DIFF
--- a/frontend/src/components/resultView.js
+++ b/frontend/src/components/resultView.js
@@ -43,10 +43,6 @@ import TestHistoryTable from './test-history';
 import ArtifactTab from './artifact-tab';
 import { IbutsuContext } from '../components/contexts/ibutsuContext';
 import { useTabHook } from './hooks/useTab';
-import FilterProvider from './contexts/filterContext';
-import { RESULT_FIELDS } from '../constants';
-
-const FILTER_BLOCK = ['result', 'component', 'start_time', 'env'];
 
 const ResultView = ({
   comparisonResults,
@@ -72,16 +68,10 @@ const ResultView = ({
           eventKey="testHistory"
           title={<TabTitle icon={<SearchIcon />} text="Test History" />}
         >
-          <FilterProvider
-            key="test-history"
-            blockRemove={FILTER_BLOCK}
-            fieldOptions={RESULT_FIELDS}
-          >
-            <TestHistoryTable
-              comparisonResults={comparisonResults}
-              testResult={testResult}
-            />
-          </FilterProvider>
+          <TestHistoryTable
+            comparisonResults={comparisonResults}
+            testResult={testResult}
+          />
         </Tab>
       );
     }


### PR DESCRIPTION
Don't use a provider/context for testhistory, the filters can't be modified and don't need context at the result view level.

## Summary by Sourcery

Migrate TestHistoryTable off FilterContext to use a standalone useTableFilters hook, clean up filter and fetching state management, and remove the FilterProvider in ResultView.

Enhancements:
- Replace FilterContext usage with useTableFilters hook and pass BLOCK fields via blockRemove option
- Refactor filter updates to use functional state setters for activeFilters
- Rename and initialize fetching and time range state (set fetching to true by default and rename setSelectedTimeRange)
- Remove unnecessary activeFilters prop from FilterTable and eliminate FilterProvider wrapper in ResultView