### PR TITLE
fix: make heatmap links bolder in dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,3 +105,8 @@ div.ibutsu-param-dropdown > div {
 :where(.pf-v5-theme-dark) .pf-v6-c-clipboard-copy .pf-v6-c-form-control[readonly] {
   border-bottom-color: var(--pf-v6-global--BorderColor--400) !important;
 }
+
+:where(.pf-v6-theme-dark) div[id="single-heatmap-cell"] a {
+  color: darkblue;
+  font-weight: bold;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -107,6 +107,6 @@ div.ibutsu-param-dropdown > div {
 }
 
 :where(.pf-v6-theme-dark) div[id="single-heatmap-cell"] a {
-  color: darkblue;
+  color: var(--pf-t--global--color--nonstatus--blue--500);
   font-weight: bold;
 }


### PR DESCRIPTION
How to test:

1. Load a jenkins archive
2. create a dashboard with Jenkins heatmap showing the archive
3. the links in the heatmap should be readable

Before:
<img width="139" height="102" alt="Screenshot From 2026-04-23 18-35-00" src="https://github.com/user-attachments/assets/7a96dd42-1a89-47a2-a33f-60c4f1dd6c9c" />

After:
<img width="139" height="102" alt="image" src="https://github.com/user-attachments/assets/3cf449d0-7991-4a7f-b0f0-7b03a2236c2b" />


## Summary by Sourcery

Bug Fixes:
- Adjust Jenkins heatmap link styling in dark mode so links remain clearly visible against the background.