### PR TITLE
include postgresql_using for alembic alter_column

### DIFF
--- a/backend/ibutsu_server/db/upgrades.py
+++ b/backend/ibutsu_server/db/upgrades.py
@@ -204,6 +204,7 @@ def upgrade_6(session):
             existing_type=Text,
             type_=PortableUUID(),
             existing_nullable=True,
+            postgresql_using="owner_id::uuid",
         )
         inspector = engine.dialect.get_inspector(engine)
         if "projects_owner_id_fkey" not in [


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add postgresql_using clause to the owner_id column type alteration in the Alembic upgrade to ensure proper casting to UUID