### PR TITLE
Add 'quick' links to filtered results in run summary page

### DIFF
--- a/frontend/src/components/filtering/active-filters.js
+++ b/frontend/src/components/filtering/active-filters.js
@@ -63,7 +63,7 @@ const ActiveFilters = ({
                       activeFilters.filter(
                         (filter) => filter?.field !== 'project_id',
                       ),
-                    ),
+                    ).toString(),
                   })
                 }
                 variant="tertiary"

--- a/frontend/src/components/resultView.js
+++ b/frontend/src/components/resultView.js
@@ -153,7 +153,7 @@ const ResultView = ({
       <Link
         to={{
           pathname: `/project/${project_id}/results`,
-          search: componentSearch,
+          search: componentSearch.toString(),
         }}
       >
         {testResult.component}
@@ -177,7 +177,7 @@ const ResultView = ({
       <Link
         to={{
           pathname: `/project/${project_id}/results`,
-          search: sourceSearch,
+          search: sourceSearch.toString(),
         }}
         relative="Path"
       >

--- a/frontend/src/run.js
+++ b/frontend/src/run.js
@@ -49,6 +49,7 @@ import { Settings } from './settings';
 import {
   resultToRow,
   filtersToAPIParams,
+  filtersToSearchParams,
   processPyTestPath,
   cleanPath,
 } from './utilities';
@@ -574,10 +575,18 @@ const Run = ({ defaultTab = 'summary' }) => {
                                       <Link
                                         to={{
                                           pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                          search: new URLSearchParams({
-                                            run_id: `[eq]${run.id}`,
-                                            result: `[eq]passed`,
-                                          }).toString(),
+                                          search: filtersToSearchParams([
+                                            {
+                                              field: 'run_id',
+                                              operator: 'eq',
+                                              value: run.id,
+                                            },
+                                            {
+                                              field: 'result',
+                                              operator: 'eq',
+                                              value: 'passed',
+                                            },
+                                          ]),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -607,10 +616,18 @@ const Run = ({ defaultTab = 'summary' }) => {
                                       <Link
                                         to={{
                                           pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                          search: new URLSearchParams({
-                                            run_id: `[eq]${run.id}`,
-                                            result: `[eq]failed`,
-                                          }).toString(),
+                                          search: filtersToSearchParams([
+                                            {
+                                              field: 'run_id',
+                                              operator: 'eq',
+                                              value: run.id,
+                                            },
+                                            {
+                                              field: 'result',
+                                              operator: 'eq',
+                                              value: 'failed',
+                                            },
+                                          ]),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -640,10 +657,18 @@ const Run = ({ defaultTab = 'summary' }) => {
                                       <Link
                                         to={{
                                           pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                          search: new URLSearchParams({
-                                            run_id: `[eq]${run.id}`,
-                                            result: `[eq]errors`,
-                                          }).toString(),
+                                          search: filtersToSearchParams([
+                                            {
+                                              field: 'run_id',
+                                              operator: 'eq',
+                                              value: run.id,
+                                            },
+                                            {
+                                              field: 'result',
+                                              operator: 'eq',
+                                              value: 'error',
+                                            },
+                                          ]),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -673,10 +698,18 @@ const Run = ({ defaultTab = 'summary' }) => {
                                       <Link
                                         to={{
                                           pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                          search: new URLSearchParams({
-                                            run_id: `[eq]${run.id}`,
-                                            result: `[eq]xfailed`,
-                                          }).toString(),
+                                          search: filtersToSearchParams([
+                                            {
+                                              field: 'run_id',
+                                              operator: 'eq',
+                                              value: run.id,
+                                            },
+                                            {
+                                              field: 'result',
+                                              operator: 'eq',
+                                              value: 'xfailed',
+                                            },
+                                          ]),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -706,10 +739,18 @@ const Run = ({ defaultTab = 'summary' }) => {
                                       <Link
                                         to={{
                                           pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                          search: new URLSearchParams({
-                                            run_id: `[eq]${run.id}`,
-                                            result: `[eq]xpassed`,
-                                          }).toString(),
+                                          search: filtersToSearchParams([
+                                            {
+                                              field: 'run_id',
+                                              operator: 'eq',
+                                              value: run.id,
+                                            },
+                                            {
+                                              field: 'result',
+                                              operator: 'eq',
+                                              value: 'xpassed',
+                                            },
+                                          ]),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -739,10 +780,18 @@ const Run = ({ defaultTab = 'summary' }) => {
                                       <Link
                                         to={{
                                           pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                          search: new URLSearchParams({
-                                            run_id: `[eq]${run.id}`,
-                                            result: `[eq]skipped`,
-                                          }).toString(),
+                                          search: filtersToSearchParams([
+                                            {
+                                              field: 'run_id',
+                                              operator: 'eq',
+                                              value: run.id,
+                                            },
+                                            {
+                                              field: 'result',
+                                              operator: 'eq',
+                                              value: 'skipped',
+                                            },
+                                          ]),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -772,10 +821,18 @@ const Run = ({ defaultTab = 'summary' }) => {
                                       <Link
                                         to={{
                                           pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                          search: new URLSearchParams({
-                                            run_id: `[eq]${run.id}`,
-                                            result: `[eq]manual`,
-                                          }).toString(),
+                                          search: filtersToSearchParams([
+                                            {
+                                              field: 'run_id',
+                                              operator: 'eq',
+                                              value: run.id,
+                                            },
+                                            {
+                                              field: 'result',
+                                              operator: 'eq',
+                                              value: 'manual',
+                                            },
+                                          ]),
                                         }}
                                       >
                                         <DataListItemRow>

--- a/frontend/src/run.js
+++ b/frontend/src/run.js
@@ -567,257 +567,236 @@ const Run = ({ defaultTab = 'summary' }) => {
                                         />
                                       </DataListItemRow>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Passed">
-                                      <DataListItemRow>
-                                        <DataListItemCells
-                                          dataListCells={[
-                                            <DataListCell key={1}>
-                                              <Label
-                                                variant="filled"
-                                                icon={ICON_RESULT_MAP.passed}
-                                                title="Passed"
-                                              >
-                                                Passed
-                                              </Label>
-                                            </DataListCell>,
-                                            <DataListCell key={2}>
-                                              {passed > 0 ? (
-                                                <Link
-                                                  to={{
-                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                                    search: new URLSearchParams(
-                                                      {
-                                                        run_id: `[eq]${run.id}`,
-                                                        result: `[eq]passed`,
-                                                      },
-                                                    ).toString(),
-                                                  }}
+                                    <DataListItem
+                                      aria-labelledby="Passed"
+                                      class="pf-v6-c-data-list__item pf-m-clickable"
+                                    >
+                                      <Link
+                                        to={{
+                                          pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                          search: new URLSearchParams({
+                                            run_id: `[eq]${run.id}`,
+                                            result: `[eq]passed`,
+                                          }).toString(),
+                                        }}
+                                      >
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>
+                                                <Label
+                                                  variant="filled"
+                                                  icon={ICON_RESULT_MAP.passed}
+                                                  title="Passed"
                                                 >
-                                                  {passed}
-                                                </Link>
-                                              ) : (
-                                                passed
-                                              )}
-                                            </DataListCell>,
-                                          ]}
-                                        />
-                                      </DataListItemRow>
+                                                  Passed
+                                                </Label>
+                                              </DataListCell>,
+                                              <DataListCell key={2}>
+                                                {passed}
+                                              </DataListCell>,
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </Link>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Failed">
-                                      <DataListItemRow>
-                                        <DataListItemCells
-                                          dataListCells={[
-                                            <DataListCell key={1}>
-                                              <Label
-                                                variant="filled"
-                                                icon={ICON_RESULT_MAP.failed}
-                                                title="Failed"
-                                              >
-                                                Failed
-                                              </Label>
-                                            </DataListCell>,
-                                            <DataListCell key={2}>
-                                              {failed > 0 ? (
-                                                <Link
-                                                  to={{
-                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                                    search: new URLSearchParams(
-                                                      {
-                                                        run_id: `[eq]${run.id}`,
-                                                        result: `[eq]failed`,
-                                                      },
-                                                    ).toString(),
-                                                  }}
+                                    <DataListItem
+                                      aria-labelledby="Failed"
+                                      class="pf-v6-c-data-list__item pf-m-clickable"
+                                    >
+                                      <Link
+                                        to={{
+                                          pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                          search: new URLSearchParams({
+                                            run_id: `[eq]${run.id}`,
+                                            result: `[eq]failed`,
+                                          }).toString(),
+                                        }}
+                                      >
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>
+                                                <Label
+                                                  variant="filled"
+                                                  icon={ICON_RESULT_MAP.failed}
+                                                  title="Failed"
                                                 >
-                                                  {failed}
-                                                </Link>
-                                              ) : (
-                                                failed
-                                              )}
-                                            </DataListCell>,
-                                          ]}
-                                        />
-                                      </DataListItemRow>
+                                                  Failed
+                                                </Label>
+                                              </DataListCell>,
+                                              <DataListCell key={2}>
+                                                {failed}
+                                              </DataListCell>,
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </Link>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Error">
-                                      <DataListItemRow>
-                                        <DataListItemCells
-                                          dataListCells={[
-                                            <DataListCell key={1}>
-                                              <Label
-                                                variant="filled"
-                                                icon={ICON_RESULT_MAP.error}
-                                                title="Error"
-                                              >
-                                                Error
-                                              </Label>
-                                            </DataListCell>,
-                                            <DataListCell key={2}>
-                                              {errors > 0 ? (
-                                                <Link
-                                                  to={{
-                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                                    search: new URLSearchParams(
-                                                      {
-                                                        run_id: `[eq]${run.id}`,
-                                                        result: `[eq]errors`,
-                                                      },
-                                                    ).toString(),
-                                                  }}
+                                    <DataListItem
+                                      aria-labelledby="Error"
+                                      class="pf-v6-c-data-list__item pf-m-clickable"
+                                    >
+                                      <Link
+                                        to={{
+                                          pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                          search: new URLSearchParams({
+                                            run_id: `[eq]${run.id}`,
+                                            result: `[eq]errors`,
+                                          }).toString(),
+                                        }}
+                                      >
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>
+                                                <Label
+                                                  variant="filled"
+                                                  icon={ICON_RESULT_MAP.error}
+                                                  title="Error"
                                                 >
-                                                  {errors}
-                                                </Link>
-                                              ) : (
-                                                errors
-                                              )}
-                                            </DataListCell>,
-                                          ]}
-                                        />
-                                      </DataListItemRow>
+                                                  Error
+                                                </Label>
+                                              </DataListCell>,
+                                              <DataListCell key={2}>
+                                                {errors}
+                                              </DataListCell>,
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </Link>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Xfailed">
-                                      <DataListItemRow>
-                                        <DataListItemCells
-                                          dataListCells={[
-                                            <DataListCell key={1}>
-                                              <Label
-                                                variant="filled"
-                                                icon={ICON_RESULT_MAP.xfailed}
-                                                title="Xfailed"
-                                              >
-                                                Xfailed
-                                              </Label>
-                                            </DataListCell>,
-                                            <DataListCell key={2}>
-                                              {xfailed > 0 ? (
-                                                <Link
-                                                  to={{
-                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                                    search: new URLSearchParams(
-                                                      {
-                                                        run_id: `[eq]${run.id}`,
-                                                        result: `[eq]xfailed`,
-                                                      },
-                                                    ).toString(),
-                                                  }}
+                                    <DataListItem
+                                      aria-labelledby="Xfailed"
+                                      class="pf-v6-c-data-list__item pf-m-clickable"
+                                    >
+                                      <Link
+                                        to={{
+                                          pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                          search: new URLSearchParams({
+                                            run_id: `[eq]${run.id}`,
+                                            result: `[eq]xfailed`,
+                                          }).toString(),
+                                        }}
+                                      >
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>
+                                                <Label
+                                                  variant="filled"
+                                                  icon={ICON_RESULT_MAP.xfailed}
+                                                  title="Xfailed"
                                                 >
-                                                  {xfailed}
-                                                </Link>
-                                              ) : (
-                                                xfailed
-                                              )}
-                                            </DataListCell>,
-                                          ]}
-                                        />
-                                      </DataListItemRow>
+                                                  Xfailed
+                                                </Label>
+                                              </DataListCell>,
+                                              <DataListCell key={2}>
+                                                {xfailed}
+                                              </DataListCell>,
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </Link>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Xpassed">
-                                      <DataListItemRow>
-                                        <DataListItemCells
-                                          dataListCells={[
-                                            <DataListCell key={1}>
-                                              <Label
-                                                variant="filled"
-                                                icon={ICON_RESULT_MAP.xpassed}
-                                                title="Xpassed"
-                                              >
-                                                Xpassed
-                                              </Label>
-                                            </DataListCell>,
-                                            <DataListCell key={2}>
-                                              {xpassed > 0 ? (
-                                                <Link
-                                                  to={{
-                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                                    search: new URLSearchParams(
-                                                      {
-                                                        run_id: `[eq]${run.id}`,
-                                                        result: `[eq]xpassed`,
-                                                      },
-                                                    ).toString(),
-                                                  }}
+                                    <DataListItem
+                                      aria-labelledby="Xpassed"
+                                      class="pf-v6-c-data-list__item pf-m-clickable"
+                                    >
+                                      <Link
+                                        to={{
+                                          pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                          search: new URLSearchParams({
+                                            run_id: `[eq]${run.id}`,
+                                            result: `[eq]xpassed`,
+                                          }).toString(),
+                                        }}
+                                      >
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>
+                                                <Label
+                                                  variant="filled"
+                                                  icon={ICON_RESULT_MAP.xpassed}
+                                                  title="Xpassed"
                                                 >
-                                                  {xpassed}
-                                                </Link>
-                                              ) : (
-                                                xpassed
-                                              )}
-                                            </DataListCell>,
-                                          ]}
-                                        />
-                                      </DataListItemRow>
+                                                  Xpassed
+                                                </Label>
+                                              </DataListCell>,
+                                              <DataListCell key={2}>
+                                                {xpassed}
+                                              </DataListCell>,
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </Link>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Skipped">
-                                      <DataListItemRow>
-                                        <DataListItemCells
-                                          dataListCells={[
-                                            <DataListCell key={1}>
-                                              <Label
-                                                variant="filled"
-                                                icon={ICON_RESULT_MAP.skipped}
-                                                title="Skipped"
-                                              >
-                                                Skipped
-                                              </Label>
-                                            </DataListCell>,
-                                            <DataListCell key={2}>
-                                              {skipped > 0 ? (
-                                                <Link
-                                                  to={{
-                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                                    search: new URLSearchParams(
-                                                      {
-                                                        run_id: `[eq]${run.id}`,
-                                                        result: `[eq]skipped`,
-                                                      },
-                                                    ).toString(),
-                                                  }}
+                                    <DataListItem
+                                      aria-labelledby="Skipped"
+                                      class="pf-v6-c-data-list__item pf-m-clickable"
+                                    >
+                                      <Link
+                                        to={{
+                                          pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                          search: new URLSearchParams({
+                                            run_id: `[eq]${run.id}`,
+                                            result: `[eq]skipped`,
+                                          }).toString(),
+                                        }}
+                                      >
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>
+                                                <Label
+                                                  variant="filled"
+                                                  icon={ICON_RESULT_MAP.skipped}
+                                                  title="Skipped"
                                                 >
-                                                  {skipped}
-                                                </Link>
-                                              ) : (
-                                                skipped
-                                              )}
-                                            </DataListCell>,
-                                          ]}
-                                        />
-                                      </DataListItemRow>
+                                                  Skipped
+                                                </Label>
+                                              </DataListCell>,
+                                              <DataListCell key={2}>
+                                                {skipped}
+                                              </DataListCell>,
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </Link>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Not Run">
-                                      <DataListItemRow>
-                                        <DataListItemCells
-                                          dataListCells={[
-                                            <DataListCell key={1}>
-                                              <Label
-                                                variant="filled"
-                                                icon={ICON_RESULT_MAP.manual}
-                                                title="Not Run / Manual"
-                                              >
-                                                Not Run / Manual
-                                              </Label>
-                                            </DataListCell>,
-                                            <DataListCell key={2}>
-                                              {not_run > 0 ? (
-                                                <Link
-                                                  to={{
-                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
-                                                    search: new URLSearchParams(
-                                                      {
-                                                        run_id: `[eq]${run.id}`,
-                                                        result: `[eq]manual`,
-                                                      },
-                                                    ).toString(),
-                                                  }}
+                                    <DataListItem
+                                      aria-labelledby="Not Run"
+                                      class="pf-v6-c-data-list__item pf-m-clickable"
+                                    >
+                                      <Link
+                                        to={{
+                                          pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                          search: new URLSearchParams({
+                                            run_id: `[eq]${run.id}`,
+                                            result: `[eq]manual`,
+                                          }).toString(),
+                                        }}
+                                      >
+                                        <DataListItemRow>
+                                          <DataListItemCells
+                                            dataListCells={[
+                                              <DataListCell key={1}>
+                                                <Label
+                                                  variant="filled"
+                                                  icon={ICON_RESULT_MAP.manual}
+                                                  title="Not Run / Manual"
                                                 >
-                                                  {not_run}
-                                                </Link>
-                                              ) : (
-                                                not_run
-                                              )}
-                                            </DataListCell>,
-                                          ]}
-                                        />
-                                      </DataListItemRow>
+                                                  Not Run / Manual
+                                                </Label>
+                                              </DataListCell>,
+                                              <DataListCell key={2}>
+                                                {not_run}
+                                              </DataListCell>,
+                                            ]}
+                                          />
+                                        </DataListItemRow>
+                                      </Link>
                                     </DataListItem>
                                   </DataList>
                                 </DataListCell>,

--- a/frontend/src/run.js
+++ b/frontend/src/run.js
@@ -581,7 +581,23 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               </Label>
                                             </DataListCell>,
                                             <DataListCell key={2}>
-                                              {passed}
+                                              {passed > 0 ? (
+                                                <Link
+                                                  to={{
+                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                                    search: new URLSearchParams(
+                                                      {
+                                                        run_id: `[eq]${run.id}`,
+                                                        result: `[eq]passed`,
+                                                      },
+                                                    ).toString(),
+                                                  }}
+                                                >
+                                                  {passed}
+                                                </Link>
+                                              ) : (
+                                                passed
+                                              )}
                                             </DataListCell>,
                                           ]}
                                         />
@@ -601,7 +617,23 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               </Label>
                                             </DataListCell>,
                                             <DataListCell key={2}>
-                                              {failed}
+                                              {failed > 0 ? (
+                                                <Link
+                                                  to={{
+                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                                    search: new URLSearchParams(
+                                                      {
+                                                        run_id: `[eq]${run.id}`,
+                                                        result: `[eq]failed`,
+                                                      },
+                                                    ).toString(),
+                                                  }}
+                                                >
+                                                  {failed}
+                                                </Link>
+                                              ) : (
+                                                failed
+                                              )}
                                             </DataListCell>,
                                           ]}
                                         />
@@ -621,7 +653,23 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               </Label>
                                             </DataListCell>,
                                             <DataListCell key={2}>
-                                              {errors}
+                                              {errors > 0 ? (
+                                                <Link
+                                                  to={{
+                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                                    search: new URLSearchParams(
+                                                      {
+                                                        run_id: `[eq]${run.id}`,
+                                                        result: `[eq]errors`,
+                                                      },
+                                                    ).toString(),
+                                                  }}
+                                                >
+                                                  {errors}
+                                                </Link>
+                                              ) : (
+                                                errors
+                                              )}
                                             </DataListCell>,
                                           ]}
                                         />
@@ -641,7 +689,23 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               </Label>
                                             </DataListCell>,
                                             <DataListCell key={2}>
-                                              {xfailed}
+                                              {xfailed > 0 ? (
+                                                <Link
+                                                  to={{
+                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                                    search: new URLSearchParams(
+                                                      {
+                                                        run_id: `[eq]${run.id}`,
+                                                        result: `[eq]xfailed`,
+                                                      },
+                                                    ).toString(),
+                                                  }}
+                                                >
+                                                  {xfailed}
+                                                </Link>
+                                              ) : (
+                                                xfailed
+                                              )}
                                             </DataListCell>,
                                           ]}
                                         />
@@ -661,7 +725,23 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               </Label>
                                             </DataListCell>,
                                             <DataListCell key={2}>
-                                              {xpassed}
+                                              {xpassed > 0 ? (
+                                                <Link
+                                                  to={{
+                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                                    search: new URLSearchParams(
+                                                      {
+                                                        run_id: `[eq]${run.id}`,
+                                                        result: `[eq]xpassed`,
+                                                      },
+                                                    ).toString(),
+                                                  }}
+                                                >
+                                                  {xpassed}
+                                                </Link>
+                                              ) : (
+                                                xpassed
+                                              )}
                                             </DataListCell>,
                                           ]}
                                         />
@@ -681,7 +761,23 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               </Label>
                                             </DataListCell>,
                                             <DataListCell key={2}>
-                                              {skipped}
+                                              {skipped > 0 ? (
+                                                <Link
+                                                  to={{
+                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                                    search: new URLSearchParams(
+                                                      {
+                                                        run_id: `[eq]${run.id}`,
+                                                        result: `[eq]skipped`,
+                                                      },
+                                                    ).toString(),
+                                                  }}
+                                                >
+                                                  {skipped}
+                                                </Link>
+                                              ) : (
+                                                skipped
+                                              )}
                                             </DataListCell>,
                                           ]}
                                         />
@@ -701,7 +797,23 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               </Label>
                                             </DataListCell>,
                                             <DataListCell key={2}>
-                                              {not_run}
+                                              {not_run > 0 ? (
+                                                <Link
+                                                  to={{
+                                                    pathname: `/project/${primaryObject?.id || project_id}/results`,
+                                                    search: new URLSearchParams(
+                                                      {
+                                                        run_id: `[eq]${run.id}`,
+                                                        result: `[eq]manual`,
+                                                      },
+                                                    ).toString(),
+                                                  }}
+                                                >
+                                                  {not_run}
+                                                </Link>
+                                              ) : (
+                                                not_run
+                                              )}
                                             </DataListCell>,
                                           ]}
                                         />

--- a/frontend/src/run.js
+++ b/frontend/src/run.js
@@ -586,7 +586,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               operator: 'eq',
                                               value: 'passed',
                                             },
-                                          ]),
+                                          ]).toString(),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -627,7 +627,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               operator: 'eq',
                                               value: 'failed',
                                             },
-                                          ]),
+                                          ]).toString(),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -668,7 +668,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               operator: 'eq',
                                               value: 'error',
                                             },
