### PR TITLE
SQLAlchemy 1.4 and user delete change

### DIFF
--- a/backend/ibutsu_server/controllers/admin/user_controller.py
+++ b/backend/ibutsu_server/controllers/admin/user_controller.py
@@ -63,7 +63,7 @@ def admin_get_user_list(filter_=None, page=1, page_size=25, token_info=None, use
 
 
 @validate_admin
-def admin_add_user(new_user=None, token_info=None, user=None):
+def admin_add_user(body=None, token_info=None, user=None):
     """Create a new user in the system"""
     if not connexion.request.is_json:
         return RESPONSE_JSON_REQ

--- a/backend/ibutsu_server/db/upgrades.py
+++ b/backend/ibutsu_server/db/upgrades.py
@@ -16,7 +16,8 @@ def get_upgrade_op(session):
 
     :param session: The SQLAlchemy session object.
     """
-    context = MigrationContext.configure(session.get_bind().connect())
+    connection = session.connection()
+    context = MigrationContext.configure(connection)
     return Operations(context)
 
 
@@ -25,7 +26,7 @@ def upgrade_1(session):
 
     This upgrade adds a dashboard_id to the widget_configs table
     """
-    engine = session.get_bind()
+    engine = session.connection().engine
     op = get_upgrade_op(session)
     metadata = MetaData()
     metadata.reflect(bind=engine)
@@ -69,8 +70,7 @@ def upgrade_2(session):
             USING gin ((data->'requirements'));
     """
     TABLES = ["runs", "results"]
-
-    engine = session.get_bind()
+    engine = session.connection().engine
     op = get_upgrade_op(session)
     metadata = MetaData()
     metadata.reflect(bind=engine)
@@ -109,7 +109,7 @@ def upgrade_3(session):
         - makes the 'result_id' column of artifacts nullable
         - adds a 'run_id' to the artifacts table
     """
-    engine = session.get_bind()
+    engine = session.connection().engine
     op = get_upgrade_op(session)
     metadata = MetaData()
     metadata.reflect(bind=engine)
@@ -138,7 +138,7 @@ def upgrade_4(session):
     This upgrade removes the "nullable" constraint on the password field, and adds a "is_superadmin"
     field to the user table.
     """
-    engine = session.get_bind()
+    engine = session.connection().engine
     op = get_upgrade_op(session)
     metadata = MetaData()
     metadata.reflect(bind=engine)
@@ -160,7 +160,7 @@ def upgrade_5(session):
 
     This upgrade adds a default dashboard to a project
     """
-    engine = session.get_bind()
+    engine = session.connection().engine
     op = get_upgrade_op(session)
     metadata = MetaData()
     metadata.reflect(bind=engine)

--- a/backend/ibutsu_server/db/util.py
+++ b/backend/ibutsu_server/db/util.py
@@ -5,7 +5,7 @@ Various utility DB functions
 from typing import Optional
 
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.sql.expression import ClauseElement, Executable, _literal_as_text
+from sqlalchemy.sql.expression import ClauseElement, Executable
 
 from ibutsu_server.db import models
 
@@ -21,7 +21,7 @@ class Explain(Executable, ClauseElement):
     """
 
     def __init__(self, stmt, analyze=False):
-        self.statement = _literal_as_text(stmt)
+        self.statement = stmt
         self.analyze = analyze
 
 

--- a/backend/ibutsu_server/widgets/compare_runs_view.py
+++ b/backend/ibutsu_server/widgets/compare_runs_view.py
@@ -18,12 +18,21 @@ def _get_comparison_data(filters):
                     queries[i] = queries[i].filter(filter_clause)
 
     # Find run IDs for each filter
-    run_id_1 = queries[0].with_entities(Result.run_id).order_by(Result.start_time.desc()).first()
-    run_id_2 = queries[1].with_entities(Result.run_id).order_by(Result.start_time.desc()).first()
+    # Extract the ID value from the result row tuple
+    run_id_1 = queries[0].with_entities(Result.run_id).order_by(Result.start_time.desc()).first()[0]
+    run_id_2 = queries[1].with_entities(Result.run_id).order_by(Result.start_time.desc()).first()[0]
 
     # Get list of tests matching our filters and run IDs
-    results_1 = queries[0].filter(Result.run_id.in_(run_id_1)).order_by(Result.data["fspath"]).all()
-    results_2 = queries[1].filter(Result.run_id.in_(run_id_2)).order_by(Result.data["fspath"]).all()
+    results_1 = []
+    results_2 = []
+    if run_id_1:
+        results_1 = (
+            queries[0].filter(Result.run_id == run_id_1).order_by(Result.data["fspath"]).all()
+        )
+    if run_id_2:
+        results_2 = (
+            queries[1].filter(Result.run_id == run_id_2).order_by(Result.data["fspath"]).all()
+        )
 
     # Build matrix by matching results
     # Could revisit this if loading is taking too long

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "redis",
     "setuptools",
     "sqlalchemy-json",
-    "sqlalchemy<1.4",
+    "sqlalchemy==1.4",
     "swagger-ui-bundle",
     "vine",
     "werkzeug",

--- a/backend/requirements-pinned.txt
+++ b/backend/requirements-pinned.txt
@@ -81,6 +81,8 @@ google-auth-oauthlib==1.2.1
     # via ibutsu-server (pyproject.toml)
 googleapis-common-protos==1.65.0
     # via google-api-core
+greenlet==3.2.3
+    # via sqlalchemy
 gunicorn==23.0.0
     # via ibutsu-server (pyproject.toml)
 httplib2==0.22.0
@@ -181,7 +183,7 @@ setuptools==75.2.0
     # via ibutsu-server (pyproject.toml)
 six==1.16.0
     # via python-dateutil
-sqlalchemy==1.3.24
+sqlalchemy==1.4.0
     # via
     #   ibutsu-server (pyproject.toml)
     #   alembic

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -444,6 +444,26 @@ if [[ $CREATE_PROJECT = true ]]; then
             http://127.0.0.1:8080/api/widget-config | jq -r '.id')
         echo "  Result Aggregator ID: ${RESULT_AGGREGATOR}"
 
+        # Create additional users and assign them to the project
+        echo "Creating 5 additional admin users..."
+        for i in {1..5}
+        do
+            # Create the user
+            USER_ID=$(curl --no-progress-meter --header "Content-Type: application/json" \
+                --header "Authorization: Bearer ${LOGIN_TOKEN}" \
+                --request POST \
+                --data "{\"email\": \"extrauser${i}@example.com\", \"password\": \"admin12345\", \"is_active\": true, \"is_superadmin\": true, \"name\": \"Extra User ${i}\"}" \
+                http://127.0.0.1:8080/api/admin/user | jq -r '.id')
+
+            # Add user to the project by updating the user
+            curl --no-progress-meter --header "Content-Type: application/json" \
+                --header "Authorization: Bearer ${LOGIN_TOKEN}" \
+                --request PUT \
+                --data "{\"projects\": [{\"id\": \"${PROJECT_ID}\"}]}" \
+                http://127.0.0.1:8080/api/admin/user/${USER_ID} > /dev/null
+
+            echo "  Created user extrauser${i}@example.com with password admin12345 and added to project"
+        done
     fi
 
 fi

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -181,6 +181,7 @@ podman run -dt \
 
 echo "================================="
 echo -n "Adding backend to the pod:    "
+# https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-two-turn-on-removedin20warnings
 podman run -d \
     --rm \
     --pod $POD_NAME \
@@ -193,13 +194,14 @@ podman run -d \
     -e POSTGRESQL_PASSWORD=ibutsu \
     -e CELERY_BROKER_URL=redis://127.0.0.1:6379 \
     -e CELERY_RESULT_BACKEND=redis://127.0.0.1:6379 \
+    -e SQLALCHEMY_WARN_20=1 \
     $BACKEND_EXTRA_ARGS \
     -w /mnt \
     -v ./backend:/mnt/:z \
     $PYTHON_IMAGE \
     /bin/bash -c 'python -m pip install -U pip wheel setuptools &&
                     pip install . &&
-                    python -m ibutsu_server --host 0.0.0.0'
+                    python -W always::DeprecationWarning -m ibutsu_server --host 0.0.0.0'
 echo -n "Waiting for backend to respond: "
 sleep 5
 until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:8080); do


### PR DESCRIPTION
Continuing to see the text/UUID coersion within the query formed when doing the bulk operation to re-assign projects to a new owner, only within stage.

Trying this with project, and leaving dashboard update as bulk to see behavior on stage. 

## Summary by Sourcery

Adapt codebase for SQLAlchemy 1.4 compatibility and fix text/UUID mismatches in user deletion by updating migration bindings, adjusting user_cleanup logic, pinning the SQLAlchemy dependency, enabling deprecation warnings, and simplifying the Explain utility.

Bug Fixes:
- Prevent text/UUID mismatch by iterating project reassignment and string-casting dashboard user IDs in user_cleanup

Enhancements:
- Switch migration scripts to use session.connection() instead of session.get_bind() for SQLAlchemy 1.4
- Simplify Explain util by removing literal text coercion

Build:
- Pin SQLAlchemy dependency to version 1.4 in pyproject.toml

Deployment:
- Enable SQLAlchemy 2.0 deprecation warnings via SQLALCHEMY_WARN_20 env and DeprecationWarning flag in the pod startup script