### PR TITLE
3.0.11 release

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ibutsu API
-  version: 3.0.10
+  version: 3.0.11
 servers:
   - url: /api
 security:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "3.0.10"
+version = "3.0.11"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "private": true,
   "description": "Ibutsu Frontend",
   "dependencies": {


### PR DESCRIPTION
## Summary by Sourcery

Bump backend API, Python project, and frontend package versions to 3.0.11 for the new release.

Build:
- Update backend Python project version metadata to 3.0.11.

Deployment:
- Update OpenAPI spec and frontend package metadata to version 3.0.11 for the 3.0.11 release.