### PR TITLE
Resolve 500 when regex filtering on id fields

### DIFF
--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -1,9 +1,11 @@
 import re
 from contextlib import suppress
 
+from sqlalchemy import Text, cast
 from sqlalchemy.dialects.postgresql import array
 
 from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
+from ibutsu_server.db.types import PortableUUID
 
 OPERATORS = {
     "=": "$eq",
@@ -110,4 +112,7 @@ def convert_filter(filter_string, model):
         value = _to_int_or_float(value)
     if is_array_field:
         return _array_compare(oper, column, value)
+    # Cast UUID columns to text when using regex operator to avoid UUID validation errors
+    if oper == "~" and isinstance(column.type, PortableUUID):
+        column = cast(column, Text)
     return OPER_COMPARE[oper](column, value)


### PR DESCRIPTION
Regex filters against run id or result id will result in a 500 because estimate is true, and the explain will try to process the partial UUID as a valid UUID.

## Summary by Sourcery

Prevent server errors when applying regex filters to UUID-based ID fields by casting PortableUUID columns to text for regex operations

Bug Fixes:
- Fix 500 error caused by treating partial UUIDs as invalid during regex filtering on run and result IDs

Enhancements:
- Cast PortableUUID columns to Text when using the regex operator to enable regex filtering on ID fields without errors