### PR TITLE
chgrp and chmod in the frontend container

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ibutsu API
-  version: 3.0.3
+  version: 3.0.4
 servers:
   - url: /api
 security:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "3.0.3"
+version = "3.0.4"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -54,6 +54,12 @@ COPY --from=builder --chown=1001:0 /opt/app-root/src/node_modules /opt/app-root/
 # Use --chmod to set executable permissions directly (avoids permission issues in minimal image)
 COPY --chmod=755 ./docker/entrypoint.sh /opt/app-root/bin/entrypoint.sh
 
+# Ensure the build directory is group-writable for OpenShift arbitrary UID support
+# OpenShift runs containers with random UIDs in the root group (GID 0)
+# chmod g=u gives the group the same permissions as the owner (including write access)
+RUN chgrp -R 0 /opt/app-root/src && \
+    chmod -R g=u /opt/app-root/src
+
 # Set NODE_ENV to production (aligns with OpenShift template ocp-templates/mpp/frontend.yaml)
 ENV NODE_ENV=production
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "description": "Ibutsu Frontend",
   "dependencies": {


### PR DESCRIPTION
## Summary by Sourcery

Bump project version to 3.0.4 across backend, frontend, and API specification metadata.

Enhancements:
- Update backend Python package version to 3.0.4.
- Update frontend package.json version to 3.0.4.
- Update OpenAPI specification version to 3.0.4.