-                                          ]),
+                                          ]).toString(),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -709,7 +709,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               operator: 'eq',
                                               value: 'xfailed',
                                             },
-                                          ]),
+                                          ]).toString(),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -750,7 +750,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               operator: 'eq',
                                               value: 'xpassed',
                                             },
-                                          ]),
+                                          ]).toString(),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -791,7 +791,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               operator: 'eq',
                                               value: 'skipped',
                                             },
-                                          ]),
+                                          ]).toString(),
                                         }}
                                       >
                                         <DataListItemRow>
@@ -832,7 +832,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               operator: 'eq',
                                               value: 'manual',
                                             },
-                                          ]),
+                                          ]).toString(),
                                         }}
                                       >
                                         <DataListItemRow>

--- a/frontend/src/utilities.js
+++ b/frontend/src/utilities.js
@@ -85,7 +85,7 @@ export const filtersToSearchParams = (filters = []) => {
   filters.forEach((filter) => {
     newSearchParams.set([filter.field], `[${filter.operator}]${filter.value}`);
   });
-  return newSearchParams.toString();
+  return newSearchParams;
 };
 
 export const toAPIFilter = (filters) => {
@@ -307,7 +307,7 @@ export const runToRow = (run, filterFunc) => {
           pathname: '../results',
           search: filtersToSearchParams([
             { field: 'run_id', operator: 'eq', value: run.id },
-          ]),
+          ]).toString(),
         }}
         relative="Path"
       >

