### PR TITLE
Add importance to the ResultView

### DIFF
--- a/frontend/src/components/resultView.js
+++ b/frontend/src/components/resultView.js
@@ -165,6 +165,32 @@ const ResultView = ({
     );
   }, [testResult, project_id]);
 
+  const importanceLink = useMemo(() => {
+    const importance = testResult.metadata?.importance;
+    const importanceSearch = filtersToSearchParams([
+      {
+        field: 'metadata.importance',
+        operator: 'eq',
+        value: importance,
+      },
+      {
+        field: 'run_id',
+        operator: 'eq',
+        value: testResult.run_id,
+      },
+    ]);
+    return (
+      <Link
+        to={{
+          pathname: `/project/${project_id}/results`,
+          search: importanceSearch.toString(),
+        }}
+      >
+        {importance}
+      </Link>
+    );
+  }, [testResult, project_id]);
+
   const sourceLink = useMemo(() => {
     const sourceSearch = filtersToSearchParams([
       {
@@ -280,6 +306,22 @@ const ResultView = ({
                               </DataListCell>,
                               <DataListCell key="component-data" width={4}>
                                 {componentLink}
+                              </DataListCell>,
+                            ]}
+                          />
+                        </DataListItemRow>
+                      </DataListItem>
+                    )}
+                    {testResult.metadata?.importance && (
+                      <DataListItem aria-labelledby="importance-label">
+                        <DataListItemRow>
+                          <DataListItemCells
+                            dataListCells={[
+                              <DataListCell key="importance-label" width={2}>
+                                <strong>Importance:</strong>
+                              </DataListCell>,
+                              <DataListCell key="importance-data" width={4}>
+                                {importanceLink}
                               </DataListCell>,
                             ]}
                           />


### PR DESCRIPTION
link to matching results for importance in the same run

<img width="1275" height="589" alt="image" src="https://github.com/user-attachments/assets/d20e7e4a-8e65-449f-acaf-f7f1f2790f4d" />

Clicking the link for importance results in a filter on the results page for the run_id and the importance. 

## Summary by Sourcery

Display test result importance in the ResultView component and link it to a filtered results page for the same importance value within the current run

New Features:
- Add a clickable 'Importance' field that navigates to a results page filtered by the current test’s importance and run ID
- Show a disabled 'No importance' button when the testResult has no importance metadata