### PR TITLE
Fix legend rendering for Apex charts

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -158,13 +158,15 @@ WIDGET_TYPES = {
                 "required": True,
                 "default": 4,
             },
-            {
-                "name": "chart_type",
-                "description": "Type of chart with which to display results, e.g. 'bar' or 'line'",
-                "type": "string",
-                "required": False,
-                "default": "bar",
-            },
+            # TODO: write migration to force all widget configs to chart_type: "bar"
+            # Separate line chart into a different widget using apex stacked lines
+            # {
+            #     "name": "chart_type",
+            #     "description": "Type of chart with which to display results, e.g. 'bar' or 'line'",
+            #     "type": "string",
+            #     "required": False,
+            #     "default": "bar",
+            # },
             _ADDITIONAL_FILTERS_PARAM,
         ],
         "type": "widget",

--- a/frontend/src/components/hooks/useSVGContainerDimensions.js
+++ b/frontend/src/components/hooks/useSVGContainerDimensions.js
@@ -1,0 +1,51 @@
+import { useEffect, useState, useRef } from 'react';
+
+/**
+ * Hook to dynamically measure SVG container dimensions
+ * @returns {Object} { containerRef, width, height }
+ */
+export const useSVGContainerDimensions = () => {
+  const containerRef = useRef(null);
+  const [dimensions, setDimensions] = useState({ width: 300, height: 60 });
+  const resizeObserverRef = useRef(null);
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    const updateDimensions = () => {
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect();
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => {
+          setDimensions({
+            width: rect.width || 300,
+            height: Math.max(60, rect.height || 60),
+          });
+        }, 50);
+      }
+    };
+
+    // Initial measurement
+    if (containerRef.current) {
+      updateDimensions();
+    }
+
+    // Set up ResizeObserver
+    if (typeof ResizeObserver !== 'undefined' && containerRef.current) {
+      resizeObserverRef.current = new ResizeObserver(updateDimensions);
+      resizeObserverRef.current.observe(containerRef.current);
+    }
+
+    // Fallback for window resize
+    window.addEventListener('resize', updateDimensions);
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+      }
+      window.removeEventListener('resize', updateDimensions);
+    };
+  }, []);
+
+  return { containerRef, width: dimensions.width, height: dimensions.height };
+};

--- a/frontend/src/components/hooks/useWidgets.js
+++ b/frontend/src/components/hooks/useWidgets.js
@@ -16,6 +16,45 @@ import ResultSummaryApex from '../../widgets/ResultSummaryApex';
 import ResultAggregateApex from '../../widgets/ResultAggregateApex';
 import RunAggregateApex from '../../widgets/RunAggregateApex';
 
