### PR TITLE
Add archive import to ibutsu-pod.sh development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,8 @@ sonar-project.properties
 .postgres-data/
 .redis-data/
 .jwtsecret
+.archives/
+
 
 scripts/populate-users-data.py
 users_data.json

--- a/frontend/src/components/fileupload.js
+++ b/frontend/src/components/fileupload.js
@@ -15,9 +15,9 @@ import { getDarkTheme } from '../utilities';
 import { toast } from 'react-toastify';
 import ToastWrapper from './toast-wrapper';
 import { Settings } from '../settings';
-import { ALERT_TIMEOUT } from '../constants';
+import { ALERT_TIMEOUT, FILE_IMPORT_KEY } from '../constants';
 
-const FileUpload = ({ name = 'file' }) => {
+const FileUpload = ({ name = FILE_IMPORT_KEY }) => {
   const context = useContext(IbutsuContext);
 
   const [importId, setImportId] = useState();

--- a/frontend/src/components/ibutsu-header.js
+++ b/frontend/src/components/ibutsu-header.js
@@ -282,7 +282,7 @@ const IbutsuHeader = () => {
             />
           </ToolbarItem>
           <ToolbarItem spacer={{ default: 'spacerSm' }}>
-            <FileUpload name="importFile" />
+            <FileUpload />
           </ToolbarItem>
           <ToolbarItem spacer={{ default: 'spacerSm' }}>
             <Button

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -194,3 +194,5 @@ export const CHART_COLOR_MAP = {
   manual: 'var(--pf-v5-chart-color-cyan-500)',
   default: 'var(--pf-v5-chart-color-organge-500)',
 };
+
+export const FILE_IMPORT_KEY = 'importFile';

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -7,44 +7,75 @@ IS_PERSISTENT=false
 USE_VOLUMES=false
 CREATE_ADMIN=false
 CREATE_PROJECT=false
+IMPORT_FOLDER="./.archives"
+SKIP_IMPORT_FILES=false
 POSTGRES_EXTRA_ARGS=
 REDIS_EXTRA_ARGS=
 BACKEND_EXTRA_ARGS=
 PYTHON_IMAGE=registry.access.redhat.com/ubi9/python-39:latest
 
 function print_usage() {
-    echo "Usage: ibutsu-pod.sh [-h|--help] [-p|--persistent] [-V|--use-volumes] [-A|--create-admin] [-P|--create-project] [POD_NAME]"
+    echo "Usage: ibutsu-pod.sh [-h|--help] [-d|--data-persistent] [-v|--use-volumes] [-a|--create-admin] [-p|--create-project] [-s|--skip-import-files] [-f|--import-folder FOLDER] [POD_NAME]"
     echo ""
     echo "optional arguments:"
-    echo "  -h, --help            show this help message"
-    echo "  -p, --persistent      persist the data in the containers"
-    echo "  -V, --use-volumes     use podman volumes to store data"
-    echo "  -A, --create-admin    create an administrator ('admin@example.com')"
-    echo "  -P, --create-project  create a default project ('my-project')"
-    echo "  POD_NAME              the name of the pod, 'ibutsu' if ommitted"
+    echo "  -h, --help                 show this help message"
+    echo "  -d, --data-persistent           persist the data in the containers (use this for keeping data between pod restarts)"
+    echo "  -v, --data-volumes          use podman volumes to store data"
+    echo "  -a, --create-admin         create an administrator ('admin@example.com')"
+    echo "  -p, --create-project       create a default project ('my-project')"
+    echo "  -s, --skip-import-files    skip import files from the import folder"
+    echo "  -f, --import-folder        folder containing files to import (./.archives/ by default)"
+    echo "  POD_NAME                   the name of the pod, 'ibutsu' if ommitted"
     echo ""
 }
 
 # Parse the arguments
-for ARG in $*; do
-    if [[ "$ARG" == "-p" ]] || [[ "$ARG" == "--persistent" ]]; then
-        IS_PERSISTENT=true
-    elif [[ "$ARG" == "-V" ]] || [[ "$ARG" == "--use-volumes" ]]; then
-        USE_VOLUMES=true
-    elif [[ "$ARG" == "-A" ]] || [[ "$ARG" == "--create-admin" ]]; then
-        CREATE_ADMIN=true
-    elif [[ "$ARG" == "-P" ]] || [[ "$ARG" == "--create-project" ]]; then
-        CREATE_PROJECT=true
-    elif [[ "$ARG" == "-h" ]] || [[ "$ARG" == "--help" ]]; then
-        print_usage
-        exit 0
-    else
-        POD_NAME=$ARG
-    fi
+i=1
+while [[ $i -le $# ]]; do
+    case "${!i}" in
+        -d|--data-persistent)
+            IS_PERSISTENT=true
+            ;;
+        -v|--data-volumes)
+            USE_VOLUMES=true
+            ;;
+        -a|--create-admin)
+            CREATE_ADMIN=true
+            ;;
+        -p|--create-project)
+            CREATE_PROJECT=true
+            ;;
+        -s|--skip-import-files)
+            SKIP_IMPORT_FILES=true
+            ;;
+        -f|--import-folder)
+            ((i++))
+            if [[ $i -le $# ]]; then
+                IMPORT_FOLDER="${!i}"
+            else
+                echo "Error: Missing argument for --import-folder"
+                print_usage
+                exit 1
+            fi
+            ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: ${!i}"
+            print_usage
+            exit 1
+            ;;
+        *)
+            POD_NAME="${!i}"
+            ;;
+    esac
+    ((i++))
 done
 
 # Check this is being run in the correct directory
-DIRS=`ls -p | grep '/'`
+DIRS=$(ls -p | grep '/')
 if [[ ! ${DIRS[*]} =~ "backend" ]] && [[ ! ${DIRS[*]} =~ "frontend" ]]; then
     echo "This script needs to be run from the root of the project"
     exit 1
@@ -107,15 +138,18 @@ fi
 if [[ $CREATE_PROJECT = true ]]; then
     echo "  Project will be created"
 fi
+if [[ $SKIP_IMPORT_FILES = false ]]; then
+    echo "  Files will be imported from ${IMPORT_FOLDER}"
+fi
 echo "Stop the pod by running: 'podman pod rm -f ${POD_NAME}'"
 echo ""
 
 # Get the pods up and running
 echo -n "Creating ibutsu pod:    "
 podman pod create -p 8080:8080 -p 3000:3000 --name $POD_NAME
+
 echo "================================="
 echo -n "Adding postgres to the pod:    "
-set -x
 podman run -dt \
        --pod $POD_NAME \
        -e POSTGRESQL_USER=ibutsu \
@@ -123,24 +157,19 @@ podman run -dt \
        -e POSTGRESQL_PASSWORD=ibutsu \
        $POSTGRES_EXTRA_ARGS \
        --name ibutsu-postgres \
-       --rm \
       registry.redhat.io/rhel8/postgresql-12
-set +x
+
 echo "================================="
 echo -n "Adding redis to the pod:    "
-set -x
 podman run -dt \
        --pod $POD_NAME \
        $REDIS_EXTRA_ARGS \
        --name ibutsu-redis \
-       --rm \
        quay.io/fedora/redis-7
-set +x
+
 echo "================================="
 echo -n "Adding backend to the pod:    "
-set -x
 podman run -d \
-       --rm \
        --pod $POD_NAME \
        --name ibutsu-backend \
        -e JWT_SECRET=$JWT_SECRET \
@@ -158,18 +187,19 @@ podman run -d \
        /bin/bash -c 'python -m pip install -U pip wheel setuptools &&
                      pip install . &&
                      python -m ibutsu_server --host 0.0.0.0'
-set +x
 echo -n "Waiting for backend to respond: "
+sleep 5
 until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:8080); do