--- a/frontend/src/views/jenkinsjob.js
+++ b/frontend/src/views/jenkinsjob.js
@@ -89,15 +89,13 @@ const JenkinsJobView = ({ view }) => {
           value: job.build_number,
         },
       ];
-      const searchString = new URLSearchParams(
-        filtersToSearchParams([
-          {
-            field: 'job_name',
-            operator: 'eq',
-            value: job.job_name,
-          },
-        ]),
-      ).toString();
+      const searchString = filtersToSearchParams([
+        {
+          field: 'job_name',
+          operator: 'eq',
+          value: job.job_name,
+        },
+      ]);
       return {
         cells: [
           analysisViewId
@@ -106,7 +104,7 @@ const JenkinsJobView = ({ view }) => {
                   <Link
                     to={{
                       pathname: `../view/${analysisViewId}`,
-                      search: searchString,
+                      search: searchString.toString(),
                     }}
                     relative="Path"
                   >
@@ -131,7 +129,7 @@ const JenkinsJobView = ({ view }) => {
             key="see-runs"
             to={{
               pathname: `/project/${project_id}/runs`,
-              search: `${filtersToSearchParams(runFilters)}`,
+              search: `${filtersToSearchParams(runFilters).toString()}`,
             }}
           >
             See runs <ChevronRightIcon />

--- a/frontend/src/widgets/filterheatmap.js
+++ b/frontend/src/widgets/filterheatmap.js
@@ -80,21 +80,19 @@ const FilterHeatmapWidget = ({
 
   const jenkinsAnalysisLink = useMemo(() => {
     if (type === HEATMAP_TYPES.jenkins && analysisViewId !== null) {
-      const searchString = new URLSearchParams(
-        filtersToSearchParams([
-          {
-            field: 'job_name',
-            operator: 'eq',
-            value: params?.job_name,
-          },
-        ]),
-      ).toString();
+      const searchString = filtersToSearchParams([
+        {
+          field: 'job_name',
+          operator: 'eq',
+          value: params?.job_name,
+        },
+      ]);
       return (
         <Link
           key="jenkins-analysis-link"
           to={{
             pathname: `/project/${primaryObject?.id || params?.project}/view/${analysisViewId}`,
-            search: searchString,
+            search: searchString.toString(),
             hash: 'heatmap',
           }}
         >
@@ -244,20 +242,18 @@ const FilterHeatmapWidget = ({
       renderData.push(values);
       values.forEach((item) => {
         if (!!item && item.length > 2 && !!item[3]) {
-          const newSearchParams = new URLSearchParams(
-            filtersToSearchParams([
-              {
-                field: 'metadata.jenkins.build_number',
-                operator: 'eq',
-                value: item[3],
-              },
-              {
-                field: 'metadata.jenkins.job_name',
-                operator: 'eq',
-                value: params?.job_name,
-              },
-            ]),
-          );
+          const newSearchParams = filtersToSearchParams([
+            {
+              field: 'metadata.jenkins.build_number',
+              operator: 'eq',
+              value: item[3],
+            },
+            {
+              field: 'metadata.jenkins.job_name',
+              operator: 'eq',
+              value: params?.job_name,
+            },
+          ]);
           newLabels.push(
             <Link
               to={{


### PR DESCRIPTION
This PR introduces a link for each "result type" (passed, failed, etc.) instead of a number in plain text.
Example:

<img width="791" height="585" alt="image" src="https://github.com/user-attachments/assets/2dbaf140-f351-456a-a1fd-b57fe8fb0ca6" />


## Summary by Sourcery

New Features:
- Wrap non-zero passed, failed, errors, xfailed, xpassed, skipped, and not_run counts in links to filter the results list for that run and result category.

## Summary by Sourcery

Wrap each result count in the run summary page with a Link that navigates to the filtered results view, and refactor the filtersToSearchParams helper to return URLSearchParams, updating all callers to serialize search parameters.

New Features:
- Make passed, failed, errors, xfailed, xpassed, skipped, and not_run counts in the run summary page clickable links that filter to the corresponding results

Enhancements:
- Refactor filtersToSearchParams to return a URLSearchParams object instead of a string
- Update all Link components and utilities to serialize URLSearchParams with toString() for search params