### PR TITLE
Admin validation decorator and user controller enhancement

### DIFF
--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -274,13 +274,13 @@ class User(Model, ModelMixin):
 
         # 3. Reassign owned projects to the current user (admin performing deletion)
         session.query(Project).filter_by(owner_id=self.id).update(
-            {"owner_id": new_owner}, synchronize_session=False
+            {"owner_id": new_owner.id}, synchronize_session=False
         )
 
         # 4. Reassign dashboards to the current user (admin performing deletion)
         # TODO: this field is null on every prod record, evaluate dropping the field or changing to creator_id
         session.query(Dashboard).filter_by(user_id=self.id).update(
-            {"user_id": new_owner}, synchronize_session=False
+            {"user_id": new_owner.id}, synchronize_session=False
         )
 
 

--- a/backend/ibutsu_server/util/admin.py
+++ b/backend/ibutsu_server/util/admin.py
@@ -5,10 +5,13 @@ from flask import abort
 from ibutsu_server.db.models import User
 
 
-def check_user_is_admin(user_id):
-    """Shared method to check if the logged in user is an administrator"""
-    user = User.query.get(user_id)
-    if not user:
-        abort(401)
-    if not user.is_superadmin:
-        abort(HTTPStatus.FORBIDDEN)
+def validate_admin(function):
+    def validate(**kwargs):
+        candidate = User.query.get(kwargs.get("user"))
+        if not candidate:
+            abort(401)
+        if not candidate.is_superadmin:
+            abort(HTTPStatus.FORBIDDEN)
+        return function(**kwargs)
+
+    return validate


### PR DESCRIPTION
Use a validation decorator to check admin status instead of calling the
same function in every admin user controller function.

Pass a user object and reference it's ID for type consistency

Was not able to replicate stage failure locally, 70% confidence this
will fix the issue.

## Summary by Sourcery

Introduce a validate_admin decorator to centralize admin checks, refactor admin user and project controllers to use this decorator and remove redundant checks, standardize passing and usage of user objects, enhance user deletion flow and cleanup logic to reference new_owner.id and add debug logging

Enhancements:
- Centralize admin authorization with a single validate_admin decorator
- Refactor all admin user and project endpoints to use the decorator and remove direct check_user_is_admin calls
- Standardize endpoint signatures to accept user objects and reference user.id consistently
- Improve user deletion flow by renaming variables, preventing self-deletion, and ensuring proper last superadmin protection