### PR TITLE
Exception Badge, handle result type

### DIFF
--- a/frontend/src/components/classify-failures.js
+++ b/frontend/src/components/classify-failures.js
@@ -109,7 +109,7 @@ const ClassifyFailuresTable = () => {
           {toTitleCase(result.result)}
         </Label>,
         <React.Fragment key="exception">
-          {(result.result === 'failed') || (result.result === 'error')
+          {result.result === 'failed' || result.result === 'error'
             ? exceptionToBadge(result?.metadata?.exception_name, filterFunc)
             : buildBadge('exception_name', 'N/A', false)}
         </React.Fragment>,

--- a/frontend/src/components/test-history.js
+++ b/frontend/src/components/test-history.js
@@ -109,7 +109,7 @@ const TestHistoryTable = ({ comparisonResults, testResult }) => {
           {result.source}
         </span>,
         <React.Fragment key="exception">
-          {(result.result === 'failed') || (result.result === 'error')
+          {result.result === 'failed' || result.result === 'error'
             ? exceptionToBadge(result?.metadata?.exception_name, filterFunc)
             : buildBadge('exception_name', 'N/A', false)}
         </React.Fragment>,


### PR DESCRIPTION
IQE-3613

## Summary by Sourcery

Enhancements:
- Show a default 'N/A' exception badge for result types other than 'failed' or 'error' in the classify failures and test history tables