### PR TITLE
Rework Chart colors

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -224,7 +224,7 @@ WIDGET_TYPES = {
             },
             {
                 "name": "chart_type",
-                "description": "Type of chart with which to display results, e.g. 'pie' or 'bar'",
+                "description": "Type of chart with which to display results, e.g. 'pie' or 'donut'",
                 "type": "string",
                 "required": False,
                 "default": "pie",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -183,3 +183,14 @@ export const RUN_RESULTS_COLUMNS = [
   'Run',
   'Started',
 ];
+
+export const CHART_COLOR_MAP = {
+  passed: 'var(--pf-v5-chart-color-green-300)',
+  failed: 'var(--pf-v5-chart-color-red-200)',
+  error: 'var(--pf-v5-chart-color-orange-200)',
+  skipped: 'var(--pf-v5-chart-color-gold-400)',
+  xfailed: 'var(--pf-v5-chart-color-purple-200)',
+  xpassed: 'var(--pf-v5-chart-color-blue-100)',
+  manual: 'var(--pf-v5-chart-color-cyan-500)',
+  default: 'var(--pf-v5-chart-color-organge-500)',
+};

--- a/frontend/src/dashboard.js
+++ b/frontend/src/dashboard.js
@@ -38,6 +38,8 @@ import DeleteModal from './components/delete-modal';
 import { useWidgets } from './components/hooks/useWidgets';
 import { IbutsuContext } from './components/contexts/ibutsuContext';
 
+import { nanoid } from 'nanoid/non-secure';
+
 const Dashboard = () => {
   const { defaultDashboard, primaryObject } = useContext(IbutsuContext);
   const { dashboard_id, project_id } = useParams();
@@ -64,6 +66,7 @@ const Dashboard = () => {
   const [selectInputValue, setSelectInputValue] = useState('');
   const [selectFilterValue, setSelectFilterValue] = useState('');
   const selectInputRef = useRef();
+  const [loadKey, setLoadKey] = useState(nanoid(6));
 
   const onDeleteWidgetClick = (id) => {
     setIsDeleteWidgetOpen(true);
@@ -103,6 +106,7 @@ const Dashboard = () => {
     dashboardId: selectedDashboard?.id,
     editCallback: onEditWidgetClick,
     deleteCallback: onDeleteWidgetClick,
+    loadKey,
   });
 
   // Fetch all dashboards for the project
@@ -272,6 +276,7 @@ const Dashboard = () => {
     };
 
     postWidget(widgetData);
+    setLoadKey(nanoid(6)); // reset load key to re-fetch widgets
   };
 
   const onEditWidgetSave = (editedData) => {
@@ -291,6 +296,7 @@ const Dashboard = () => {
       }
     };
     putWidget(editedData);
+    setLoadKey(nanoid(6)); // reset load key to re-fetch widgets
     setIsEditModalOpen(false);
   };
 
@@ -520,6 +526,7 @@ const Dashboard = () => {
         isOpen={isDeleteWidgetOpen}
         onClose={() => {
           setIsDeleteWidgetOpen(false);
+          setLoadKey(nanoid(6)); // reset load key to re-fetch widgets
         }}
         toDeletePath={['widget-config']}
         toDeleteId={currentWidget}
@@ -530,6 +537,7 @@ const Dashboard = () => {
           onSave={onEditWidgetSave}
           onClose={() => {
             setIsEditModalOpen(false);
+            setLoadKey(nanoid(6)); // reset load key to re-fetch widgets
           }}
           data={editWidgetData}
         />

--- a/frontend/src/views/accessibilityanalysis.js
+++ b/frontend/src/views/accessibilityanalysis.js
@@ -20,7 +20,11 @@ import {
   ChevronRightIcon,
   CodeIcon,
 } from '@patternfly/react-icons';
-import { ChartLegend, ChartDonut } from '@patternfly/react-charts';
+import {
+  ChartLegend,
+  ChartDonut,
+  ChartThemeColor,
+} from '@patternfly/react-charts';
 import {
   Link,
   useLocation,
@@ -327,6 +331,7 @@ const AccessibilityAnalysisView = ({ view }) => {
                 legendPosition="right"
                 legendComponent={
                   <ChartLegend
+                    themeColor={ChartThemeColor.multiOrdered}
                     data={[
                       {
                         name: 'Passes: ' + pieData[0].y,
@@ -349,12 +354,7 @@ const AccessibilityAnalysisView = ({ view }) => {
                   right: 140,
                   top: 0,
                 }}
-                colorScale={[
-                  'var(--pf-v5-global--success-color--100)',
-                  'var(--pf-v5-global--danger-color--100)',
-                  'var(--pf-v5-global--warning-color--100)',
-                  'var(--pf-v5-global--info-color--100)',
-                ]}
+                themeColor={ChartThemeColor.multiOrdered}
                 width={300}
               />
             </div>

--- a/frontend/src/views/jenkinsjobanalysis.js
+++ b/frontend/src/views/jenkinsjobanalysis.js
@@ -7,7 +7,7 @@ import { Settings } from '../settings';
 
 import GenericAreaWidget from '../widgets/genericarea';
 import GenericBarWidget from '../widgets/genericbar';
-import FilterHeatmapWidget from '../widgets/filterheatmap';
+import { FilterHeatmapWidget, HEATMAP_TYPES } from '../widgets/filterheatmap';
 import { HEATMAP_MAX_BUILDS } from '../constants';
 import { IbutsuContext } from '../components/contexts/ibutsuContext';
 import ParamDropdown from '../components/param-dropdown';
@@ -91,22 +91,6 @@ const JenkinsJobAnalysisView = ({ view, defaultTab = 'heatmap' }) => {
     setBarWidth(newWidth);
   }, [builds]);
 
-  const getColors = (key) => {
-    let color = 'var(--pf-v5-global--success-color--100)';
-    if (key === 'failed') {
-      color = 'var(--pf-v5-global--danger-color--100)';
-    } else if (key === 'skipped') {
-      color = 'var(--pf-v5-global--info-color--100)';
-    } else if (key === 'error') {
-      color = 'var(--pf-v5-global--warning-color--100)';
-    } else if (key === 'xfailed') {
-      color = 'var(--pf-v5-global--palette--purple-400)';
-    } else if (key === 'xpassed') {
-      color = 'var(--pf-v5-global--palette--purple-700)';
-    }
-    return color;
-  };
-
   const heatmapParams = useMemo(() => {
     return {
       ...widgetParams,
@@ -185,7 +169,7 @@ const JenkinsJobAnalysisView = ({ view, defaultTab = 'heatmap' }) => {
             <FilterHeatmapWidget
               params={heatmapParams}
               hideDropdown={true}
-              type="jenkins"
+              type={HEATMAP_TYPES.jenkins}
             />
           )}
         </Tab>
@@ -217,19 +201,12 @@ const JenkinsJobAnalysisView = ({ view, defaultTab = 'heatmap' }) => {
               title={'Test counts for ' + barchartParams.job_name}
               params={barchartParams}
               hideDropdown={true}
-              getColors={getColors}
               widgetEndpoint="jenkins-bar-chart"
               height={180}
               yLabel="Test counts"
               xLabel="Build number"
               sortOrder="ascending"
               showTooltip={false}
-              colorScale={[
-                'var(--pf-v5-global--warning-color--100)',
-                'var(--pf-v5-global--danger-color--100)',
-                'var(--pf-v5-global--success-color--100)',
-                'var(--pf-v5-global--info-color--100)',
-              ]}
               padding={{
                 bottom: 50,
                 left: 50,

--- a/frontend/src/widgets/resultsummary.js
+++ b/frontend/src/widgets/resultsummary.js
@@ -8,6 +8,7 @@ import { HttpClient } from '../services/http';
 import { Settings } from '../settings';
 import { toTitleCase } from '../utilities';
 import WidgetHeader from '../components/widget-header';
+import { CHART_COLOR_MAP } from '../constants';
 
 const ResultSummaryWidget = ({ title, params, onDeleteClick, onEditClick }) => {
   const [summary, setSummary] = useState({
@@ -47,15 +48,53 @@ const ResultSummaryWidget = ({ title, params, onDeleteClick, onEditClick }) => {
     }
   }, [params]);
 
-  const themeColors = [
-    'var(--pf-v5-global--success-color--100)',
-    'var(--pf-v5-global--danger-color--100)',
-    'var(--pf-v5-global--info-color--100)',
-    'var(--pf-v5-global--warning-color--100)',
-    'var(--pf-v5-global--palette--purple-400)',
-    'var(--pf-v5-global--palette--purple-700)',
-    'var(--pf-v5-global--primary-color--100)',
-  ];
+  // Create chart data and legend data with appropriate color mapping
+  const chartData =
+    !isError && !fetching && Object.keys(summary || {}).length
+      ? [
+          { x: 'Passed', y: summary.passed },
+          { x: 'Failed', y: summary.failed },
+          { x: 'Skipped', y: summary.skipped },
+          { x: 'Error', y: summary.error },
+          { x: 'Xfailed', y: summary.xfailed },
+          { x: 'Xpassed', y: summary.xpassed },
+          { x: 'Manual', y: summary?.manual || 0 },
+        ]
+      : [];
+
+  const legendData =
+    !isError && !fetching && Object.keys(summary || {}).length
+      ? [
+          {
+            name: `Passed (${summary.passed})`,
+            symbol: { fill: CHART_COLOR_MAP.passed },
+          },
+          {
+            name: `Failed (${summary.failed})`,
+            symbol: { fill: CHART_COLOR_MAP.failed },
+          },
+          {
+            name: `Skipped (${summary.skipped})`,
+            symbol: { fill: CHART_COLOR_MAP.skipped },
+          },
+          {
+            name: `Error (${summary.error})`,
+            symbol: { fill: CHART_COLOR_MAP.error },
+          },
+          {
+            name: `xFailed (${summary.xfailed})`,
+            symbol: { fill: CHART_COLOR_MAP.xfailed },
+          },
+          {
+            name: `xPassed (${summary.xpassed})`,
+            symbol: { fill: CHART_COLOR_MAP.xpassed },
+          },
+          {
+            name: `Manual (${summary.manual || 'N/A'})`,
+            symbol: { fill: CHART_COLOR_MAP.manual },
+          },
+        ]
+      : [];
 
   return (
     <Card>
@@ -71,45 +110,28 @@ const ResultSummaryWidget = ({ title, params, onDeleteClick, onEditClick }) => {
           <div>
             <ChartDonut
               constrainToVisibleArea={true}
-              data={[
-                { x: 'Passed', y: summary.passed },
-                { x: 'Failed', y: summary.failed },
-                { x: 'Skipped', y: summary.skipped },
-                { x: 'Error', y: summary.error },
-                { x: 'Xfailed', y: summary.xfailed },
-                { x: 'Xpassed', y: summary.xpassed },
-                { x: 'Manual', y: summary?.manual }, // TODO result-summary data needs it
-              ]}
+              data={chartData}
               labels={({ datum }) => `${toTitleCase(datum.x)}: ${datum.y}`}
               height={200}
               title={summary.total}
               subTitle="total results"
+              colorScale={Object.values(CHART_COLOR_MAP)}
               style={{
                 labels: { fontFamily: 'RedHatText' },
               }}
-              colorScale={themeColors}
             />
             <p className="pf-u-pt-sm">Total number of tests: {summary.total}</p>
           </div>
         )}
       </CardBody>
       <CardFooter>
-        {!isError && !fetching && (
+        {!isError && !fetching && Object.keys(summary || {}).length > 0 && (
           <ChartLegend
-            data={[
-              { name: `Passed (${summary.passed})` },
-              { name: `Failed (${summary.failed})` },
-              { name: `Skipped (${summary.skipped})` },
-              { name: `Error (${summary.error})` },
-              { name: `xFailed (${summary.xfailed})` },
-              { name: `xPassed (${summary.xpassed})` },
-              { name: `Manual (${summary.manual || 'N/A'})` },
-            ]}
-            height={120}
+            data={legendData}
+            height={90}
             orientation="horizontal"
             responsive={false}
             itemsPerRow={2}
-            colorScale={themeColors}
             style={{
               labels: { fontFamily: 'RedHatText' },
               title: { fontFamily: 'RedHatText' },


### PR DESCRIPTION
Use data styles and legendData, along with a new constant for chart colors

Use chart colors instead of global colors for charts

Some async/await patterns too

FIXES #463

## Summary by Sourcery

Rework chart color management and streamline data fetching across various widgets

Enhancements:
- Introduce CHART_COLOR_MAP constant for unified chart colors and update all chart widgets to use it
- Refactor widget data fetching to use async/await with debounced useEffect hooks
- Generate legendData via useMemo and replace hard-coded colorScale and getColors props in bar, area, heatmap and summary widgets
- Add HEATMAP_TYPES constant and refactor FilterHeatmapWidget to fetch analysis view ID and link using hooks
- Implement loadKey with nanoid in Dashboard and useWidgets to trigger widget reloads on add/edit/delete
- Update accessibility analysis view to use themeColor for ChartLegend ordering

Documentation:
- Clarify default "chart_type" description to include "donut" in backend constants