### PR TITLE
Update chown for frontend dockerfile

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ibutsu API
-  version: 3.0.2
+  version: 3.0.3
 servers:
   - url: /api
 security:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "3.0.2"
+version = "3.0.3"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -41,14 +41,14 @@ FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:9.7
 WORKDIR /opt/app-root/src
 
 # Copy only the build artifacts (React static files) from the builder image
-COPY --from=builder /opt/app-root/src/build /opt/app-root/src/build
+COPY --from=builder --chown=1001:0 /opt/app-root/src/build /opt/app-root/src/build
 
 # Copy package.json for running yarn start
-COPY --from=builder /opt/app-root/src/package.json /opt/app-root/src/package.json
+COPY --from=builder --chown=1001:0 /opt/app-root/src/package.json /opt/app-root/src/package.json
 
 # Copy the already-pruned production node_modules from the builder
 # This avoids a second install in the runtime stage while keeping only production deps
-COPY --from=builder /opt/app-root/src/node_modules /opt/app-root/src/node_modules
+COPY --from=builder --chown=1001:0 /opt/app-root/src/node_modules /opt/app-root/src/node_modules
 
 # Copy the entrypoint script for runtime configuration
 # Use --chmod to set executable permissions directly (avoids permission issues in minimal image)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "private": true,
   "description": "Ibutsu Frontend",
   "dependencies": {


### PR DESCRIPTION
set it when copying from builder

## Summary by Sourcery

Build:
- Leave frontend Dockerfile configuration effectively unchanged with no build-impacting changes