### PR TITLE
Set binary format in openapi spec

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ibutsu API
-  version: 3.0.5
+  version: 3.0.6
 servers:
   - url: /api
 security:

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -237,6 +237,7 @@ paths:
                   description: "name of the file"
                 file:
                   type: string
+                  format: binary
                   description: "file to upload"
                 additionalMetadata:
                   type: object

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "3.0.5"
+version = "3.0.6"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": true,
   "description": "Ibutsu Frontend",
   "dependencies": {


### PR DESCRIPTION
## Summary by Sourcery

Ensure artifact file uploads are correctly described and validated as binary data in the OpenAPI schema and covered by an end-to-end HTTP upload test.

Bug Fixes:
- Correct the OpenAPI artifact upload schema to mark the file field as binary so multipart uploads validate and work as intended.

Tests:
- Add an end-to-end test that uploads an artifact via an actual HTTP multipart request through the Connexion validation layer and verifies it is persisted.