-  echo -n '.'
-  sleep 5
+  echo -n ' .'
+  sleep 2
 done
+echo " backend up."
+
+
 # Note the COLUMNS=80 env var is for https://github.com/celery/celery/issues/5761
 echo "================================="
 echo -n "Adding celery worker to the pod:    "
-set -x
 podman run -d \
-       --rm \
        --pod $POD_NAME \
        --name ibutsu-worker \
        -e COLUMNS=80 \
@@ -186,12 +216,111 @@ podman run -d \
        /bin/bash -c 'pip install -U pip wheel &&
                      pip install . &&
                      ./celery_worker.sh'
-set +x
+echo -n "Waiting for celery to respond: "
+sleep 5
+until $(podman exec ibutsu-worker celery inspect ping -d celery@ibutsu 2>/dev/null | grep -q pong); do
+    echo -n ' .'
+    sleep 2
+done
+echo " celery worker up."
+
+
+if [[ $CREATE_PROJECT = true ]]; then
+    echo -n "Creating default project... "
+    LOGIN_TOKEN=$(curl --no-progress-meter --header "Content-Type: application/json" \
+        --request POST \
+        --data '{"email": "admin@example.com", "password": "admin12345"}' \
+        http://127.0.0.1:8080/api/login | jq -r '.token')
+
+    PROJECT_ID=$(curl --no-progress-meter --header "Content-Type: application/json" \
+    --header "Authorization: Bearer ${LOGIN_TOKEN}" \
+    --request POST \
+    --data '{"name": "my-project", "title": "My Project"}' \
+    http://127.0.0.1:8080/api/project | jq -r '.id')
+
+    echo "Project created"
+
+    # Initialize counters for successful and failed imports
+    SUCCESSFUL_IMPORTS=0
+    FAILED_IMPORTS=0
+
+    # Import files if requested and project was created
+    if [[ $SKIP_IMPORT_FILES = false ]] &&
+        [[ ! -z "$PROJECT_ID" ]] &&
+        [[ ! -z "$LOGIN_TOKEN" ]]; then
+        echo "Importing files from: ${IMPORT_FOLDER}"
+
+        # Check if the import folder exists
+        if [[ ! -d "$IMPORT_FOLDER" ]]; then
+            echo "Import folder not found: ${IMPORT_FOLDER}"
+        else
+            # Get list of files in the import folder
+            FILES=$(ls -1 ${IMPORT_FOLDER}/*.tar.gz 2>/dev/null || true)
+
+            if [[ -z "$FILES" ]]; then
+                echo "No files found to import."
+            else
+                for FILE in $FILES; do
+                    echo -n "Importing ${FILE}... "
+
+                    # Submit the file for import
+                    IMPORT_RESPONSE=$(curl --no-progress-meter --header "Authorization: Bearer ${LOGIN_TOKEN}" \
+                        --request POST \
+                        --form "importFile=@${FILE}" \
+                        --form "project=${PROJECT_ID}" \
+                        http://127.0.0.1:8080/api/import)
+                    # Extract the import ID from the response
+                    IMPORT_ID=$(echo ${IMPORT_RESPONSE} | jq -r '.id')
+                    IMPORT_STATUS=$(echo ${IMPORT_RESPONSE} | jq -r '.status')
+
+
+                    if [[ -z "$IMPORT_ID" ]]; then
+                        echo "Failed to get import ID."
+                        ((FAILED_IMPORTS++))
+                        continue
+                    fi
+
+                    # Wait for import to complete with a retry limit
+                    RETRY_COUNT=0
+                    MAX_RETRIES=10
+                    while ([[ "$IMPORT_STATUS" =~ "pending" ]] ||
+                        [[ "$IMPORT_STATUS" =~ "running" ]]) &&
+                        [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; do
+                        IMPORT_STATUS=$(curl --no-progress-meter --header "Authorization: Bearer ${LOGIN_TOKEN}" \
+                            http://127.0.0.1:8080/api/import/${IMPORT_ID} | jq -r '.status')
+
+                        # Increment retry counter
+                        ((RETRY_COUNT++))
+
+                        # Wait before checking again
+                        sleep 1
+                        echo -n " ."
+                    done
+
+                    # Check if we hit the retry limit
+                    if [[ $RETRY_COUNT -ge $MAX_RETRIES ]]; then
+                        echo "timed out after ${MAX_RETRIES} attempts."
+                        ((FAILED_IMPORTS++))
+                    fi
+
+                    if [[ "$IMPORT_STATUS" =~ "done" ]]; then
+                        echo " completed."
+                        ((SUCCESSFUL_IMPORTS++))
+                    else
+                        echo " weird state? "
+                    fi
+                done
+            fi
+            RUNS_COUNT=$(curl --no-progress-meter --header "Authorization: Bearer ${LOGIN_TOKEN}" \
+                http://127.0.0.1:8080/api/run | jq '.id | length')
+            echo "Runs in the database: ${RUNS_COUNT}"
+        fi
+    fi
+fi
+
 echo "================================="
 echo -n "Adding frontend to the pod:    "
-set -x
 podman run -d \
-       --rm \
        --pod $POD_NAME \
        --name ibutsu-frontend \
        -w /mnt \
@@ -200,22 +329,15 @@ podman run -d \
        /bin/bash -c "node --dns-result-order=ipv4first /usr/local/bin/npm install --no-save --no-package-lock yarn &&
          yarn install &&
          CI=1 yarn devserver"
-set +x
 echo "done."
+
 echo -n "Waiting for frontend to respond: "
 until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:3000); do
-  printf '.'
+  printf ' .'
   sleep 5
 done
-echo "frontend up."
+echo " frontend available."
 
-if [[ $CREATE_PROJECT = true ]]; then
-    echo -n "Creating default project..."
-    LOGIN_TOKEN=`curl --no-progress-meter --header "Content-Type: application/json" --request POST --data '{"email": "admin@example.com", "password": "admin12345"}' http://127.0.0.1:8080/api/login | grep 'token' | cut -d\" -f 4`
-    PROJECT_ID=`curl --no-progress-meter --header "Content-Type: application/json" --header "Authorization: Bearer ${LOGIN_TOKEN}" --request POST --data '{"name": "my-project", "title": "My Project"}' http://127.0.0.1:8080/api/project | grep '"id"' | cut -d\" -f 4`
-    echo "done."
-fi
-echo ""
 echo "Ibutsu has been deployed into the pod: ${POD_NAME}."
 echo "  Frontend URL: http://localhost:3000"
 echo "  Backend URL: http://localhost:8080"
@@ -226,7 +348,14 @@ else
 fi
 if [[ $CREATE_PROJECT = true ]]; then
     echo "  Project ID: ${PROJECT_ID}"
-else
-    echo "  No project created, use -P to create a project"
+    if [[ $SKIP_IMPORT_FILES = false ]]; then
+        if [[ -n "$SUCCESSFUL_IMPORTS" ]] && [[ "$SUCCESSFUL_IMPORTS" -gt 0 ]]; then
+            echo "  Successfully imported: ${SUCCESSFUL_IMPORTS} files"
+        fi
+        if [[ -n "$FAILED_IMPORTS" ]] && [[ "$FAILED_IMPORTS" -gt 0 ]]; then
+            echo "  Failed to import: ${FAILED_IMPORTS} files"
+        fi
+    fi
 fi
-echo "Stop the pod by running: 'podman pod rm -f ${POD_NAME}'"
+
+echo "Stop the pod by running: \"podman pod rm -f ${POD_NAME}\""


### PR DESCRIPTION
## Summary by Sourcery

Enable data loading in the ibutsu-pod script by adding import flags, automating project creation and file imports, and aligning the frontend file upload field with a new constant.

New Features:
- Add --skip-import-files and --import-folder flags to ibutsu-pod.sh to control archive import
- Automate default project creation and bulk import of .tar.gz data into Ibutsu via the pod script
- Introduce FILE_IMPORT_KEY constant and default file upload field name in the frontend

Enhancements:
- Refactor CLI argument parsing in ibutsu-pod.sh with a case-based loop and rename flags for clarity
- Remove automatic container cleanup flags and improve service readiness polling in the pod orchestration script
- Update frontend header to use the default FileUpload key constant instead of a hardcoded string