### PR TITLE
Track import dates and clean up records

### DIFF
--- a/backend/ibutsu_server/controllers/import_controller.py
+++ b/backend/ibutsu_server/controllers/import_controller.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Optional
 
@@ -77,6 +78,7 @@ def add_import(
             "filename": import_file.filename,
             "format": "",
             "data": data,
+            "created": datetime.now(timezone.utc),
         }
     )
     session.add(new_import)

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -1,6 +1,6 @@
-from datetime import datetime
 from uuid import uuid4
 
+from sqlalchemy import func
 from sqlalchemy.exc import DBAPIError, SQLAlchemyError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
@@ -86,7 +86,7 @@ class Artifact(Model, FileMixin):
     run_id = Column(PortableUUID(), ForeignKey("runs.id"), index=True)
     filename = Column(Text, index=True)
     data = Column(mutable_json_type(dbtype=PortableJSON(), nested=True))
-    upload_date = Column(DateTime, default=datetime.utcnow, index=True)
+    upload_date = Column(DateTime, default=func.now(), index=True)
 
 
 class Dashboard(Model, ModelMixin):
@@ -114,6 +114,7 @@ class Import(Model, ModelMixin):
     format = Column(Text, index=True)
     data = Column(mutable_json_type(dbtype=PortableJSON(), nested=True))
     status = Column(Text, index=True)
+    created = Column(DateTime, default=func.now(), index=True)
 
 
 class ImportFile(Model, FileMixin):
@@ -149,7 +150,7 @@ class Project(Model, ModelMixin):
 
 class Report(Model, ModelMixin):
     __tablename__ = "reports"
-    created = Column(DateTime, default=datetime.utcnow, index=True)
+    created = Column(DateTime, default=func.now(), index=True)
     download_url = Column(Text, index=True)
     filename = Column(Text, index=True)
     mimetype = Column(Text, index=True)
@@ -182,7 +183,7 @@ class Result(Model, ModelMixin):
     result = Column(Text, index=True)
     run_id = Column(PortableUUID(), ForeignKey("runs.id"), index=True)
     source = Column(Text, index=True)
-    start_time = Column(DateTime, default=datetime.utcnow, index=True)
+    start_time = Column(DateTime, default=func.now(), index=True)
     test_id = Column(Text, index=True)
     artifacts = relationship("Artifact", backref="result")
 
@@ -191,7 +192,7 @@ class Run(Model, ModelMixin):
     __tablename__ = "runs"
     artifacts = relationship("Artifact")
     component = Column(Text, index=True)
-    created = Column(DateTime, default=datetime.utcnow, index=True)
+    created = Column(DateTime, default=func.now(), index=True)
     # this is metadata but it is a reserved attr
     data = Column(mutable_json_type(dbtype=PortableJSON(), nested=True))
     duration = Column(Float, index=True)
@@ -199,7 +200,7 @@ class Run(Model, ModelMixin):
     project_id = Column(PortableUUID(), ForeignKey("projects.id"), index=True)
     results = relationship("Result")
     source = Column(Text, index=True)
-    start_time = Column(DateTime, default=datetime.utcnow, index=True)
+    start_time = Column(DateTime, default=func.now(), index=True)
     summary = Column(mutable_json_type(dbtype=PortableJSON()))
     artifacts = relationship("Artifact", backref="run")
 

