### PR TITLE
Bug fixes

### DIFF
--- a/backend/ibutsu_server/controllers/artifact_controller.py
+++ b/backend/ibutsu_server/controllers/artifact_controller.py
@@ -82,6 +82,8 @@ def view_artifact(id_, token_info=None, user=None):
     :rtype: file
     """
     artifact, response = _build_artifact_response(id_)
+    if not isinstance(artifact, Artifact):
+        return artifact, response
     if not _user_has_artifact_access(artifact, user):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     return response
@@ -97,6 +99,8 @@ def download_artifact(id_, token_info=None, user=None):
     :rtype: file
     """
     artifact, response = _build_artifact_response(id_)
+    if not isinstance(artifact, Artifact):
+        return artifact, response
     if not _user_has_artifact_access(artifact, user):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     response.headers["Content-Disposition"] = f"attachment; filename={artifact.filename}"

--- a/backend/ibutsu_server/controllers/artifact_controller.py
+++ b/backend/ibutsu_server/controllers/artifact_controller.py
@@ -27,6 +27,20 @@ class BadRequestError(Exception):
         self.status = status
 
 
+def _user_has_artifact_access(artifact, user):
+    """Check whether the user has access to the artifact's project.
+
+    Access is determined by the project associated with the artifact's result or run.
+    If the artifact is not linked to either a result or a run, access is denied
+    to avoid silently granting access to orphaned artifacts.
+    """
+    if artifact.result:
+        return project_has_user(artifact.result.project, user)
+    if artifact.run:
+        return project_has_user(artifact.run.project, user)
+    return False
+
+
 def _get_form_param(form, *keys):
     """Get a form parameter supporting both camelCase and snake_case naming.
 
@@ -68,9 +82,7 @@ def view_artifact(id_, token_info=None, user=None):
     :rtype: file
     """
     artifact, response = _build_artifact_response(id_)
-    if (artifact.result and not project_has_user(artifact.result.project, user)) or (
-        artifact.run and not project_has_user(artifact.run.project, user)
-    ):
+    if not _user_has_artifact_access(artifact, user):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     return response
 
@@ -85,9 +97,7 @@ def download_artifact(id_, token_info=None, user=None):
     :rtype: file
     """
     artifact, response = _build_artifact_response(id_)
-    if (artifact.result and not project_has_user(artifact.result.project, user)) or (
-        artifact.run and not project_has_user(artifact.run.project, user)
-    ):
+    if not _user_has_artifact_access(artifact, user):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     response.headers["Content-Disposition"] = f"attachment; filename={artifact.filename}"
     return response
@@ -105,9 +115,7 @@ def get_artifact(id_, token_info=None, user=None):
     artifact = db.session.get(Artifact, id_)
     if not artifact:
         return HTTPStatus.NOT_FOUND.phrase, HTTPStatus.NOT_FOUND
-    if (artifact.result and not project_has_user(artifact.result.project, user)) or (
-        artifact.run and not project_has_user(artifact.run.project, user)
-    ):
+    if not _user_has_artifact_access(artifact, user):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     return artifact.to_dict()
 
@@ -340,9 +348,7 @@ def delete_artifact(id_, token_info=None, user=None):
     artifact = db.session.get(Artifact, id_)
     if not artifact:
         return HTTPStatus.NOT_FOUND.phrase, HTTPStatus.NOT_FOUND
-    if (artifact.result and not project_has_user(artifact.result.project, user)) or (
-        artifact.run and not project_has_user(artifact.run.project, user)
-    ):
+    if not _user_has_artifact_access(artifact, user):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     session.delete(artifact)
     session.commit()

--- a/backend/ibutsu_server/controllers/artifact_controller.py
+++ b/backend/ibutsu_server/controllers/artifact_controller.py
@@ -85,7 +85,9 @@ def download_artifact(id_, token_info=None, user=None):
     :rtype: file
     """
     artifact, response = _build_artifact_response(id_)
-    if not project_has_user(artifact.result.project, user):
+    if (artifact.result and not project_has_user(artifact.result.project, user)) or (
+        artifact.run and not project_has_user(artifact.run.project, user)
+    ):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     response.headers["Content-Disposition"] = f"attachment; filename={artifact.filename}"
     return response
@@ -103,7 +105,9 @@ def get_artifact(id_, token_info=None, user=None):
     artifact = db.session.get(Artifact, id_)
     if not artifact:
         return HTTPStatus.NOT_FOUND.phrase, HTTPStatus.NOT_FOUND
-    if not project_has_user(artifact.result.project, user):
+    if (artifact.result and not project_has_user(artifact.result.project, user)) or (
+        artifact.run and not project_has_user(artifact.run.project, user)
+    ):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     return artifact.to_dict()
 
