### PR TITLE
Revert "Index on widget_configs"

### DIFF
--- a/backend/ibutsu_server/db/upgrades.py
+++ b/backend/ibutsu_server/db/upgrades.py
@@ -1,17 +1,10 @@
 import logging
-import warnings
 from datetime import datetime, timezone
 
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from sqlalchemy import MetaData, inspect, text
 from sqlalchemy.sql import quoted_name
-
-try:
-    from sqlalchemy.exc import SAWarning
-except ImportError:
-    # Fallback for older SQLAlchemy versions
-    SAWarning = None
 from sqlalchemy.sql.expression import null
 
 from ibutsu_server.constants import WIDGET_TYPES
@@ -19,7 +12,7 @@ from ibutsu_server.db.base import Boolean, Column, DateTime, ForeignKey, Text
 from ibutsu_server.db.models import WidgetConfig
 from ibutsu_server.db.types import PortableUUID
 
-__version__ = 11
+__version__ = 10
 
 
 def get_upgrade_op(session):
@@ -382,56 +375,6 @@ def _migrate_widget_config(widget_config, migration_stats, logger):
     return params_updated
 
 
-def _create_index_safely(op, metadata, table_name, index_name, index_args, logger, indexes_created):
-    """Helper function to safely create an index with error handling."""
-    table = metadata.tables.get(table_name)
-    if table is None or index_name in [idx.name for idx in table.indexes]:
-        return False
-
-    try:
-        op.create_index(index_name, table_name, **index_args)
-        indexes_created.append(index_name)
-        logger.info(f"Created index: {index_name}")
-        return True
-    except Exception as e:
-        logger.warning(f"Could not create index {index_name}: {e}")
-        # Let the migration framework handle transaction management
-        return False
-
-
-def _check_pg_trgm_extension(session, logger):
-    """Check if pg_trgm extension exists, and try to create it if it doesn't.
-
-    Returns True if the extension is available (either already exists or was created),
-    False if it cannot be created (e.g., insufficient privileges).
-    """
-    # First check if the extension already exists
-    try:
-        result = session.execute(
-            text("SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm')")
-        )
-        extension_exists = result.scalar()
-        if extension_exists:
-            logger.info("pg_trgm extension already exists")
-            return True
-    except Exception as e:
-        logger.warning(f"Could not check for pg_trgm extension: {e}")
-        # Continue to try creating it
-
-    # Try to create the extension if it doesn't exist
-    try:
-        session.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
-        logger.info("Enabled pg_trgm extension for pattern matching indexes")
-        return True
-    except Exception as e:
-        logger.warning(
-            f"Could not enable pg_trgm extension: {e}. "
-            "Trigram indexes will be skipped. "
-            "To enable them, a database superuser must run: CREATE EXTENSION pg_trgm;"
-        )
-        return False
-
-
 def upgrade_9(session):
     """Version 9 upgrade
 
@@ -500,116 +443,6 @@ def upgrade_9(session):
     )
 
 
-def _create_index_concurrently(session, index_name, index_sql, logger):
-    """Create an index concurrently (non-blocking) with proper transaction handling.
-
-    CREATE INDEX CONCURRENTLY cannot be run inside a transaction, so we:
-    1. Commit any pending transaction
-    2. Use autocommit mode to create the index outside a transaction
-    3. Handle errors gracefully
-
-    :param session: SQLAlchemy session
-    :param index_name: Name of the index to create
-    :param index_sql: SQL statement to create the index (should include CONCURRENTLY)
-    :param logger: Logger instance
-    :return: True if index was created or already exists, False on error
-    """
-    try:
-        # Commit any pending transaction before creating CONCURRENT index
-        # CONCURRENT indexes cannot be created inside a transaction
-        session.commit()
-
-        # Get the engine and use raw_connection() to access the DBAPI connection directly
-        # This is required because CREATE INDEX CONCURRENTLY must run outside a transaction
-        engine = session.connection().engine
-
-        # Use raw_connection() to get direct DBAPI access for autocommit mode
-        raw_conn = engine.raw_connection()
-        try:
-            # Save original autocommit state
-            original_autocommit = getattr(raw_conn, "autocommit", False)
-
-            # Enable autocommit mode for CONCURRENT index creation
-            raw_conn.autocommit = True
-            cursor = raw_conn.cursor()
-            try:
-                cursor.execute(index_sql)
-                # In autocommit mode, commit() is a no-op but we call it for clarity
-                raw_conn.commit()
-                logger.info(f"Created index: {index_name}")
-                return True
-            finally:
-                cursor.close()
-        finally:
-            # Restore original autocommit state and close connection
-            if hasattr(raw_conn, "autocommit"):
-                raw_conn.autocommit = original_autocommit
-            raw_conn.close()
-
-    except Exception as e:
-        error_msg = str(e).lower()
-        # Index already exists or is being created concurrently
-        if "already exists" in error_msg or "duplicate" in error_msg:
-            logger.info(f"Index {index_name} already exists, skipping")
-            return True
-        # Invalid index name might mean it's in an invalid state from a previous failed attempt
-        if "invalid" in error_msg and "name" in error_msg:
-            logger.warning(
-                f"Index {index_name} may be in invalid state. Attempting to drop and recreate: {e}"
-            )
-            try:
-                # Try to drop the invalid index and recreate
-                engine = session.connection().engine
-                raw_conn = engine.raw_connection()
-                try:
-                    original_autocommit = getattr(raw_conn, "autocommit", False)
-                    raw_conn.autocommit = True
-                    cursor = raw_conn.cursor()
-                    try:
-                        cursor.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
-                        cursor.execute(index_sql)
-                        raw_conn.commit()
-                        logger.info(f"Successfully recreated index: {index_name}")
-                        return True
-                    finally:
-                        cursor.close()
-                finally:
-                    if hasattr(raw_conn, "autocommit"):
-                        raw_conn.autocommit = original_autocommit
-                    raw_conn.close()
-            except Exception as drop_error:
-                logger.error(
-                    f"Failed to recreate index {index_name} after drop attempt: {drop_error}"
-                )
-                return False
-        else:
-            logger.error(f"Failed to create index {index_name}: {e}")
-            return False
-
-
-def _create_index_if_missing(session, index_name, index_sql, existing_indexes, logger, stats):
-    """Helper to create an index if it doesn't exist, updating stats.
-
-    :param session: SQLAlchemy session
-    :param index_name: Name of the index
-    :param index_sql: SQL to create the index
-    :param existing_indexes: Set of existing index names
-    :param logger: Logger instance
-    :param stats: Dict with 'created', 'skipped', 'failed' counters
-    :return: None
-    """
-    if index_name not in existing_indexes:
-        logger.info(f"Creating index {index_name} (this may take a while on large databases)...")
-        success = _create_index_concurrently(session, index_name, index_sql, logger)
-        if success:
-            stats["created"] += 1
-        else:
-            stats["failed"] += 1
-    else:
-        logger.info(f"Index {index_name} already exists, skipping")
-        stats["skipped"] += 1
-
-
 def upgrade_10(session):
     """Version 10 upgrade
 
