### PR TITLE
Update TestHistory to allow filter transfer

### DIFF
--- a/frontend/src/components/filtering/admin-filter.js
+++ b/frontend/src/components/filtering/admin-filter.js
@@ -109,6 +109,7 @@ const AdminFilter = () => {
         <ActiveFilters
           activeFilters={activeFilters}
           onRemoveFilter={onRemoveFilter}
+          transferTarget={null}
         />
       </Flex>
     </CardBody>

--- a/frontend/src/components/filtering/result-filter.js
+++ b/frontend/src/components/filtering/result-filter.js
@@ -499,6 +499,7 @@ const ResultFilter = ({ hideFilters, runs }) => {
             activeFilters={activeFilters}
             onRemoveFilter={onRemoveFilter}
             hideFilters={hideFilters}
+            transferTarget="reports"
           />
         </Flex>
       </Flex>

--- a/frontend/src/components/filtering/run-filter.js
+++ b/frontend/src/components/filtering/run-filter.js
@@ -150,6 +150,7 @@ const RunFilter = ({ hideFilters }) => {
             activeFilters={activeFilters}
             onRemoveFilter={onRemoveFilter}
             hideFilters={hideFilters}
+            transferTarget="reports"
           />
         </Flex>
       </Flex>

--- a/frontend/src/components/test-history.js
+++ b/frontend/src/components/test-history.js
@@ -364,6 +364,7 @@ const TestHistoryTable = ({ comparisonResults, testResult }) => {
                 activeFilters={activeFilters}
                 onRemoveFilter={onRemoveFilter}
                 hideFilters={HIDE}
+                transferTarget="results"
               />
             </FlexItem>
           </Flex>


### PR DESCRIPTION
Use a prop for ActiveFilters and compose the button there for both report builder and transfering to results/runs etc.

![image](https://github.com/user-attachments/assets/985bbc9f-2acc-40e7-916a-8fc534b02e05)

![image](https://github.com/user-attachments/assets/c5a9df83-e87c-41d1-ba68-89d61612731a)

## Summary by Sourcery

Allow composition of a transfer filters button via a new prop on ActiveFilters and apply it in TestHistory to transfer filters to the test results page.

New Features:
- Add a transfer_target prop to ActiveFilters for routing filter transfers to arbitrary pages
- Render a dynamic tertiary button in ActiveFilters with customizable text and an icon based on transfer_target

Enhancements:
- Use the new transfer_target in TestHistory to enable transferring active filters to the results page
- Simplify the TestHistory header Flex structure to accommodate the updated filter controls

## Summary by Sourcery

Add a composable transfer_target prop to ActiveFilters for customizable filter transfer routing and apply it in TestHistory to transfer active filters to the results page.

New Features:
- Add transfer_target prop to ActiveFilters to enable custom routing of filter transfers

Enhancements:
- Render a dynamic tertiary button in ActiveFilters with customizable text and icon based on transfer_target
- Use transfer_target in TestHistory to enable transferring active filters to the results page
- Simplify the TestHistory header Flex structure to support the updated filter controls