@@ -338,7 +342,9 @@ def delete_artifact(id_, token_info=None, user=None):
     artifact = db.session.get(Artifact, id_)
     if not artifact:
         return HTTPStatus.NOT_FOUND.phrase, HTTPStatus.NOT_FOUND
-    if not project_has_user(artifact.result.project, user):
+    if (artifact.result and not project_has_user(artifact.result.project, user)) or (
+        artifact.run and not project_has_user(artifact.run.project, user)
+    ):
         return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
     session.delete(artifact)
     session.commit()

--- a/backend/ibutsu_server/controllers/artifact_controller.py
+++ b/backend/ibutsu_server/controllers/artifact_controller.py
@@ -124,8 +124,6 @@ def get_artifact_list(
     """
     query = db.select(Artifact)
     user = db.session.get(User, user)
-    if "result_id" in request.args:
-        result_id = request.args["result_id"]
     if result_id:
         query = query.where(Artifact.result_id == result_id)
     if run_id:

--- a/backend/ibutsu_server/controllers/import_controller.py
+++ b/backend/ibutsu_server/controllers/import_controller.py
@@ -102,7 +102,7 @@ def add_import(
         project_obj = get_project(project)
         if not project_obj:
             return f"Project {project} doesn't exist", HTTPStatus.BAD_REQUEST
-        if not project_has_user(project, user):
+        if not project_has_user(project_obj, user):
             return HTTPStatus.FORBIDDEN.phrase, HTTPStatus.FORBIDDEN
         data["project_id"] = project_obj.id
     if request.form.get("metadata"):

--- a/backend/ibutsu_server/controllers/login_controller.py
+++ b/backend/ibutsu_server/controllers/login_controller.py
@@ -291,7 +291,7 @@ def recover(body=None):
     if not user:
         return HTTPStatus.BAD_REQUEST.phrase, HTTPStatus.BAD_REQUEST
     # Create a random activation code. Base64 just for funsies
-    user.activation_code = urlsafe_b64encode(str(uuid4()).encode("utf8")).strip(b"=")
+    user.activation_code = urlsafe_b64encode(str(uuid4()).encode("utf8")).strip(b"=").decode()
     session.add(user)
     session.commit()
     return {}, HTTPStatus.CREATED

--- a/backend/ibutsu_server/util/projects.py
+++ b/backend/ibutsu_server/util/projects.py
@@ -28,6 +28,8 @@ def project_has_user(project, user):
         return True
     if isinstance(project, str):
         project = get_project(project)
+    if project is None:
+        return False
     return user in project.users or project.owner.id == user.id
 
 

--- a/backend/tests/test_util.py
+++ b/backend/tests/test_util.py
@@ -560,6 +560,12 @@ def test_project_has_user(make_project, make_user, user_role, expected_result):
     assert result is expected_result
 
 
+def test_project_has_user_none_project(make_user):
+    """Test project_has_user returns False when project is None (data integrity issue)."""
+    user = make_user(email="user@test.com")
+    assert project_has_user(None, user) is False
+
+
 def test_project_has_user_with_string_ids(make_project, make_user):
     """Test project_has_user with string IDs instead of objects."""
     owner = make_user(email="owner@test.com")

--- a/backend/tests/test_util.py
+++ b/backend/tests/test_util.py
@@ -566,6 +566,12 @@ def test_project_has_user_none_project(make_user):
     assert project_has_user(None, user) is False
 
 
+def test_project_has_user_invalid_string_project_id(make_user):
+    """Test project_has_user returns False when a string project ID resolves to None."""
+    user = make_user(email="user@test.com")
+    assert project_has_user("non-existent-project-id", user) is False
+
+
 def test_project_has_user_with_string_ids(make_project, make_user):
     """Test project_has_user with string IDs instead of objects."""
     owner = make_user(email="owner@test.com")


### PR DESCRIPTION
## Summary by Sourcery

Fix artifact and project access control edge cases and improve robustness around user/project lookups.

Bug Fixes:
- Ensure artifact access checks correctly handle artifacts linked via either results or runs and deny access to orphaned artifacts.
- Prevent errors when project_has_user is called with None or a non-existent project ID by explicitly returning False in those cases.
- Correct project permission checking during import to use the resolved project object instead of the raw identifier.
- Fix password recovery activation_code to be stored as a string rather than bytes.

Enhancements:
- Refactor artifact access validation into a shared helper to centralize project-based permission logic.

Tests:
- Add tests covering project_has_user behavior when given None or string IDs that do not resolve to a project.