+// Move constants outside component to prevent unnecessary re-renders
+const DEFAULT_COLSPAN = Object.freeze({
+  sm: 12,
+  md: 6,
+  lg: 6,
+  xl: 4,
+  xl2: 4,
+});
+
+const COLUMN_SPAN = Object.freeze({
+  'jenkins-heatmap': { sm: 12, md: 6, lg: 6, xl: 6, xl2: 6 },
+  'filter-heatmap': { sm: 12, md: 6, lg: 6, xl: 6, xl2: 6 },
+  'run-aggregator': DEFAULT_COLSPAN,
+  'result-summary': DEFAULT_COLSPAN,
+  'result-aggregator': DEFAULT_COLSPAN,
+  'jenkins-bar-chart': DEFAULT_COLSPAN,
+  'jenkins-line-chart': DEFAULT_COLSPAN,
+  'importance-component': DEFAULT_COLSPAN,
+});
+
+const DEFAULT_ROWSPAN = Object.freeze({
+  smRowSpan: 1,
+  mdRowSpan: 1,
+  lgRowSpan: 1,
+  xlRowSpan: 1,
+  xl2RowSpan: 1,
+});
+
+const ROW_SPAN = Object.freeze({
+  'jenkins-heatmap': DEFAULT_ROWSPAN,
+  'filter-heatmap': DEFAULT_ROWSPAN,
+  'run-aggregator': DEFAULT_ROWSPAN,
+  'result-summary': DEFAULT_ROWSPAN,
+  'result-aggregator': DEFAULT_ROWSPAN,
+  'jenkins-bar-chart': DEFAULT_ROWSPAN,
+  'jenkins-line-chart': DEFAULT_ROWSPAN,
+  'importance-component': DEFAULT_ROWSPAN,
+});
+
 export const useWidgets = ({
   dashboardId = null,
   editCallback = () => {},
@@ -52,26 +91,13 @@ export const useWidgets = ({
     }
   }, [dashboardId, primaryObject, loadKey]);
 
-  // Proxy this to set defaults?
-  const DEFAULT_SIZES = Object.freeze({ sm: 12, md: 6, lg: 6, xl: 4, xl2: 4 });
-
-  const gridItemSpan = Object.freeze({
-    'jenkins-heatmap': { sm: 12, md: 6, lg: 6, xl: 6, xl2: 6 },
-    'filter-heatmap': { sm: 12, md: 6, lg: 6, xl: 6, xl2: 6 },
-    'run-aggregator': DEFAULT_SIZES,
-    'result-summary': DEFAULT_SIZES,
-    'result-aggregator': DEFAULT_SIZES,
-    'jenkins-bar-chart': DEFAULT_SIZES,
-    'jenkins-line-chart': DEFAULT_SIZES,
-    'importance-component': DEFAULT_SIZES,
-  });
-
   const widgetComponents = useMemo(() => {
     return widgets?.map((widget) => {
       if (KNOWN_WIDGETS.includes(widget.widget)) {
         return (
           <GridItem
-            {...gridItemSpan[widget.widget]}
+            {...COLUMN_SPAN[widget.widget]}
+            {...ROW_SPAN[widget.widget]}
             key={`${widget.id}-${loadKey}`}
           >
             {widget.type === 'widget' &&
@@ -198,7 +224,7 @@ export const useWidgets = ({
         );
       }
     });
-  }, [deleteCallback, editCallback, gridItemSpan, loadKey, widgets]);
+  }, [deleteCallback, editCallback, loadKey, widgets]);
 
   return { widgets, widgetComponents };
 };

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -24,6 +24,8 @@ export const KNOWN_WIDGETS = [
   'jenkins-line-chart',
   'importance-component',
 ];
+export const WIDGET_HEIGHT = 250; // px
+
 export const STRING_OPERATIONS = Object.freeze({
   eq: { opChar: '=', opString: 'equals' },
   ne: { opChar: '!', opString: 'not equals' },
@@ -228,6 +230,20 @@ export const CHART_COLOR_MAP = Object.freeze({
   manual: 'var(--pf-t--chart--color--cyan--500)',
   default: 'var(--pf-t--chart--color--black--100)',
 });
+
+// Default color palette for non-result aggregations using PatternFly chart color tokens
+export const DEFAULT_CHART_COLORS = Object.freeze([
+  'var(--pf-t--chart--color--blue--100)',
+  'var(--pf-t--chart--color--green--100)',
+  'var(--pf-t--chart--color--purple--200)',
+  'var(--pf-t--chart--color--cyan--500)',
+  'var(--pf-t--chart--color--orange--300)',
+  'var(--pf-t--chart--color--red--100)',
+  'var(--pf-t--chart--color--teal--500)',
+  'var(--pf-t--chart--color--pink--300)',
+  'var(--pf-t--chart--color--lime--400)',
+  'var(--pf-t--chart--color--indigo--300)',
+]);
 
 export const FILE_IMPORT_KEY = 'importFile';
 

--- a/frontend/src/views/compareruns.js
+++ b/frontend/src/views/compareruns.js
@@ -104,8 +104,6 @@ const CompareRunsView = () => {
         project_id: { op: 'in', val: projectId },
       };
 
-      console.dir(filtersWithProject);
-
       // Retrieve results from database
       HttpClient.get([Settings.serverUrl, 'widget', 'compare-runs-view'], {
         filters: filtersWithProject.map((f) => toAPIFilter(f)),

--- a/frontend/src/widgets/ResultWidgetLegend.js
+++ b/frontend/src/widgets/ResultWidgetLegend.js
@@ -7,7 +7,7 @@ const ResultWidgetLegend = ({ x, y, datum, style }) => {
   const textOffset = iconSize + 8;
   const resultType = datum?.symbol?.type;
 
-  // Get the appropriate icon from ICON_RESULT_MAP
+  // Get the appropriate icon from ICON_RESULT_MAP (already has correct colors)
   const IconComponent = ICON_RESULT_MAP[resultType];
 
   if (!IconComponent) {
@@ -51,12 +51,8 @@ const ResultWidgetLegend = ({ x, y, datum, style }) => {
           style={{
             width: iconSize,
             height: iconSize,
-            display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            color:
-              datum.symbol?.fill ||
-              'var(--pf-t--global--color--brand--default)',
           }}
         >
           {IconComponent}

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -437,7 +437,8 @@ if [[ $CREATE_PROJECT = true ]]; then
                     \"widget\": \"result-aggregator\", \
                     \"params\": {\"group_field\": \"result\", \
                                 \"chart_type\": \"donut\", \
-                                \"days\": 120}}" \
+                                \"days\": 30, \
+                                \"additional_filters\": \"env*stage_proxy;stage\", \}}" \
             http://127.0.0.1:8080/api/widget-config | jq -r '.id')
         echo "  Result Aggregator ID: ${RESULT_AGGREGATOR}"
 


### PR DESCRIPTION
switch between the result legend with custom icons and the apex legend for ResultAgg

## Summary by Sourcery

Add custom legend rendering and responsive sizing enhancements to Apex charts across multiple widgets, refactor color utilities and layout constants, and clean up deprecated configurations and debug logs.

New Features:
- Enable custom icon legends for result-type donut charts in ResultAggregateApex and ResultSummaryApex, switching seamlessly from default Apex legends when appropriate

Bug Fixes:
- Fix legend rendering issues by toggling between custom and Apex legends based on data mapping

Enhancements:
- Refactor color assignment with DEFAULT_CHART_COLORS and getColorForLabel utilities for consistent chart styling
- Implement responsive legend layout using SVG positioning and dynamic row/column calculations
- Introduce ResizeObserver-based responsive chart height calculation in RunAggregateApex for variable container and data sizes
- Extract WIDGET_HEIGHT constant for uniform chart sizing
- Update grid layout in useWidgets hook with distinct column and row span definitions

Chores:
- Comment out deprecated chart_type widget configuration in backend constants
- Adjust default days and add additional_filters in ibutsu-pod.sh script
- Remove console.dir debug statements from frontend code