--- a/backend/ibutsu_server/tasks/__init__.py
+++ b/backend/ibutsu_server/tasks/__init__.py
@@ -95,6 +95,11 @@ def create_celery_app(_app=None):
     task = app.task
     # Add in any periodic tasks
     app.conf.beat_schedule = {
+        "prune-old-imports": {
+            "task": "ibutsu_server.tasks.db.prune_old_imports",
+            "schedule": crontab(minute=0, hour=3, day_of_week=6),  # 3 am on Saturday
+            "args": (1,),  # delete any import older than 1 months
+        },
         "prune-old-artifact-files": {
             "task": "ibutsu_server.tasks.db.prune_old_files",
             "schedule": crontab(minute=0, hour=4, day_of_week=6),  # 4 am on Saturday, after DB dump

--- a/backend/ibutsu_server/tasks/db.py
+++ b/backend/ibutsu_server/tasks/db.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from ibutsu_server.db.base import session
-from ibutsu_server.db.models import Artifact, Project, Result, Run, User
+from ibutsu_server.db.models import Artifact, Import, Project, Result, Run, User
 from ibutsu_server.tasks import task
 
 DAYS_IN_MONTH = 30
@@ -18,7 +18,7 @@ def prune_old_files(months=5):
             # we don't want to remove files more recent than 2 months
             return
 
-        max_date = datetime.utcnow() - timedelta(days=months * DAYS_IN_MONTH)
+        max_date = datetime.now(timezone.utc) - timedelta(days=months * DAYS_IN_MONTH)
         # delete artifact files older than max_date
         delete_statement = Artifact.__table__.delete().where(Artifact.upload_date < max_date)
         session.execute(delete_statement)
@@ -44,7 +44,7 @@ def prune_old_results(months=6):
             # we don't want to remove files more recent than 4 months
             return
 
-        max_date = datetime.utcnow() - timedelta(days=months * DAYS_IN_MONTH)
+        max_date = datetime.now(timezone.utc) - timedelta(days=months * DAYS_IN_MONTH)
         # delete artifact files older than max_date
         delete_statement = Result.__table__.delete().where(Result.start_time < max_date)
         session.execute(delete_statement)
@@ -70,9 +70,31 @@ def prune_old_runs(months=12):
             # we don't want to remove files more recent than 10 months
             return
 
-        max_date = datetime.utcnow() - timedelta(days=months * DAYS_IN_MONTH)
+        max_date = datetime.now(timezone.utc) - timedelta(days=months * DAYS_IN_MONTH)
         # delete artifact files older than max_date
         delete_statement = Run.__table__.delete().where(Run.start_time < max_date)
+        session.execute(delete_statement)
+        session.commit()
+    except Exception:
+        # we don't want to continually retry this task
+        return
+
+
+@task
+def prune_old_imports(months=2):
+    """Delete import records older than specified months (here defined as 30 days)."""
+    try:
+        if isinstance(months, str):
+            months = int(months)
+
+        if months < 1:
+            # we don't want to remove imports more recent than 1 month
+            return
+
+        max_date = datetime.now(timezone.utc) - timedelta(days=months * DAYS_IN_MONTH)
+        # delete import records older than max_date
+        # Note: import_files should be deleted via cascade when imports are deleted
+        delete_statement = Import.__table__.delete().where(Import.created < max_date)
         session.execute(delete_statement)
         session.commit()
     except Exception:

--- a/backend/ibutsu_server/test/__init__.py
+++ b/backend/ibutsu_server/test/__init__.py
@@ -150,7 +150,7 @@ class MockGroup(MockModel):
 
 
 class MockImport(MockModel):
-    COLUMNS = ["id", "filename", "format", "data", "status"]
+    COLUMNS = ["id", "filename", "format", "data", "status", "created"]
 
 
 class MockProject(MockModel):


### PR DESCRIPTION
there's no cleanup of import files, or creation column for them

include a celery beat task to regularly clean up the import and import files tables.

## Summary by Sourcery

Track import dates and associate imports with runs by extending the imports schema, migrate the database, update the import creation logic, and add a scheduled task to clean up old import records

New Features:
- Add run_id and created columns to imports table to link imports to runs and timestamp them for cleanup
- Introduce prune_old_imports Celery beat task scheduled weekly to delete stale import records

Enhancements:
- Migrate database schema to version 7 to add new imports fields
- Use timezone-aware datetime.now(timezone.utc) instead of naive utcnow in prune tasks
- Set created timestamp when adding new imports in the import controller

Tests:
- Update MockImport test model to include run_id and created fields