### PR TITLE
Safe element reference in activeFilter

### DIFF
--- a/frontend/src/components/filtering/active-filters.js
+++ b/frontend/src/components/filtering/active-filters.js
@@ -32,7 +32,7 @@ const ActiveFilters = ({
   const navigate = useNavigate();
 
   const shownFilters = activeFilters?.filter(
-    (filter) => !hideFilters?.includes(filter.field),
+    (filter) => !hideFilters?.includes(filter?.field),
   );
 
   // Get the proper button text based on transfer_target
@@ -61,7 +61,7 @@ const ActiveFilters = ({
                     pathname: `/project/${params.project_id}/${transferTarget}`,
                     search: filtersToSearchParams(
                       activeFilters.filter(
-                        (filter) => filter.field !== 'project_id',
+                        (filter) => filter?.field !== 'project_id',
                       ),
                     ),
                   })


### PR DESCRIPTION
## Summary by Sourcery

Add optional chaining to filter.field references in ActiveFilters to prevent runtime errors when filter items are null or undefined

Bug Fixes:
- Use filter?.field instead of filter.field when filtering out hidden filters
- Use filter?.field instead of filter.field when excluding project_id in URL search parameters