### PR TITLE
Migration cast fix

### DIFF
--- a/backend/alembic/versions/e5736dbcc0b0_merge_perfscale_project_into_insights_qe.py
+++ b/backend/alembic/versions/e5736dbcc0b0_merge_perfscale_project_into_insights_qe.py
@@ -131,7 +131,7 @@ def upgrade() -> None:
 
     if is_pg:
         proj_json = f'{{"project": "{TO_PROJECT_NAME}"}}'
-        extra_set = ", data = COALESCE(data, '{}'::jsonb) || :proj_json::jsonb"
+        extra_set = ", data = COALESCE(data, '{}'::jsonb) || CAST(:proj_json AS jsonb)"
         extra_params = {"proj_json": proj_json}
     else:
         extra_set = ""

--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ibutsu API
-  version: 3.0.9
+  version: 3.0.10
 servers:
   - url: /api
 security:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "3.0.9"
+version = "3.0.10"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "private": true,
   "description": "Ibutsu Frontend",
   "dependencies": {


### PR DESCRIPTION
## Summary by Sourcery

Fix JSONB casting in a PostgreSQL migration and bump project version.

Bug Fixes:
- Correct JSONB casting in the PostgreSQL migration to ensure compatibility with parameterized queries.

Build:
- Update backend and frontend project versions from 3.0.9 to 3.0.10.

Documentation:
- Update OpenAPI specification version to 3.0.10 to match the new release.