### PR TITLE
Release 2.7.1 file versioning

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: A system to store and query test results
   title: Ibutsu API
-  version: 2.7.0
+  version: 2.7.1
 servers:
   - url: /api
 tags:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "2.7.0"
+version = "2.7.1"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "private": true,
   "dependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
## Summary by Sourcery

Bump the project version to 2.7.1 for release

Chores:
- Update API version to 2.7.1 in openapi.yaml
- Bump Python project version to 2.7.1 in pyproject.toml
- Upgrade frontend package version to 2.7.1 in package.json