### PR TITLE
2.6.7 versioning

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.6.6
+  version: 2.6.7
 servers:
   - url: /api
 tags:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2.6.6"
+version = "2.6.7"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 2.6.7 across backend and frontend

Chores:
- Update OpenAPI spec version to 2.6.7
- Update backend pyproject.toml version to 2.6.7
- Update frontend package.json version to 2.6.7