### PR TITLE
Move backend to ubi9.6, cast both sides of UUID comparison

### DIFF
--- a/backend/docker/Dockerfile.backend
+++ b/backend/docker/Dockerfile.backend
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041,DL3059
-FROM registry.access.redhat.com/ubi9/python-39:9.5
+FROM registry.access.redhat.com/ubi9/python-39:9.6
 
 USER 0
 COPY . /app

--- a/backend/docker/Dockerfile.flower
+++ b/backend/docker/Dockerfile.flower
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041
-FROM registry.access.redhat.com/ubi9/python-39:9.5
+FROM registry.access.redhat.com/ubi9/python-39:9.6
 ENV BROKER_URL=redis://localhost
 
 # add application sources with correct perms for OCP

--- a/backend/docker/Dockerfile.fuzz_testing
+++ b/backend/docker/Dockerfile.fuzz_testing
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39:1
+FROM registry.access.redhat.com/ubi9/python-39:9.6
 
 ENV UPGRADE_PIP_TO_LATEST=1
 

--- a/backend/docker/Dockerfile.scheduler
+++ b/backend/docker/Dockerfile.scheduler
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041
-FROM registry.access.redhat.com/ubi9/python-39:9.5
+FROM registry.access.redhat.com/ubi9/python-39:9.6
 USER 0
 
 ENV UPGRADE_PIP_TO_LATEST=1

--- a/backend/docker/Dockerfile.worker
+++ b/backend/docker/Dockerfile.worker
@@ -1,5 +1,5 @@
 # hadolint global ignore=DL3013,DL3041
-FROM registry.access.redhat.com/ubi9/python-39:9.5
+FROM registry.access.redhat.com/ubi9/python-39:9.6
 
 ENV UPGRADE_PIP_TO_LATEST=1
 

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -279,9 +279,9 @@ class User(Model, ModelMixin):
         # The string coercion here is not ideal and PortableUUID needs a review
         # The RH of the comparison is forced to a string by sqlalchemy even though it is a UUID
         # Cast the project field, also a UUID, to a string since the RH side is already a string
-        session.query(Project).filter(sa_cast(Project.owner_id, sa_text) == self.id).update(
-            {"owner_id": new_owner.id}, synchronize_session=False
-        )
+        session.query(Project).filter(
+            sa_cast(Project.owner_id, sa_text) == sa_cast(self.id, sa_text)
+        ).update({"owner_id": new_owner.id}, synchronize_session=False)
 
         # 4. Reassign dashboards to the current user (admin performing deletion)
         # TODO: this field is null on every prod record, evaluate dropping the field or changing to creator_id


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update backend, scheduler, worker, flower, and fuzz-testing Dockerfiles to UBI 9.6 Python 3.9 base images