### PR TITLE
Explicitly coerce to strings for bulk updates on user delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ sonar-project.properties
 .redis-data/
 .jwtsecret
 .archives/
+.archives-back/
 
 
 scripts/populate-users-data.py

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -273,14 +273,15 @@ class User(Model, ModelMixin):
         session.query(Token).filter_by(user_id=self.id).delete(synchronize_session=False)
 
         # 3. Reassign owned projects to the current user (admin performing deletion)
-        session.query(Project).filter_by(owner_id=self.id).update(
-            {"owner_id": new_owner.id}, synchronize_session=False
+        # Ensure string consistency for UUID values
+        session.query(Project).filter_by(owner_id=str(self.id)).update(
+            {"owner_id": str(new_owner.id)}, synchronize_session=False
         )
 
         # 4. Reassign dashboards to the current user (admin performing deletion)
         # TODO: this field is null on every prod record, evaluate dropping the field or changing to creator_id
-        session.query(Dashboard).filter_by(user_id=self.id).update(
-            {"user_id": new_owner.id}, synchronize_session=False
+        session.query(Dashboard).filter_by(user_id=str(self.id)).update(
+            {"user_id": str(new_owner.id)}, synchronize_session=False
         )
 
 

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -273,7 +273,8 @@ class User(Model, ModelMixin):
         session.query(Token).filter_by(user_id=self.id).delete(synchronize_session=False)
 
         # 3. Reassign owned projects to the current user (admin performing deletion)
-        # Ensure string consistency for UUID values
+        # The string coercion here is not ideal and PortableUUID needs a review
+        # without it, the bulk query fails comparing text == uuid
         session.query(Project).filter_by(owner_id=str(self.id)).update(
             {"owner_id": str(new_owner.id)}, synchronize_session=False
         )


### PR DESCRIPTION
Within the bulk update, sqlalchemy is not handling the PortableUUID wrapper and we end up comparing text and UUID types.

## Summary by Sourcery

Bug Fixes:
- Coerce UUID values to strings in bulk update queries for Project.owner_id and Dashboard.user_id during user deletion to avoid text/UUID type mismatches