@@ -625,237 +458,97 @@ def upgrade_10(session):
     - Filter by project_id and time range
     - Aggregate results over time periods
 
-    Note: Uses CREATE INDEX CONCURRENTLY to avoid blocking writes on large production databases.
-    This allows the upgrade to complete without causing extended downtime, though index creation
-    may take longer. The upgrade is idempotent and can be safely retried if interrupted.
-
     SQL equivalents:
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_data_gin
-            ON results USING gin (data);
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_project_start_time
+        CREATE INDEX IF NOT EXISTS ix_results_data_gin ON results USING gin (data);
+        CREATE INDEX IF NOT EXISTS ix_results_project_start_time
             ON results (project_id, start_time DESC);
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_project_start_component
+        CREATE INDEX IF NOT EXISTS ix_results_project_start_component
             ON results (project_id, start_time DESC, component);
     """
     logger = logging.getLogger(__name__)
-    logger.info("Starting upgrade_10: Adding indexes for result-aggregator optimization")
+    print("Starting upgrade_10: Adding indexes for result-aggregator optimization")
 
     engine = session.connection().engine
-    get_upgrade_op(session)
+    op = get_upgrade_op(session)
     metadata = MetaData()
-    # Suppress warnings about expression-based indexes that SQLAlchemy can't reflect
-    with warnings.catch_warnings():
-        if SAWarning:
-            warnings.filterwarnings(
-                "ignore",
-                category=SAWarning,
-                message=".*Skipped unsupported reflection of expression-based index.*",
-            )
-        else:
-            # Fallback: filter by message pattern if SAWarning is not available
-            warnings.filterwarnings(
-                "ignore", message=".*Skipped unsupported reflection of expression-based index.*"
-            )
-        metadata.reflect(bind=engine)
+    metadata.reflect(bind=engine)
 
     if engine.url.get_dialect().name == "postgresql":
         results_table = metadata.tables.get("results")
         if results_table is None:
             logger.warning("Results table not found, skipping index creation")
-            logger.info("upgrade_10 skipped: Results table not found")
+            print("upgrade_10 warning: Results table not found")
             return
 
         existing_indexes = {idx.name for idx in results_table.indexes}
         logger.info(f"Found {len(existing_indexes)} existing indexes on results table")
 
-        stats = {"created": 0, "skipped": 0, "failed": 0}
+        indexes_created = 0
+        indexes_skipped = 0
 
-        # Define indexes to create
-        indexes_to_create = [
-            (
-                "ix_results_data_gin",
-                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_data_gin "
-                "ON results USING gin (data)",
-            ),
-            (
-                "ix_results_project_start_time",
-                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_project_start_time "
-                "ON results (project_id, start_time DESC)",
-            ),
-            (
-                "ix_results_project_start_component",
-                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_project_start_component "
-                "ON results (project_id, start_time DESC, component)",
-            ),
-        ]
-
-        # Create each index if it doesn't exist
-        for index_name, index_sql in indexes_to_create:
-            _create_index_if_missing(
-                session, index_name, index_sql, existing_indexes, logger, stats
-            )
-
-        logger.info(
-            f"upgrade_10 completed: {stats['created']} indexes created, "
-            f"{stats['skipped']} already existed, {stats['failed']} failed"
-        )
-        if stats["failed"] > 0:
-            logger.warning(
-                "Some indexes failed to create. The upgrade can be safely retried. "
-                "Failed indexes will be skipped if they already exist."
-            )
-    else:
-        logger.info("upgrade_10 skipped: Not PostgreSQL database")
-
-
-def upgrade_11(session):
-    """Version 11 upgrade
-
-    This upgrade adds optimized indexes for common widget query patterns to improve performance:
-
-    1. Composite indexes for frequently co-filtered columns:
-       - (project_id, start_time) on both runs and results
-       - (project_id, component, start_time) on both runs and results
-       - (run_id, start_time) on results
-
-    2. GIN indexes on commonly queried JSONB paths:
-       - data->'jenkins' on both runs and results (for job_name, build_number)
-       - data->'test_suite' on results
-
-    3. GIN indexes for regex/pattern matching (using pg_trgm):
-       - component column on both runs and results
-       - source column on both runs and results
-
-    4. GIN index on summary JSONB column for aggregation queries
-
-    These indexes target the most common widget query patterns:
-    - run-aggregator: filters by project_id, start_time, component with summary aggregations
-    - jenkins-heatmap: filters by jenkins.job_name, build_number with component grouping
-    - result-aggregator: filters by project_id, run_id, start_time with component grouping
-    - filter-heatmap: heavy metadata filtering with component patterns
-    """
-    logger = logging.getLogger(__name__)
-    logger.info("Starting upgrade_11: Adding optimized indexes for common widget query patterns")
-    engine = session.connection().engine
-    op = get_upgrade_op(session)
-    metadata = MetaData()
-    # Suppress warnings about expression-based indexes that SQLAlchemy can't reflect
-    with warnings.catch_warnings():
-        if SAWarning:
-            warnings.filterwarnings(
-                "ignore",
-                category=SAWarning,
-                message=".*Skipped unsupported reflection of expression-based index.*",
-            )
-        else:
-            # Fallback: filter by message pattern if SAWarning is not available
-            warnings.filterwarnings(
-                "ignore", message=".*Skipped unsupported reflection of expression-based index.*"
-            )
-        metadata.reflect(bind=engine)
-
-    # Only apply to PostgreSQL (SQLite doesn't support GIN indexes or pg_trgm)
-    if engine.url.get_dialect().name != "postgresql":
-        logger.info("Skipping upgrade_11: not using PostgreSQL")
-        return
-
-    indexes_created = []
-    pg_trgm_available = _check_pg_trgm_extension(session, logger)
-
-    # Define and create composite indexes for common query patterns
-    composite_indexes = [
-        ("runs", "ix_runs_project_id_start_time", ["project_id", "start_time"]),
-        ("results", "ix_results_project_id_start_time", ["project_id", "start_time"]),
-        ("runs", "ix_runs_project_component_start_time", ["project_id", "component", "start_time"]),
-        (
-            "results",
-            "ix_results_project_component_start_time",
-            ["project_id", "component", "start_time"],
-        ),
-        ("results", "ix_results_run_id_start_time", ["run_id", "start_time"]),
-    ]
-
-    for table_name, index_name, columns in composite_indexes:
-        _create_index_safely(
-            op,
-            metadata,
-            table_name,
-            index_name,
-            {"columns": columns},
-            logger,
-            indexes_created,
-        )
-
-    # Define and create GIN indexes for JSONB path queries
-    # Use raw SQL for JSONB path expressions to ensure they're treated as
-    # expressions, not column names
-    jsonb_path_indexes = [
-        ("runs", "ix_runs_jenkins", "data->'jenkins'"),
-        ("results", "ix_results_jenkins", "data->'jenkins'"),
-        ("results", "ix_results_test_suite", "data->'test_suite'"),
-    ]
-
-    for table_name, index_name, path_expression in jsonb_path_indexes:
-        table = metadata.tables.get(table_name)
-        if table is None or index_name in [idx.name for idx in table.indexes]:
-            continue
-
-        try:
-            # Use raw SQL to create expression indexes on JSONB paths
-            connection = session.connection()
-            connection.execute(
-                text(
-                    f"CREATE INDEX IF NOT EXISTS {index_name} "
-                    f"ON {table_name} USING gin (({path_expression}))"
+        # 1. Add GIN index on data column for fast metadata queries
+        data_gin_index = "ix_results_data_gin"
+        if data_gin_index not in existing_indexes:
+            try:
+                op.create_index(
+                    data_gin_index,
+                    "results",
+                    [quoted_name("data", False)],
+                    postgresql_using="gin",
                 )
-            )
-            indexes_created.append(index_name)
-            logger.info(f"Created GIN JSONB index: {index_name}")
-        except Exception as e:
-            logger.warning(f"Could not create index {index_name}: {e}")
+                logger.info(f"Created index: {data_gin_index}")
+                indexes_created += 1
+            except Exception as e:
+                logger.error(f"Failed to create index {data_gin_index}: {e}")
+        else:
+            logger.info(f"Index {data_gin_index} already exists, skipping")
+            indexes_skipped += 1
 
-    # Define and create GIN indexes for pattern matching on text columns
-    # These require pg_trgm extension, so only create if extension is available
-    if pg_trgm_available:
-        pattern_indexes = [
-            ("runs", "ix_runs_component_trgm", "component"),
-            ("results", "ix_results_component_trgm", "component"),
-            ("runs", "ix_runs_source_trgm", "source"),
-            ("results", "ix_results_source_trgm", "source"),
-        ]
+        # 2. Add composite index on (project_id, start_time) for time-range queries
+        project_time_index = "ix_results_project_start_time"
+        if project_time_index not in existing_indexes:
+            try:
+                # Use raw SQL for DESC ordering compatibility across PostgreSQL versions
+                connection = session.connection()
+                connection.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_results_project_start_time "
+                        "ON results (project_id, start_time DESC)"
+                    )
+                )
+                logger.info(f"Created index: {project_time_index}")
+                indexes_created += 1
+            except Exception as e:
+                logger.error(f"Failed to create index {project_time_index}: {e}")
+        else:
+            logger.info(f"Index {project_time_index} already exists, skipping")
+            indexes_skipped += 1
 
-        for table_name, index_name, column_name in pattern_indexes:
-            _create_index_safely(
-                op,
-                metadata,
-                table_name,
-                index_name,
-                {
-                    "columns": [column_name],
-                    "postgresql_using": "gin",
-                    "postgresql_ops": {column_name: "gin_trgm_ops"},
-                },
-                logger,
-                indexes_created,
-            )
-    else:
-        logger.info(
-            "Skipping trigram indexes (ix_*_component_trgm, ix_*_source_trgm) "
-            "because pg_trgm extension is not available"
+        # 3. Add composite index on (project_id, start_time, component) for component queries
+        project_time_component_index = "ix_results_project_start_component"
+        if project_time_component_index not in existing_indexes:
+            try:
+                # Use raw SQL for DESC ordering compatibility across PostgreSQL versions
+                connection = session.connection()
+                connection.execute(
+                    text(
+                        "CREATE INDEX IF NOT EXISTS ix_results_project_start_component "
+                        "ON results (project_id, start_time DESC, component)"
+                    )
+                )
+                logger.info(f"Created index: {project_time_component_index}")
+                indexes_created += 1
+            except Exception as e:
+                logger.error(f"Failed to create index {project_time_component_index}: {e}")
+        else:
+            logger.info(f"Index {project_time_component_index} already exists, skipping")
+            indexes_skipped += 1
+
+        logger.info("Upgrade 10 completed: Added indexes for result-aggregator optimization")
+        print(
+            f"upgrade_10 completed: {indexes_created} indexes created, "
+            f"{indexes_skipped} already existed"
         )
-
-    # Create GIN index on summary JSONB for aggregation queries
-    _create_index_safely(
-        op,
-        metadata,
-        "runs",
-        "ix_runs_summary",
-        {"columns": ["summary"], "postgresql_using": "gin"},
-        logger,
-        indexes_created,
-    )
-
-    # Log summary
-    logger.info(f"upgrade_11 completed: created {len(indexes_created)} indexes")
-    if indexes_created:
-        logger.info(f"  Indexes created: {', '.join(indexes_created)}")
+    else:
+        logger.info("Upgrade 10 skipped: Not PostgreSQL database")
+        print("upgrade_10 skipped: Not a PostgreSQL database")

--- a/backend/tests/test_upgrades.py
+++ b/backend/tests/test_upgrades.py
@@ -1,271 +1,166 @@
 """Tests for database upgrades"""
 
 import pytest
-from sqlalchemy import MetaData, text
+from sqlalchemy import MetaData
 
-from ibutsu_server.db.upgrades import upgrade_10, upgrade_11
-
-
-@pytest.fixture
-def requires_postgresql(db_session):
-    """Skip test if not using PostgreSQL"""
-    engine = db_session.connection().engine
-    if engine.url.get_dialect().name != "postgresql":
-        pytest.skip("This test only applies to PostgreSQL")
-
-
-@pytest.fixture
-def requires_sqlite(db_session):
-    """Skip test if not using SQLite"""
-    engine = db_session.connection().engine
-    if engine.url.get_dialect().name != "sqlite":
-        pytest.skip("This test is only for SQLite databases")
-
-
-def _get_index_definition(engine, table_name, index_name):
-    """Get index definition from PostgreSQL system catalogs"""
-    with engine.connect() as conn:
-        result = conn.execute(
-            text(
-                """
-                SELECT indexdef
-                FROM pg_indexes
-                WHERE schemaname = current_schema()
-                  AND tablename = :table_name
-                  AND indexname = :index_name
-                """
-            ),
-            {"table_name": table_name, "index_name": index_name},
-        )
-        return result.scalar_one_or_none()
-
-
-def _verify_gin_index(engine, table_name, index_name, expected_column=None):
-    """Verify that an index is a GIN index and optionally check the column"""
-    indexdef = _get_index_definition(engine, table_name, index_name)
-    assert indexdef is not None, (
-        f"Expected GIN index {index_name} on {table_name} to exist in pg_indexes"
-    )
-
-    normalized_indexdef = indexdef.lower()
-
-    # Assert that the index uses the GIN index method
-    assert "using gin" in normalized_indexdef, (
-        f"Index {index_name} is not a GIN index. Definition: {indexdef}"
-    )
-
-    # If expected_column is provided, verify it's in the definition
-    if expected_column:
-        # The definition is typically like:
-        #   CREATE INDEX ix_name ON public.table USING gin (column)
-        #   or for expressions: CREATE INDEX ix_name ON public.table USING gin ((expression))
-        assert (
-            f"({expected_column})" in normalized_indexdef
-            or f" {expected_column} " in normalized_indexdef
-            or f"({expected_column})" in normalized_indexdef
-        ), (
-            f"Index {index_name} does not appear to be on the {expected_column} column. "
-            f"Definition: {indexdef}"
-        )
-
-
-def _verify_trigram_index(engine, table_name, index_name, column_name):
-    """Verify that an index is a GIN trigram index with gin_trgm_ops"""
-    indexdef = _get_index_definition(engine, table_name, index_name)
-    assert indexdef is not None, (
-        f"Expected trigram index {index_name} on {table_name} to exist in pg_indexes"
-    )
-
-    normalized_indexdef = indexdef.lower()
-
-    # Assert that the index uses the GIN index method
-    assert "using gin" in normalized_indexdef, (
-        f"Index {index_name} is not a GIN index. Definition: {indexdef}"
-    )
-
-    # Assert that it uses gin_trgm_ops operator class
-    assert "gin_trgm_ops" in normalized_indexdef, (
-        f"Index {index_name} does not use gin_trgm_ops operator class. Definition: {indexdef}"
-    )
-
-    # Assert that it targets the expected column
-    assert (
-        f"({column_name} gin_trgm_ops)" in normalized_indexdef
-        or f"{column_name} gin_trgm_ops" in normalized_indexdef
-    ), (
-        f"Index {index_name} does not appear to be on the {column_name} column "
-        f"with gin_trgm_ops. Definition: {indexdef}"
-    )
+from ibutsu_server.db.upgrades import upgrade_10
 
 
 class TestUpgrade10:
-    """Tests for upgrade_10 - result-aggregator optimization indexes"""
+    """Tests for upgrade_10 - performance optimization indexes"""
 
-    @pytest.mark.parametrize(
-        "index_name",
-        [
-            "ix_results_data_gin",
-            "ix_results_project_start_time",
-            "ix_results_project_start_component",
-        ],
-    )
-    def test_upgrade_10_creates_index(self, db_session, requires_postgresql, index_name):
-        """Test that upgrade_10 creates expected indexes"""
+    def test_upgrade_10_creates_composite_indexes(self, db_session):
+        """Test that upgrade_10 creates expected composite B-tree indexes"""
+        # Run the upgrade
         upgrade_10(db_session)
 
+        # Get the current database metadata
         engine = db_session.connection().engine
+
+        # Skip test if not using PostgreSQL
+        if engine.url.get_dialect().name != "postgresql":
+            pytest.skip("Upgrade 10 only applies to PostgreSQL")
+
         metadata = MetaData()
         metadata.reflect(bind=engine)
 
-        results_table = metadata.tables.get("results")
-        assert results_table is not None, "Results table not found"
+        # Define expected composite indexes
+        expected_indexes = {
+            "runs": [
+                "ix_runs_project_id_start_time",
+                "ix_runs_project_component_start_time",
+            ],
+            "results": [
+                "ix_results_project_id_start_time",
+                "ix_results_project_component_start_time",
+                "ix_results_run_id_start_time",
+            ],
+        }
 
-        existing_index_names = [idx.name for idx in results_table.indexes]
-        assert index_name in existing_index_names, (
-            f"Expected index {index_name} not found. Existing indexes: {existing_index_names}"
-        )
+        # Verify each expected index exists
+        for table_name, index_names in expected_indexes.items():
+            table = metadata.tables.get(table_name)
+            assert table is not None, f"Table {table_name} not found"
 
-    def test_upgrade_10_creates_data_gin_index_type(self, db_session, requires_postgresql):
-        """Test that upgrade_10 creates GIN index on results.data column with correct type"""
+            existing_index_names = [idx.name for idx in table.indexes]
+            for index_name in index_names:
+                assert index_name in existing_index_names, (
+                    f"Expected index {index_name} not found in {table_name}. "
+                    f"Existing indexes: {existing_index_names}"
+                )
+
+    def test_upgrade_10_creates_jsonb_gin_indexes(self, db_session):
+        """Test that upgrade_10 creates GIN indexes on JSONB paths"""
+        # Run the upgrade
         upgrade_10(db_session)
 
         engine = db_session.connection().engine
-        _verify_gin_index(engine, "results", "ix_results_data_gin", "data")
 
-    def test_upgrade_10_idempotent(self, db_session, requires_postgresql):
+        # Skip test if not using PostgreSQL
+        if engine.url.get_dialect().name != "postgresql":
+            pytest.skip("Upgrade 10 only applies to PostgreSQL")
+
+        metadata = MetaData()
+        metadata.reflect(bind=engine)
+
+        # Define expected GIN indexes on JSONB paths
+        expected_gin_indexes = {
+            "runs": [
+                "ix_runs_jenkins",
+                "ix_runs_summary",
+            ],
+            "results": [
+                "ix_results_jenkins",
+                "ix_results_test_suite",
+            ],
+        }
+
+        # Verify each expected GIN index exists
+        for table_name, index_names in expected_gin_indexes.items():
+            table = metadata.tables.get(table_name)
+            assert table is not None, f"Table {table_name} not found"
+
+            existing_index_names = [idx.name for idx in table.indexes]
+            for index_name in index_names:
+                assert index_name in existing_index_names, (
+                    f"Expected GIN index {index_name} not found in {table_name}. "
+                    f"Existing indexes: {existing_index_names}"
+                )
+
+    def test_upgrade_10_creates_trigram_indexes(self, db_session):
+        """Test that upgrade_10 creates GIN trigram indexes for pattern matching"""
+        # Run the upgrade
+        upgrade_10(db_session)
+
+        engine = db_session.connection().engine
+
+        # Skip test if not using PostgreSQL
+        if engine.url.get_dialect().name != "postgresql":
+            pytest.skip("Upgrade 10 only applies to PostgreSQL")
+
+        metadata = MetaData()
+        metadata.reflect(bind=engine)
+
+        # Define expected trigram indexes
+        expected_trgm_indexes = {
+            "runs": [
+                "ix_runs_component_trgm",
+                "ix_runs_source_trgm",
+            ],
+            "results": [
+                "ix_results_component_trgm",
+                "ix_results_source_trgm",
+            ],
+        }
+
+        # Verify each expected trigram index exists
+        for table_name, index_names in expected_trgm_indexes.items():
+            table = metadata.tables.get(table_name)
+            assert table is not None, f"Table {table_name} not found"
+
+            existing_index_names = [idx.name for idx in table.indexes]
+            for index_name in index_names:
+                assert index_name in existing_index_names, (
+                    f"Expected trigram index {index_name} not found in {table_name}. "
+                    f"Existing indexes: {existing_index_names}"
+                )
+
+    def test_upgrade_10_enables_pg_trgm_extension(self, db_session):
+        """Test that upgrade_10 enables the pg_trgm extension"""
+        # Run the upgrade
+        upgrade_10(db_session)
+
+        engine = db_session.connection().engine
+
+        # Skip test if not using PostgreSQL
+        if engine.url.get_dialect().name != "postgresql":
+            pytest.skip("Upgrade 10 only applies to PostgreSQL")
+
+        # Query for installed extensions
+        result = db_session.execute("SELECT * FROM pg_extension WHERE extname = 'pg_trgm'")
+        extensions = result.fetchall()
+
+        assert len(extensions) > 0, "pg_trgm extension not installed"
+
+    def test_upgrade_10_idempotent(self, db_session):
         """Test that upgrade_10 can be run multiple times without errors"""
+        engine = db_session.connection().engine
+
+        # Skip test if not using PostgreSQL
+        if engine.url.get_dialect().name != "postgresql":
+            pytest.skip("Upgrade 10 only applies to PostgreSQL")
+
+        # Run the upgrade twice
         upgrade_10(db_session)
 
         # Get index count before second run
-        engine = db_session.connection().engine
-        metadata = MetaData()
-        metadata.reflect(bind=engine)
-        results_table = metadata.tables.get("results")
-        initial_index_count = len(results_table.indexes) if results_table else 0
-
-        # Run again - should not raise errors
-        upgrade_10(db_session)
-
-        # Verify index count hasn't changed (no duplicates created)
-        metadata = MetaData()
-        metadata.reflect(bind=engine)
-        results_table = metadata.tables.get("results")
-        final_index_count = len(results_table.indexes) if results_table else 0
-
-        assert final_index_count == initial_index_count, (
-            "Running upgrade_10 twice should not create duplicate indexes"
-        )
-
-    def test_upgrade_10_skips_on_sqlite(self, db_session, requires_sqlite):
-        """Test that upgrade_10 gracefully skips on SQLite databases"""
-        # Should not raise any errors, just log and return
-        upgrade_10(db_session)
-
-    def test_upgrade_10_handles_missing_results_table(
-        self, db_session, requires_postgresql, monkeypatch
-    ):
-        """Test that upgrade_10 handles missing results table gracefully"""
-        # Mock metadata.tables.get to return None for results table
-        original_reflect = MetaData.reflect
-
-        def mock_reflect(self, *args, **kwargs):
-            original_reflect(self, *args, **kwargs)
-            # Remove results table from metadata
-            if "results" in self.tables:
-                del self.tables["results"]
-
-        monkeypatch.setattr(MetaData, "reflect", mock_reflect)
-
-        # Should not raise - just log warning and return
-        upgrade_10(db_session)
-
-
-class TestUpgrade11:
-    """Tests for upgrade_11 - widget query pattern optimization indexes"""
-
-    @pytest.mark.parametrize(
-        ("table_name", "index_name"),
-        [
-            ("runs", "ix_runs_project_id_start_time"),
-            ("results", "ix_results_project_id_start_time"),
-            ("runs", "ix_runs_project_component_start_time"),
-            ("results", "ix_results_project_component_start_time"),
-            ("results", "ix_results_run_id_start_time"),
-        ],
-    )
-    def test_upgrade_11_creates_composite_indexes(
-        self, db_session, requires_postgresql, table_name, index_name
-    ):
-        """Test that upgrade_11 creates composite indexes"""
-        upgrade_11(db_session)
-
-        engine = db_session.connection().engine
-        metadata = MetaData()
-        metadata.reflect(bind=engine)
-
-        table = metadata.tables.get(table_name)
-        assert table is not None, f"{table_name} table not found"
-
-        existing_index_names = [idx.name for idx in table.indexes]
-        assert index_name in existing_index_names, (
-            f"Expected index {index_name} not found. Existing indexes: {existing_index_names}"
-        )
-
-    @pytest.mark.parametrize(
-        ("table_name", "index_name", "path_expression"),
-        [
-            ("runs", "ix_runs_jenkins", "data->'jenkins'"),
-            ("results", "ix_results_jenkins", "data->'jenkins'"),
-            ("results", "ix_results_test_suite", "data->'test_suite'"),
-        ],
-    )
-    def test_upgrade_11_creates_jsonb_gin_indexes(
-        self, db_session, requires_postgresql, table_name, index_name, path_expression
-    ):
-        """Test that upgrade_11 creates GIN indexes on JSONB paths"""
-        upgrade_11(db_session)
-
-        engine = db_session.connection().engine
-        _verify_gin_index(engine, table_name, index_name)
-
-    def test_upgrade_11_creates_summary_gin_index(self, db_session, requires_postgresql):
-        """Test that upgrade_11 creates GIN index on runs.summary column"""
-        upgrade_11(db_session)
-
-        engine = db_session.connection().engine
-        _verify_gin_index(engine, "runs", "ix_runs_summary", "summary")
-
-    @pytest.mark.parametrize(
-        ("table_name", "index_name", "column_name"),
-        [
-            ("runs", "ix_runs_component_trgm", "component"),
-            ("results", "ix_results_component_trgm", "component"),
-            ("runs", "ix_runs_source_trgm", "source"),
-            ("results", "ix_results_source_trgm", "source"),
-        ],
-    )
-    def test_upgrade_11_creates_trigram_indexes(
-        self, db_session, requires_postgresql, table_name, index_name, column_name
-    ):
-        """Test that upgrade_11 creates trigram indexes with gin_trgm_ops"""
-        upgrade_11(db_session)
-
-        engine = db_session.connection().engine
-        _verify_trigram_index(engine, table_name, index_name, column_name)
-
-    def test_upgrade_11_idempotent(self, db_session, requires_postgresql):
-        """Test that upgrade_11 can be run multiple times without errors"""
-        upgrade_11(db_session)
-
-        # Get index count before second run
-        engine = db_session.connection().engine
         metadata = MetaData()
         metadata.reflect(bind=engine)
         runs_table = metadata.tables.get("runs")
         initial_index_count = len(runs_table.indexes) if runs_table else 0
 
         # Run again - should not raise errors
-        upgrade_11(db_session)
+        upgrade_10(db_session)
 
         # Verify index count hasn't changed (no duplicates created)
         metadata = MetaData()
@@ -274,31 +169,44 @@ class TestUpgrade11:
         final_index_count = len(runs_table.indexes) if runs_table else 0
 
         assert final_index_count == initial_index_count, (
-            "Running upgrade_11 twice should not create duplicate indexes"
+            "Running upgrade_10 twice should not create duplicate indexes"
         )
 
-    def test_upgrade_11_skips_on_sqlite(self, db_session, requires_sqlite):
-        """Test that upgrade_11 gracefully skips on SQLite databases"""
-        # Should not raise any errors, just log and return
-        upgrade_11(db_session)
+    def test_upgrade_10_skips_on_sqlite(self, db_session):
+        """Test that upgrade_10 gracefully skips on SQLite databases"""
+        engine = db_session.connection().engine
 
-    def test_upgrade_11_handles_missing_pg_trgm(self, db_session, requires_postgresql, monkeypatch):
-        """Test that upgrade_11 handles missing pg_trgm extension gracefully"""
+        # Only run this test on SQLite
+        if engine.url.get_dialect().name != "sqlite":
+            pytest.skip("This test is only for SQLite databases")
+
+        # Should not raise any errors, just log and return
+        upgrade_10(db_session)
+
+        # No assertions needed - just verify it doesn't crash
+
+    def test_upgrade_10_handles_missing_pg_trgm(self, db_session, monkeypatch):
+        """Test that upgrade_10 handles missing pg_trgm extension gracefully"""
+        engine = db_session.connection().engine
+
+        # Skip test if not using PostgreSQL
+        if engine.url.get_dialect().name != "postgresql":
+            pytest.skip("Upgrade 10 only applies to PostgreSQL")
+
         # Mock session.execute to raise error for CREATE EXTENSION
         original_execute = db_session.execute
 
         def mock_execute(statement, *args, **kwargs):
             if "CREATE EXTENSION" in str(statement):
-                raise RuntimeError("Extension creation not permitted")
+                raise Exception("Extension creation not permitted")
             return original_execute(statement, *args, **kwargs)
 
         monkeypatch.setattr(db_session, "execute", mock_execute)
 
         # Should not raise - just log warning and continue
-        upgrade_11(db_session)
+        upgrade_10(db_session)
 
         # Note: Trigram indexes won't be created, but other indexes should be
-        engine = db_session.connection().engine
         metadata = MetaData()
         metadata.reflect(bind=engine)
 


### PR DESCRIPTION
Reverts ibutsu/ibutsu-server#760

## Summary by Sourcery

Revert the database migration and tests that added extensive widget-related and trigram indexes, returning the upgrade logic to version 10 with simpler PostgreSQL result index creation.

Enhancements:
- Downgrade the database upgrade module version from 11 to 10 and remove the upgrade_11 migration and associated helper functions for advanced index and pg_trgm management.
- Simplify upgrade_10 to only create a small set of result table indexes using standard index creation instead of concurrent/index-introspection helpers, and adjust logging accordingly.

Tests:
- Rewrite the upgrade tests to cover only upgrade_10, removing upgrade_11-specific expectations and loosening index expectations to match the simplified migration behavior.