### PR TITLE
Add pass percentage to run summary

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -69,7 +69,15 @@ def run_migrations_online() -> None:
         connectable = db.engine
 
         with connectable.connect() as connection:
-            context.configure(connection=connection, target_metadata=target_metadata)
+            # transaction_per_migration: each revision commits independently.
+            # Required for migrations that use autocommit_block() (e.g. CREATE
+            # INDEX CONCURRENTLY / batched backfills that must not share a
+            # long-lived transaction with prior DDL locks).
+            context.configure(
+                connection=connection,
+                target_metadata=target_metadata,
+                transaction_per_migration=True,
+            )
 
             with context.begin_transaction():
                 context.run_migrations()

--- a/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
+++ b/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
@@ -1,0 +1,127 @@
+"""backfill_pass_percent_in_run_summary
+
+Backfill pass_percent into the summary JSON blob for all existing runs,
+and create a B-tree expression index for fast range filtering.
+
+PostgreSQL only -- skipped on SQLite (dev/test environments).
+
+Revision ID: d18de2b3253f
+Revises: e5736dbcc0b0
+Create Date: 2026-05-18 19:30:00.000000
+
+"""
+
+import logging
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d18de2b3253f"
+down_revision = "e5736dbcc0b0"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.versions.d18de2b3253f")
+
+
+def _ensure_index(name: str, table: str, columns, *, create: bool, **kwargs) -> None:
+    """Idempotent index create/drop for PostgreSQL-specific indexes."""
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+
+    exists = conn.execute(
+        sa.text(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_indexes
+                WHERE indexname = :index_name
+                  AND tablename = :table_name
+            )
+            """
+        ),
+        {"index_name": name, "table_name": table},
+    ).scalar()
+
+    if create and not exists:
+        op.create_index(name, table, columns, **kwargs)
+    elif not create and exists:
+        op.drop_index(name, table_name=table)
+
+
+def upgrade() -> None:
+    logger.info("Starting migration d18de2b3253f: backfill pass_percent")
+
+    conn = op.get_bind()
+
+    if conn.dialect.name != "postgresql":
+        logger.info("Non-PostgreSQL dialect; skipping pass_percent backfill")
+        return
+
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE runs
+            SET summary = jsonb_set(
+                COALESCE(summary, '{}'::jsonb),
+                '{pass_percent}',
+                to_jsonb(
+                    CASE
+                        -- passes key present: compute directly from passes/tests
+                        WHEN summary IS NOT NULL
+                         AND summary->>'tests' ~ '^[0-9]+$'
+                         AND (summary->>'tests')::int > 0
+                         AND summary->>'passes' ~ '^[0-9]+$'
+                        THEN floor(
+                            ((summary->>'passes')::numeric
+                             / (summary->>'tests')::numeric) * 100
+                        )::int
+
+                        -- no passes key (very old runs): derive from counters
+                        WHEN summary IS NOT NULL
+                         AND summary->>'tests' ~ '^[0-9]+$'
+                         AND (summary->>'tests')::int > 0
+                         AND summary->>'passes' IS NULL
+                        THEN floor(
+                            (
+                                (summary->>'tests')::numeric
+                                - CASE WHEN summary->>'failures' ~ '^[0-9]+$'
+                                       THEN (summary->>'failures')::numeric ELSE 0 END
+                                - CASE WHEN summary->>'errors' ~ '^[0-9]+$'
+                                       THEN (summary->>'errors')::numeric ELSE 0 END
+                                - CASE WHEN summary->>'skips' ~ '^[0-9]+$'
+                                       THEN (summary->>'skips')::numeric ELSE 0 END
+                                - CASE WHEN summary->>'xpasses' ~ '^[0-9]+$'
+                                       THEN (summary->>'xpasses')::numeric ELSE 0 END
+                                - CASE WHEN summary->>'xfailures' ~ '^[0-9]+$'
+                                       THEN (summary->>'xfailures')::numeric ELSE 0 END
+                            ) / (summary->>'tests')::numeric * 100
+                        )::int
+
+                        -- zero tests, missing tests key, or malformed values: store 0
+                        ELSE 0
+                    END
+                )
+            )
+            WHERE summary IS NOT NULL
+              AND summary->'pass_percent' IS NULL
+            """
+        )
+    )
+    logger.info("Backfilled pass_percent for %d runs", result.rowcount)
+
+    _ensure_index(
+        "ix_runs_pass_percent",
+        "runs",
+        [sa.text("((summary->>'pass_percent')::int)")],
+        create=True,
+        unique=False,
+    )
+    logger.info("Created ix_runs_pass_percent index")
+
+
+def downgrade() -> None:
+    _ensure_index("ix_runs_pass_percent", "runs", None, create=False)

--- a/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
+++ b/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
@@ -57,6 +57,9 @@ def upgrade() -> None:
 
     conn = op.get_bind()
 
+    # The backfill and index use PostgreSQL-specific JSON operators and
+    # expression indexes.  SQLite (used in dev/test) has no runs with
+    # production data, so skipping is safe there.
     if conn.dialect.name != "postgresql":
         logger.info("Non-PostgreSQL dialect; skipping pass_percent backfill")
         return
@@ -64,55 +67,117 @@ def upgrade() -> None:
     result = conn.execute(
         sa.text(
             """
-            UPDATE runs
+            -- Normalize each counter field from text to numeric exactly once so
+            -- the UPDATE expression stays shallow and avoids repeating casts and
+            -- regex guards.  Fields that are absent or non-numeric are coerced to
+            -- NULL (tests/passes, which drive branching) or 0 (loss counters,
+            -- which default-to-zero is safe for subtraction arithmetic).
+            WITH normalized AS (
+                SELECT
+                    id,
+                    CASE
+                        WHEN summary->>'tests' ~ '^[0-9]+$'
+                        THEN (summary->>'tests')::numeric
+                        ELSE NULL
+                    END AS tests_num,
+                    CASE
+                        WHEN summary->>'passes' ~ '^[0-9]+$'
+                        THEN (summary->>'passes')::numeric
+                        ELSE NULL
+                    END AS passes_num,
+                    -- Loss counters default to 0 so the derived-passes arithmetic
+                    -- below stays correct even when a counter key is missing.
+                    CASE
+                        WHEN summary->>'failures' ~ '^[0-9]+$'
+                        THEN (summary->>'failures')::numeric
+                        ELSE 0
+                    END AS failures_num,
+                    CASE
+                        WHEN summary->>'errors' ~ '^[0-9]+$'
+                        THEN (summary->>'errors')::numeric
+                        ELSE 0
+                    END AS errors_num,
+                    CASE
+                        WHEN summary->>'skips' ~ '^[0-9]+$'
+                        THEN (summary->>'skips')::numeric
+                        ELSE 0
+                    END AS skips_num,
+                    -- xpasses and xfailures count as non-passing outcomes and are
+                    -- subtracted when deriving passes from counters.
+                    CASE
+                        WHEN summary->>'xpasses' ~ '^[0-9]+$'
+                        THEN (summary->>'xpasses')::numeric
+                        ELSE 0
+                    END AS xpasses_num,
+                    CASE
+                        WHEN summary->>'xfailures' ~ '^[0-9]+$'
+                        THEN (summary->>'xfailures')::numeric
+                        ELSE 0
+                    END AS xfailures_num
+                FROM runs
+                WHERE summary IS NOT NULL
+                  AND summary->'pass_percent' IS NULL   -- skip already-backfilled rows
+            )
+            UPDATE runs AS r
             SET summary = jsonb_set(
-                COALESCE(summary, '{}'::jsonb),
+                COALESCE(r.summary, '{}'::jsonb),
                 '{pass_percent}',
                 to_jsonb(
                     CASE
-                        -- passes key present: compute directly from passes/tests
-                        WHEN summary IS NOT NULL
-                         AND summary->>'tests' ~ '^[0-9]+$'
-                         AND (summary->>'tests')::int > 0
-                         AND summary->>'passes' ~ '^[0-9]+$'
-                        THEN floor(
-                            ((summary->>'passes')::numeric
-                             / (summary->>'tests')::numeric) * 100
-                        )::int
+                        -- Modern runs that recorded a 'passes' counter directly.
+                        -- This is the preferred path; divide passes by tests.
+                        WHEN n.tests_num IS NOT NULL
+                         AND n.tests_num > 0
+                         AND n.passes_num IS NOT NULL
+                        THEN LEAST(
+                            GREATEST(
+                                floor((n.passes_num / n.tests_num) * 100)::int,
+                                0    -- guard against a passes value > tests
+                            ),
+                            100      -- guard against a passes value > tests
+                        )
 
-                        -- no passes key (very old runs): derive from counters
-                        WHEN summary IS NOT NULL
-                         AND summary->>'tests' ~ '^[0-9]+$'
-                         AND (summary->>'tests')::int > 0
-                         AND summary->>'passes' IS NULL
-                        THEN floor(
-                            (
-                                (summary->>'tests')::numeric
-                                - CASE WHEN summary->>'failures' ~ '^[0-9]+$'
-                                       THEN (summary->>'failures')::numeric ELSE 0 END
-                                - CASE WHEN summary->>'errors' ~ '^[0-9]+$'
-                                       THEN (summary->>'errors')::numeric ELSE 0 END
-                                - CASE WHEN summary->>'skips' ~ '^[0-9]+$'
-                                       THEN (summary->>'skips')::numeric ELSE 0 END
-                                - CASE WHEN summary->>'xpasses' ~ '^[0-9]+$'
-                                       THEN (summary->>'xpasses')::numeric ELSE 0 END
-                                - CASE WHEN summary->>'xfailures' ~ '^[0-9]+$'
-                                       THEN (summary->>'xfailures')::numeric ELSE 0 END
-                            ) / (summary->>'tests')::numeric * 100
-                        )::int
+                        -- Very old runs that never stored a 'passes' key.
+                        -- Derive passes by subtracting every known loss counter
+                        -- from the total.  LEAST/GREATEST clamps the result to
+                        -- [0, 100] in case the historical counters are inconsistent
+                        -- (e.g. sum of losses exceeds tests due to data corruption).
+                        WHEN n.tests_num IS NOT NULL
+                         AND n.tests_num > 0
+                         AND n.passes_num IS NULL
+                        THEN LEAST(
+                            GREATEST(
+                                floor(
+                                    (
+                                        n.tests_num
+                                        - n.failures_num
+                                        - n.errors_num
+                                        - n.skips_num
+                                        - n.xpasses_num
+                                        - n.xfailures_num
+                                    ) / n.tests_num * 100
+                                )::int,
+                                0
+                            ),
+                            100
+                        )
 
-                        -- zero tests, missing tests key, or malformed values: store 0
+                        -- tests is 0, absent, or malformed: no meaningful
+                        -- percentage can be computed, store 0 as a sentinel.
                         ELSE 0
                     END
                 )
             )
-            WHERE summary IS NOT NULL
-              AND summary->'pass_percent' IS NULL
+            FROM normalized AS n
+            WHERE r.id = n.id
             """
         )
     )
     logger.info("Backfilled pass_percent for %d runs", result.rowcount)
 
+    # Expression index on the integer cast of summary->>'pass_percent' so that
+    # range filter queries (e.g. pass_percent >= 80) can use an index scan
+    # rather than a full sequential scan over the JSONB column.
     _ensure_index(
         "ix_runs_pass_percent",
         "runs",
@@ -124,4 +189,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Drops the expression index only.  The backfilled pass_percent values are
+    # left in place intentionally: removing them would require re-deriving each
+    # value and risks data loss if the source counters have since been modified.
+    # Re-running upgrade() after a downgrade is safe because the CTE filters on
+    # summary->'pass_percent' IS NULL, so already-populated rows are skipped.
     _ensure_index("ix_runs_pass_percent", "runs", None, create=False)

--- a/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
+++ b/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
@@ -15,7 +15,7 @@ import logging
 
 import sqlalchemy as sa
 
-from alembic import op
+from alembic import context, op
 
 # revision identifiers, used by Alembic.
 revision = "d18de2b3253f"
@@ -25,123 +25,144 @@ depends_on = None
 
 logger = logging.getLogger("alembic.versions.d18de2b3253f")
 
+BATCH_SIZE = 5000
+
+# Canonical pass_percent formula: floor(passes * 100 / tests), clamped to
+# [0, 100].  This matches the runtime calculation in
+# ibutsu_server/tasks/runs.py (update_run) and the frontend fallback in
+# frontend/src/utilities/run.js (getRunPassPercent).
+#
+# Non-passing outcomes subtracted when deriving passes (old runs that lack an
+# explicit "passes" key): failures, errors, skips, xpasses, xfailures.
+# If this list changes, update update_run and getRunPassPercent as well.
+#
+# The query uses two CTEs because PostgreSQL does not allow referencing column
+# aliases defined in the same SELECT list.  ``parsed`` extracts numeric values
+# from the JSONB summary once, and ``computed`` derives pass_percent from them.
+# A LIMIT on ``parsed`` keeps each batch bounded.
+_BACKFILL_BATCH_SQL = sa.text("""\
+WITH parsed AS (
+    SELECT
+        id,
+        CASE WHEN summary->>'tests' ~ '^[0-9]+$'
+             THEN (summary->>'tests')::numeric
+        END AS tests_num,
+        CASE WHEN summary->>'passes' ~ '^[0-9]+$'
+             THEN (summary->>'passes')::numeric
+        END AS passes_num,
+        COALESCE(
+            CASE WHEN summary->>'failures' ~ '^[0-9]+$'
+                 THEN (summary->>'failures')::numeric
+            END, 0) AS failures_num,
+        COALESCE(
+            CASE WHEN summary->>'errors' ~ '^[0-9]+$'
+                 THEN (summary->>'errors')::numeric
+            END, 0) AS errors_num,
+        COALESCE(
+            CASE WHEN summary->>'skips' ~ '^[0-9]+$'
+                 THEN (summary->>'skips')::numeric
+            END, 0) AS skips_num,
+        COALESCE(
+            CASE WHEN summary->>'xpasses' ~ '^[0-9]+$'
+                 THEN (summary->>'xpasses')::numeric
+            END, 0) AS xpasses_num,
+        COALESCE(
+            CASE WHEN summary->>'xfailures' ~ '^[0-9]+$'
+                 THEN (summary->>'xfailures')::numeric
+            END, 0) AS xfailures_num
+    FROM runs
+    WHERE summary IS NOT NULL
+      AND summary->'pass_percent' IS NULL
+    LIMIT :batch_size
+),
+computed AS (
+    SELECT
+        id,
+        CASE
+            WHEN tests_num IS NOT NULL
+             AND tests_num > 0
+             AND passes_num IS NOT NULL
+            THEN LEAST(GREATEST(
+                floor(passes_num * 100 / tests_num)::int,
+                0), 100)
+        END AS pass_pct_direct,
+        CASE
+            WHEN tests_num IS NOT NULL
+             AND tests_num > 0
+             AND passes_num IS NULL
+            THEN LEAST(GREATEST(
+                floor((
+                    tests_num
+                    - failures_num
+                    - errors_num
+                    - skips_num
+                    - xpasses_num
+                    - xfailures_num
+                ) * 100 / tests_num)::int,
+                0), 100)
+        END AS pass_pct_derived
+    FROM parsed
+)
+UPDATE runs AS r
+SET summary = jsonb_set(
+    COALESCE(r.summary, '{}'::jsonb),
+    '{pass_percent}',
+    to_jsonb(COALESCE(c.pass_pct_direct, c.pass_pct_derived, 0))
+)
+FROM computed AS c
+WHERE r.id = c.id
+""")
+
 
 def upgrade() -> None:
-    logger.info("Starting migration d18de2b3253f: backfill pass_percent")
+    if context.is_offline_mode():
+        raise RuntimeError(
+            "This migration requires a live database connection and does not support "
+            "offline SQL generation (alembic upgrade --sql). Run in online mode."
+        )
 
-    conn = op.get_bind()
+    bind = op.get_bind()
 
     # The backfill and index use PostgreSQL-specific JSON operators and
     # expression indexes.  SQLite (used in dev/test) has no runs with
     # production data, so skipping is safe there.
-    if conn.dialect.name != "postgresql":
+    if bind.dialect.name != "postgresql":
         logger.info("Non-PostgreSQL dialect; skipping pass_percent backfill")
         return
 
-    # Canonical pass_percent formula: floor(passes * 100 / tests), clamped
-    # to [0, 100].  This matches the runtime calculation in
-    # ibutsu_server/tasks/runs.py (update_run) and the frontend fallback in
-    # frontend/src/utilities/run.js (getRunPassPercent).
-    #
-    # Non-passing outcomes subtracted when deriving passes (old runs that
-    # lack an explicit "passes" key): failures, errors, skips, xpasses,
-    # xfailures.  If this list changes, update update_run and
-    # getRunPassPercent as well.
-    result = conn.execute(
-        sa.text(
-            """
-            WITH normalized AS (
-                SELECT
-                    id,
-                    -- Parse each counter once; tests/passes NULL when absent
-                    -- or non-numeric, loss counters default to 0.
-                    CASE WHEN summary->>'tests'   ~ '^[0-9]+$'
-                         THEN (summary->>'tests')::numeric   END AS tests_num,
-                    CASE WHEN summary->>'passes'  ~ '^[0-9]+$'
-                         THEN (summary->>'passes')::numeric  END AS passes_num,
-                    COALESCE(
-                        CASE WHEN summary->>'failures'  ~ '^[0-9]+$'
-                             THEN (summary->>'failures')::numeric  END, 0
-                    ) AS failures_num,
-                    COALESCE(
-                        CASE WHEN summary->>'errors'    ~ '^[0-9]+$'
-                             THEN (summary->>'errors')::numeric    END, 0
-                    ) AS errors_num,
-                    COALESCE(
-                        CASE WHEN summary->>'skips'     ~ '^[0-9]+$'
-                             THEN (summary->>'skips')::numeric     END, 0
-                    ) AS skips_num,
-                    COALESCE(
-                        CASE WHEN summary->>'xpasses'   ~ '^[0-9]+$'
-                             THEN (summary->>'xpasses')::numeric   END, 0
-                    ) AS xpasses_num,
-                    COALESCE(
-                        CASE WHEN summary->>'xfailures' ~ '^[0-9]+$'
-                             THEN (summary->>'xfailures')::numeric END, 0
-                    ) AS xfailures_num,
+    logger.info("Starting migration d18de2b3253f: backfill pass_percent")
 
-                    -- Precompute: direct path (passes key present)
-                    CASE
-                        WHEN summary->>'tests'  ~ '^[0-9]+$'
-                         AND (summary->>'tests')::numeric > 0
-                         AND summary->>'passes' ~ '^[0-9]+$'
-                        THEN LEAST(GREATEST(
-                            floor(
-                                (summary->>'passes')::numeric * 100
-                                / (summary->>'tests')::numeric
-                            )::int,
-                            0), 100)
-                    END AS pass_percent_direct,
+    # Use a separate connection for the batched backfill to avoid conflicting
+    # with Alembic's transaction management.  Each batch gets its own explicit
+    # transaction so row locks are released between iterations.  The query is
+    # idempotent (filters on summary->'pass_percent' IS NULL), so a failure
+    # mid-loop is safe to re-run.
+    engine = bind.engine
+    total_updated = 0
+    with engine.connect() as backfill_conn:
+        while True:
+            with backfill_conn.begin():
+                result = backfill_conn.execute(_BACKFILL_BATCH_SQL, {"batch_size": BATCH_SIZE})
+                batch_count = result.rowcount
+                total_updated += batch_count
+                logger.info("  batch: %d rows updated", batch_count)
+            if batch_count < BATCH_SIZE:
+                break
 
-                    -- Precompute: derived path (passes key absent)
-                    CASE
-                        WHEN summary->>'tests'  ~ '^[0-9]+$'
-                         AND (summary->>'tests')::numeric > 0
-                         AND NOT (summary ? 'passes')
-                        THEN LEAST(GREATEST(
-                            floor(
-                                (
-                                    (summary->>'tests')::numeric
-                                    - COALESCE(CASE WHEN summary->>'failures'  ~ '^[0-9]+$' THEN (summary->>'failures')::numeric  END, 0)
-                                    - COALESCE(CASE WHEN summary->>'errors'    ~ '^[0-9]+$' THEN (summary->>'errors')::numeric    END, 0)
-                                    - COALESCE(CASE WHEN summary->>'skips'     ~ '^[0-9]+$' THEN (summary->>'skips')::numeric     END, 0)
-                                    - COALESCE(CASE WHEN summary->>'xpasses'   ~ '^[0-9]+$' THEN (summary->>'xpasses')::numeric   END, 0)
-                                    - COALESCE(CASE WHEN summary->>'xfailures' ~ '^[0-9]+$' THEN (summary->>'xfailures')::numeric END, 0)
-                                ) * 100
-                                / (summary->>'tests')::numeric
-                            )::int,
-                            0), 100)
-                    END AS pass_percent_derived
+    logger.info("Backfilled pass_percent for %d runs total", total_updated)
 
-                FROM runs
-                WHERE summary IS NOT NULL
-                  AND summary->'pass_percent' IS NULL
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    # Use a separate connection with AUTOCOMMIT isolation level so that
+    # PostgreSQL allows the concurrent index build without conflicting with
+    # Alembic's transaction management.
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as idx_conn:
+        idx_conn.execute(
+            sa.text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_runs_pass_percent "
+                "ON runs (((summary->>'pass_percent')::int))"
             )
-            UPDATE runs AS r
-            SET summary = jsonb_set(
-                COALESCE(r.summary, '{}'::jsonb),
-                '{pass_percent}',
-                to_jsonb(COALESCE(n.pass_percent_direct, n.pass_percent_derived, 0))
-            )
-            FROM normalized AS n
-            WHERE r.id = n.id
-            """
         )
-    )
-    logger.info("Backfilled pass_percent for %d runs", result.rowcount)
-
-    # Expression index on the integer cast of summary->>'pass_percent' so that
-    # range filter queries (e.g. pass_percent >= 80) can use an index scan
-    # rather than a full sequential scan over the JSONB column.
-    op.create_index(
-        "ix_runs_pass_percent",
-        "runs",
-        [sa.text("((summary->>'pass_percent')::int)")],
-        unique=False,
-        postgresql_using="btree",
-        if_not_exists=True,
-    )
-    logger.info("Created ix_runs_pass_percent index")
+    logger.info("Created ix_runs_pass_percent index (CONCURRENTLY)")
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
+++ b/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
@@ -26,32 +26,6 @@ depends_on = None
 logger = logging.getLogger("alembic.versions.d18de2b3253f")
 
 
-def _ensure_index(name: str, table: str, columns, *, create: bool, **kwargs) -> None:
-    """Idempotent index create/drop for PostgreSQL-specific indexes."""
-    conn = op.get_bind()
-    if conn.dialect.name != "postgresql":
-        return
-
-    exists = conn.execute(
-        sa.text(
-            """
-            SELECT EXISTS (
-                SELECT 1
-                FROM pg_indexes
-                WHERE indexname = :index_name
-                  AND tablename = :table_name
-            )
-            """
-        ),
-        {"index_name": name, "table_name": table},
-    ).scalar()
-
-    if create and not exists:
-        op.create_index(name, table, columns, **kwargs)
-    elif not create and exists:
-        op.drop_index(name, table_name=table)
-
-
 def upgrade() -> None:
     logger.info("Starting migration d18de2b3253f: backfill pass_percent")
 
@@ -132,9 +106,11 @@ def upgrade() -> None:
                         THEN LEAST(
                             GREATEST(
                                 floor((n.passes_num / n.tests_num) * 100)::int,
-                                0    -- guard against a passes value > tests
+                                0
+                                -- guard against negative % (passes_num > tests_num)
                             ),
-                            100      -- guard against a passes value > tests
+                            100
+                            -- guard against over-100 % (passes_num > tests_num)
                         )
 
                         -- Very old runs that never stored a 'passes' key.
@@ -178,12 +154,13 @@ def upgrade() -> None:
     # Expression index on the integer cast of summary->>'pass_percent' so that
     # range filter queries (e.g. pass_percent >= 80) can use an index scan
     # rather than a full sequential scan over the JSONB column.
-    _ensure_index(
+    op.create_index(
         "ix_runs_pass_percent",
         "runs",
         [sa.text("((summary->>'pass_percent')::int)")],
-        create=True,
         unique=False,
+        postgresql_using="btree",
+        if_not_exists=True,
     )
     logger.info("Created ix_runs_pass_percent index")
 
@@ -194,4 +171,7 @@ def downgrade() -> None:
     # value and risks data loss if the source counters have since been modified.
     # Re-running upgrade() after a downgrade is safe because the CTE filters on
     # summary->'pass_percent' IS NULL, so already-populated rows are skipped.
-    _ensure_index("ix_runs_pass_percent", "runs", None, create=False)
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    op.drop_index("ix_runs_pass_percent", table_name="runs", if_exists=True)

--- a/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
+++ b/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
@@ -1,0 +1,322 @@
+"""backfill_pass_percent_in_run_summary
+
+Backfill pass_percent into the summary JSON blob for all existing runs,
+and create a B-tree expression index for fast range filtering.
+
+PostgreSQL only -- skipped on SQLite (dev/test environments).
+
+Revision ID: d18de2b3253f
+Revises: e5736dbcc0b0
+Create Date: 2026-05-18 19:30:00.000000
+
+"""
+
+import logging
+import time
+
+import sqlalchemy as sa
+
+from alembic import context, op
+
+# revision identifiers, used by Alembic.
+revision = "d18de2b3253f"
+down_revision = "e5736dbcc0b0"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.versions.d18de2b3253f")
+
+BATCH_SIZE = 5000
+
+# Fail fast on lock waits instead of hanging the container until it is killed.
+# 30s is enough to prove contention; production backfills that take longer per
+# batch should raise this via ALTER ... SET lock_timeout if needed.
+_LOCK_TIMEOUT = "30s"
+
+# Canonical pass_percent formula: floor(passes * 100 / tests), clamped to
+# [0, 100].  This matches ibutsu_server.tasks.runs.compute_pass_percent
+# (used by update_run) and the frontend fallback in
+# frontend/src/utilities/run.js (getRunPassPercent). This SQL can't call
+# into either of those directly, so if the formula changes, update all
+# three -- see test_runs.py::test_compute_pass_percent_* for the cases
+# that must match across implementations.
+#
+# Non-passing outcomes subtracted when deriving passes (old runs that lack an
+# explicit "passes" key): failures, errors, skips, xpasses, xfailures.
+# If this list changes, update compute_pass_percent and getRunPassPercent
+# as well.
+#
+# The query uses two CTEs because PostgreSQL does not allow referencing column
+# aliases defined in the same SELECT list.  ``parsed`` extracts numeric values
+# from the JSONB summary once, and ``computed`` derives pass_percent from them.
+# A LIMIT on ``parsed`` keeps each batch bounded.
+_BACKFILL_BATCH_SQL = sa.text("""\
+WITH parsed AS (
+    SELECT
+        id,
+        CASE WHEN summary->>'tests' ~ '^[0-9]+$'
+             THEN (summary->>'tests')::numeric
+        END AS tests_num,
+        CASE WHEN summary->>'passes' ~ '^[0-9]+$'
+             THEN (summary->>'passes')::numeric
+        END AS passes_num,
+        COALESCE(
+            CASE WHEN summary->>'failures' ~ '^[0-9]+$'
+                 THEN (summary->>'failures')::numeric
+            END, 0) AS failures_num,
+        COALESCE(
+            CASE WHEN summary->>'errors' ~ '^[0-9]+$'
+                 THEN (summary->>'errors')::numeric
+            END, 0) AS errors_num,
+        COALESCE(
+            CASE WHEN summary->>'skips' ~ '^[0-9]+$'
+                 THEN (summary->>'skips')::numeric
+            END, 0) AS skips_num,
+        COALESCE(
+            CASE WHEN summary->>'xpasses' ~ '^[0-9]+$'
+                 THEN (summary->>'xpasses')::numeric
+            END, 0) AS xpasses_num,
+        COALESCE(
+            CASE WHEN summary->>'xfailures' ~ '^[0-9]+$'
+                 THEN (summary->>'xfailures')::numeric
+            END, 0) AS xfailures_num
+    FROM runs
+    WHERE summary IS NOT NULL
+      AND summary->'pass_percent' IS NULL
+    LIMIT :batch_size
+),
+computed AS (
+    SELECT
+        id,
+        CASE
+            WHEN tests_num IS NOT NULL
+             AND tests_num > 0
+             AND passes_num IS NOT NULL
+            THEN LEAST(GREATEST(
+                floor(passes_num * 100 / tests_num)::int,
+                0), 100)
+        END AS pass_pct_direct,
+        CASE
+            WHEN tests_num IS NOT NULL
+             AND tests_num > 0
+             AND passes_num IS NULL
+            THEN LEAST(GREATEST(
+                floor((
+                    tests_num
+                    - failures_num
+                    - errors_num
+                    - skips_num
+                    - xpasses_num
+                    - xfailures_num
+                ) * 100 / tests_num)::int,
+                0), 100)
+        END AS pass_pct_derived
+    FROM parsed
+)
+UPDATE runs AS r
+SET summary = jsonb_set(
+    COALESCE(r.summary, '{}'::jsonb),
+    '{pass_percent}',
+    to_jsonb(COALESCE(c.pass_pct_direct, c.pass_pct_derived, 0))
+)
+FROM computed AS c
+WHERE r.id = c.id
+""")
+
+_PENDING_COUNT_SQL = sa.text("""\
+SELECT COUNT(*) FROM runs
+WHERE summary IS NOT NULL
+  AND summary->'pass_percent' IS NULL
+""")
+
+_BACKEND_PID_SQL = sa.text("SELECT pg_backend_pid()")
+
+_LOCK_DIAG_SQL = sa.text("""\
+SELECT
+    a.pid,
+    a.state,
+    a.wait_event_type,
+    a.wait_event,
+    a.query_start,
+    LEFT(a.query, 120) AS query,
+    l.locktype,
+    l.mode,
+    l.granted,
+    l.relation::regclass AS relation
+FROM pg_stat_activity AS a
+LEFT JOIN pg_locks AS l ON l.pid = a.pid
+WHERE a.datname = current_database()
+  AND a.pid <> pg_backend_pid()
+  AND (
+    NOT COALESCE(l.granted, true)
+    OR a.wait_event_type IS NOT NULL
+    OR a.state <> 'idle'
+  )
+ORDER BY a.query_start NULLS LAST
+LIMIT 40
+""")
+
+
+def _log(msg: str, *args: object) -> None:
+    logger.info(msg, *args)
+
+
+def _flush_logs() -> None:
+    """Flush handlers so container logs show progress before a hang/kill.
+
+    Called at coarse-grained points (batch/step boundaries, and on error)
+    rather than after every _log() call, since flushing on every message is
+    needless overhead for a migration that may log hundreds of batches.
+    """
+    for handler in logging.root.handlers:
+        handler.flush()
+    for handler in logger.handlers:
+        handler.flush()
+
+
+def _dump_lock_diagnostics(conn: sa.Connection, reason: str) -> None:
+    """Emit pg_stat_activity / pg_locks snapshot to explain a lock wait."""
+    _log("Lock diagnostic dump (%s):", reason)
+    try:
+        rows = conn.execute(_LOCK_DIAG_SQL).mappings().all()
+    except Exception as exc:
+        _log("  failed to query lock diagnostics: %s", exc)
+        _flush_logs()
+        return
+    if not rows:
+        _log("  (no blocking/waiting activity found)")
+    for row in rows:
+        _log(
+            "  pid=%s state=%s wait=%s/%s granted=%s mode=%s rel=%s query=%r",
+            row["pid"],
+            row["state"],
+            row["wait_event_type"],
+            row["wait_event"],
+            row["granted"],
+            row["mode"],
+            row["relation"],
+            row["query"],
+        )
+    _flush_logs()
+
+
+def _run_backfill_batches(conn: sa.Connection) -> int:
+    """Repeatedly apply _BACKFILL_BATCH_SQL until fewer than BATCH_SIZE rows remain.
+
+    Returns the total number of rows updated across all batches.
+    """
+    total_updated = 0
+    batch_num = 0
+    while True:
+        batch_num += 1
+        started = time.monotonic()
+        _log("Executing backfill batch %d ...", batch_num)
+        _flush_logs()
+        try:
+            result = conn.execute(_BACKFILL_BATCH_SQL, {"batch_size": BATCH_SIZE})
+        except Exception:
+            _dump_lock_diagnostics(conn, f"batch {batch_num} failed")
+            raise
+        batch_count = result.rowcount if result.rowcount is not None else -1
+        # Treat unknown rowcount as "keep going only if we know we updated"
+        # — for PostgreSQL UPDATE, rowcount is reliable.
+        if batch_count < 0:
+            _log("Batch %d returned unknown rowcount; treating as complete", batch_num)
+            break
+        total_updated += batch_count
+        elapsed = time.monotonic() - started
+        _log(
+            "  batch %d: %d rows updated in %.2fs (total=%d)",
+            batch_num,
+            batch_count,
+            elapsed,
+            total_updated,
+        )
+        if batch_count < BATCH_SIZE:
+            break
+
+    return total_updated
+
+
+def _create_pass_percent_index(conn: sa.Connection) -> None:
+    """Create the ix_runs_pass_percent expression index outside a transaction."""
+    _log("Creating ix_runs_pass_percent CONCURRENTLY ...")
+    _flush_logs()
+    idx_started = time.monotonic()
+    try:
+        conn.execute(
+            sa.text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_runs_pass_percent "
+                "ON runs (((summary->>'pass_percent')::int))"
+            )
+        )
+    except Exception:
+        _dump_lock_diagnostics(conn, "CREATE INDEX CONCURRENTLY failed")
+        raise
+    _log(
+        "Created ix_runs_pass_percent index (CONCURRENTLY) in %.2fs",
+        time.monotonic() - idx_started,
+    )
+    _flush_logs()
+
+
+def upgrade() -> None:
+    if context.is_offline_mode():
+        raise RuntimeError(
+            "This migration requires a live database connection and does not support "
+            "offline SQL generation (alembic upgrade --sql). Run in online mode."
+        )
+
+    bind = op.get_bind()
+
+    # The backfill and index use PostgreSQL-specific JSON operators and
+    # expression indexes.  SQLite (used in dev/test) has no runs with
+    # production data, so skipping is safe there.
+    if bind.dialect.name != "postgresql":
+        _log("Non-PostgreSQL dialect; skipping pass_percent backfill")
+        return
+
+    _log("Starting migration d18de2b3253f: backfill pass_percent")
+    _flush_logs()
+
+    # IMPORTANT: Do NOT open a second engine.connect() while Alembic still holds
+    # its migration transaction. Prior DDL (e.g. CREATE INDEX on runs) keeps
+    # ShareLocks until that transaction commits; a second connection's UPDATE
+    # then waits forever (self-deadlock). Use autocommit_block so Alembic
+    # commits first, then each batch / CONCURRENTLY index runs outside a txn.
+    with op.get_context().autocommit_block():
+        conn = op.get_bind()
+        backend_pid = conn.execute(_BACKEND_PID_SQL).scalar()
+        pending = conn.execute(_PENDING_COUNT_SQL).scalar() or 0
+        _log(
+            "Autocommit block active (pg_backend_pid=%s); pending runs=%d; batch_size=%d",
+            backend_pid,
+            pending,
+            BATCH_SIZE,
+        )
+
+        # PostgreSQL's SET does not reliably accept bind parameters for its
+        # value, so _LOCK_TIMEOUT (a trusted internal constant, not user
+        # input) is interpolated directly to keep the log message and the
+        # effective timeout in sync.
+        conn.execute(sa.text(f"SET lock_timeout = '{_LOCK_TIMEOUT}'"))
+        _log("Set lock_timeout=%s for backfill connection", _LOCK_TIMEOUT)
+        _flush_logs()
+
+        total_updated = _run_backfill_batches(conn)
+        _log("Backfilled pass_percent for %d runs total", total_updated)
+        _flush_logs()
+
+        _create_pass_percent_index(conn)
+
+
+def downgrade() -> None:
+    # Drops the expression index only.  The backfilled pass_percent values are
+    # left in place intentionally: removing them would require re-deriving each
+    # value and risks data loss if the source counters have since been modified.
+    # Re-running upgrade() after a downgrade is safe because the CTE filters on
+    # summary->'pass_percent' IS NULL, so already-populated rows are skipped.
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    op.drop_index("ix_runs_pass_percent", table_name="runs", if_exists=True)

--- a/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
+++ b/backend/alembic/versions/d18de2b3253f_backfill_pass_percent_in_run_summary.py
@@ -38,111 +38,90 @@ def upgrade() -> None:
         logger.info("Non-PostgreSQL dialect; skipping pass_percent backfill")
         return
 
+    # Canonical pass_percent formula: floor(passes * 100 / tests), clamped
+    # to [0, 100].  This matches the runtime calculation in
+    # ibutsu_server/tasks/runs.py (update_run) and the frontend fallback in
+    # frontend/src/utilities/run.js (getRunPassPercent).
+    #
+    # Non-passing outcomes subtracted when deriving passes (old runs that
+    # lack an explicit "passes" key): failures, errors, skips, xpasses,
+    # xfailures.  If this list changes, update update_run and
+    # getRunPassPercent as well.
     result = conn.execute(
         sa.text(
             """
-            -- Normalize each counter field from text to numeric exactly once so
-            -- the UPDATE expression stays shallow and avoids repeating casts and
-            -- regex guards.  Fields that are absent or non-numeric are coerced to
-            -- NULL (tests/passes, which drive branching) or 0 (loss counters,
-            -- which default-to-zero is safe for subtraction arithmetic).
             WITH normalized AS (
                 SELECT
                     id,
+                    -- Parse each counter once; tests/passes NULL when absent
+                    -- or non-numeric, loss counters default to 0.
+                    CASE WHEN summary->>'tests'   ~ '^[0-9]+$'
+                         THEN (summary->>'tests')::numeric   END AS tests_num,
+                    CASE WHEN summary->>'passes'  ~ '^[0-9]+$'
+                         THEN (summary->>'passes')::numeric  END AS passes_num,
+                    COALESCE(
+                        CASE WHEN summary->>'failures'  ~ '^[0-9]+$'
+                             THEN (summary->>'failures')::numeric  END, 0
+                    ) AS failures_num,
+                    COALESCE(
+                        CASE WHEN summary->>'errors'    ~ '^[0-9]+$'
+                             THEN (summary->>'errors')::numeric    END, 0
+                    ) AS errors_num,
+                    COALESCE(
+                        CASE WHEN summary->>'skips'     ~ '^[0-9]+$'
+                             THEN (summary->>'skips')::numeric     END, 0
+                    ) AS skips_num,
+                    COALESCE(
+                        CASE WHEN summary->>'xpasses'   ~ '^[0-9]+$'
+                             THEN (summary->>'xpasses')::numeric   END, 0
+                    ) AS xpasses_num,
+                    COALESCE(
+                        CASE WHEN summary->>'xfailures' ~ '^[0-9]+$'
+                             THEN (summary->>'xfailures')::numeric END, 0
+                    ) AS xfailures_num,
+
+                    -- Precompute: direct path (passes key present)
                     CASE
-                        WHEN summary->>'tests' ~ '^[0-9]+$'
-                        THEN (summary->>'tests')::numeric
-                        ELSE NULL
-                    END AS tests_num,
+                        WHEN summary->>'tests'  ~ '^[0-9]+$'
+                         AND (summary->>'tests')::numeric > 0
+                         AND summary->>'passes' ~ '^[0-9]+$'
+                        THEN LEAST(GREATEST(
+                            floor(
+                                (summary->>'passes')::numeric * 100
+                                / (summary->>'tests')::numeric
+                            )::int,
+                            0), 100)
+                    END AS pass_percent_direct,
+
+                    -- Precompute: derived path (passes key absent)
                     CASE
-                        WHEN summary->>'passes' ~ '^[0-9]+$'
-                        THEN (summary->>'passes')::numeric
-                        ELSE NULL
-                    END AS passes_num,
-                    -- Loss counters default to 0 so the derived-passes arithmetic
-                    -- below stays correct even when a counter key is missing.
-                    CASE
-                        WHEN summary->>'failures' ~ '^[0-9]+$'
-                        THEN (summary->>'failures')::numeric
-                        ELSE 0
-                    END AS failures_num,
-                    CASE
-                        WHEN summary->>'errors' ~ '^[0-9]+$'
-                        THEN (summary->>'errors')::numeric
-                        ELSE 0
-                    END AS errors_num,
-                    CASE
-                        WHEN summary->>'skips' ~ '^[0-9]+$'
-                        THEN (summary->>'skips')::numeric
-                        ELSE 0
-                    END AS skips_num,
-                    -- xpasses and xfailures count as non-passing outcomes and are
-                    -- subtracted when deriving passes from counters.
-                    CASE
-                        WHEN summary->>'xpasses' ~ '^[0-9]+$'
-                        THEN (summary->>'xpasses')::numeric
-                        ELSE 0
-                    END AS xpasses_num,
-                    CASE
-                        WHEN summary->>'xfailures' ~ '^[0-9]+$'
-                        THEN (summary->>'xfailures')::numeric
-                        ELSE 0
-                    END AS xfailures_num
+                        WHEN summary->>'tests'  ~ '^[0-9]+$'
+                         AND (summary->>'tests')::numeric > 0
+                         AND NOT (summary ? 'passes')
+                        THEN LEAST(GREATEST(
+                            floor(
+                                (
+                                    (summary->>'tests')::numeric
+                                    - COALESCE(CASE WHEN summary->>'failures'  ~ '^[0-9]+$' THEN (summary->>'failures')::numeric  END, 0)
+                                    - COALESCE(CASE WHEN summary->>'errors'    ~ '^[0-9]+$' THEN (summary->>'errors')::numeric    END, 0)
+                                    - COALESCE(CASE WHEN summary->>'skips'     ~ '^[0-9]+$' THEN (summary->>'skips')::numeric     END, 0)
+                                    - COALESCE(CASE WHEN summary->>'xpasses'   ~ '^[0-9]+$' THEN (summary->>'xpasses')::numeric   END, 0)
+                                    - COALESCE(CASE WHEN summary->>'xfailures' ~ '^[0-9]+$' THEN (summary->>'xfailures')::numeric END, 0)
+                                ) * 100
+                                / (summary->>'tests')::numeric
+                            )::int,
+                            0), 100)
+                    END AS pass_percent_derived
+
                 FROM runs
                 WHERE summary IS NOT NULL
-                  AND summary->'pass_percent' IS NULL   -- skip already-backfilled rows
+                  AND summary->'pass_percent' IS NULL
             )
             UPDATE runs AS r
             SET summary = jsonb_set(
                 COALESCE(r.summary, '{}'::jsonb),
                 '{pass_percent}',
-                to_jsonb(
-                    CASE
-                        -- Modern runs that recorded a 'passes' counter directly.
-                        -- This is the preferred path; divide passes by tests.
-                        WHEN n.tests_num IS NOT NULL
-                         AND n.tests_num > 0
-                         AND n.passes_num IS NOT NULL
-                        THEN LEAST(
-                            GREATEST(
-                                floor((n.passes_num / n.tests_num) * 100)::int,
-                                0
-                                -- guard against negative % (passes_num > tests_num)
-                            ),
-                            100
-                            -- guard against over-100 % (passes_num > tests_num)
-                        )
-
-                        -- Very old runs that never stored a 'passes' key.
-                        -- Derive passes by subtracting every known loss counter
-                        -- from the total.  LEAST/GREATEST clamps the result to
-                        -- [0, 100] in case the historical counters are inconsistent
-                        -- (e.g. sum of losses exceeds tests due to data corruption).
-                        WHEN n.tests_num IS NOT NULL
-                         AND n.tests_num > 0
-                         AND n.passes_num IS NULL
-                        THEN LEAST(
-                            GREATEST(
-                                floor(
-                                    (
-                                        n.tests_num
-                                        - n.failures_num
-                                        - n.errors_num
-                                        - n.skips_num
-                                        - n.xpasses_num
-                                        - n.xfailures_num
-                                    ) / n.tests_num * 100
-                                )::int,
-                                0
-                            ),
-                            100
-                        )
-
-                        -- tests is 0, absent, or malformed: no meaningful
-                        -- percentage can be computed, store 0 as a sentinel.
-                        ELSE 0
-                    END
-                )
+                to_jsonb(COALESCE(n.pass_percent_direct, n.pass_percent_derived, 0))
             )
             FROM normalized AS n
             WHERE r.id = n.id

--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -37,6 +37,7 @@ NUMERIC_FIELDS = [
     "start_time",
     "summary.failures",
     "summary.errors",
+    "summary.pass_percent",
     "summary.passes",
     "summary.skips",
     "summary.tests",

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -254,6 +254,7 @@ class Run(Model, ModelMixin):
     - ix_runs_jjn_jbn: Composite on both Jenkins fields
     - ix_runs_summary: GIN index on summary JSONB field
     - ix_runs_tags: GIN index on data->'tags'
+    - ix_runs_pass_percent: Expression index on ((summary->>'pass_percent')::int)
     """
 
     __tablename__ = "runs"

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -137,6 +137,10 @@ def convert_filter(filter_string, model):
     value = match.group(3).strip('"')
     is_version = VERSION_RE.match(value) is not None
     column = string_to_column(field, model)
+    if column is None:
+        # Unknown/invalid field -- return None so apply_filters skips the
+        # clause instead of producing a 500 or an accidental boolean filter.
+        return None
     # determine if the field is an array field, if so it requires some additional care
     is_array_field = field in ARRAY_FIELDS
     # Do some type casting

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -119,6 +119,9 @@ def has_project_filter(filter_list):
 
 
 def convert_filter(filter_string, model):
+    # Normalize two-character operators to their single-char internal equivalents
+    # before regex matching, since FILTER_RE only captures one character.
+    filter_string = filter_string.replace(">=", ")").replace("<=", "(")
     match = FILTER_RE.match(filter_string)
     if not match:
         return None

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -10,6 +10,8 @@ from ibutsu_server.db.types import PortableUUID
 OPERATORS = {
     "=": "$eq",
     "!": "$ne",
+    ">=": "$gte",
+    "<=": "$lte",
     ">": "$gt",
     ")": "$gte",
     "<": "$lt",
@@ -22,6 +24,8 @@ OPERATORS = {
 OPER_COMPARE = {
     "=": lambda column, value: column == value,
     "!": lambda column, value: column != value,
+    ">=": lambda column, value: column >= value,
+    "<=": lambda column, value: column <= value,
     ">": lambda column, value: column > value,
     "<": lambda column, value: column < value,
     ")": lambda column, value: column >= value,
@@ -31,7 +35,10 @@ OPER_COMPARE = {
     "%": lambda column, value: column.ilike("%" + value + "%"),
 }
 FIELD_RE_PATTERN = r"[a-zA-Z0-9._-]+"
-FILTER_RE = re.compile(r"(" + FIELD_RE_PATTERN + r")([" + "".join(OPERATORS.keys()) + "])(.*)")
+_OPERATOR_PATTERN = "|".join(
+    re.escape(op) for op in sorted(OPERATORS.keys(), key=len, reverse=True)
+)
+FILTER_RE = re.compile(r"(" + FIELD_RE_PATTERN + r")(" + _OPERATOR_PATTERN + r")(.*)")
 FLOAT_RE = re.compile(r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?")
 VERSION_RE = re.compile("([0-9].*[0-9])")
 
@@ -119,16 +126,7 @@ def has_project_filter(filter_list):
     return False
 
 
-_TWO_CHAR_OPER_RE = re.compile(r"^(" + FIELD_RE_PATTERN + r")(>=|<=)")
-
-
 def convert_filter(filter_string, model):
-    # Normalize two-character operators only in the operator position so that
-    # occurrences of >= / <= inside the value portion are left untouched.
-    filter_string = _TWO_CHAR_OPER_RE.sub(
-        lambda m: m.group(1) + (")" if m.group(2) == ">=" else "("),
-        filter_string,
-    )
     match = FILTER_RE.match(filter_string)
     if not match:
         return None

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -7,9 +7,21 @@ from sqlalchemy.dialects.postgresql import array
 from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
 from ibutsu_server.db.types import PortableUUID
 
+# gte/lte each have two operator spellings, and both are actively used (not
+# legacy/deprecated):
+#   - ")" / "(" are the single-character encoding the frontend generates for
+#     every filter it builds (see NUMERIC_OPERATIONS.opChar in
+#     frontend/src/constants.js), because ">" and "<" require URL-encoding
+#     inside query-string values while ")"/"(" don't.
+#   - ">=" / "<=" are accepted so the API also matches conventional operator
+#     syntax for direct/human API callers (curl, docs, tests) who don't go
+#     through the frontend's compact encoding.
+# Both must keep working; removing either would break existing callers.
 OPERATORS = {
     "=": "$eq",
     "!": "$ne",
+    ">=": "$gte",
+    "<=": "$lte",
     ">": "$gt",
     ")": "$gte",
     "<": "$lt",
@@ -22,6 +34,8 @@ OPERATORS = {
 OPER_COMPARE = {
     "=": lambda column, value: column == value,
     "!": lambda column, value: column != value,
+    ">=": lambda column, value: column >= value,
+    "<=": lambda column, value: column <= value,
     ">": lambda column, value: column > value,
     "<": lambda column, value: column < value,
     ")": lambda column, value: column >= value,
@@ -30,7 +44,11 @@ OPER_COMPARE = {
     "~": lambda column, value: column.op("~")(value),
     "%": lambda column, value: column.ilike("%" + value + "%"),
 }
-FILTER_RE = re.compile(r"([a-zA-Z\._]+)([" + "".join(OPERATORS.keys()) + "])(.*)")
+FIELD_RE_PATTERN = r"[a-zA-Z0-9._-]+"
+_OPERATOR_PATTERN = "|".join(
+    re.escape(op) for op in sorted(OPERATORS.keys(), key=len, reverse=True)
+)
+FILTER_RE = re.compile(r"(" + FIELD_RE_PATTERN + r")(" + _OPERATOR_PATTERN + r")(.*)")
 FLOAT_RE = re.compile(r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?")
 VERSION_RE = re.compile("([0-9].*[0-9])")
 
@@ -78,7 +96,9 @@ def string_to_column(field, model):
                 continue
             column = column[part]
 
-        if field not in ARRAY_FIELDS and field not in NUMERIC_FIELDS:
+        if field in NUMERIC_FIELDS:
+            column = column.as_integer()
+        elif field not in ARRAY_FIELDS:
             column = column.as_string()
     else:
         try:
@@ -125,6 +145,10 @@ def convert_filter(filter_string, model):
     value = match.group(3).strip('"')
     is_version = VERSION_RE.match(value) is not None
     column = string_to_column(field, model)
+    if column is None:
+        # Unknown/invalid field -- return None so apply_filters skips the
+        # clause instead of producing a 500 or an accidental boolean filter.
+        return None
     # determine if the field is an array field, if so it requires some additional care
     is_array_field = field in ARRAY_FIELDS
     # Do some type casting
@@ -132,8 +156,9 @@ def convert_filter(filter_string, model):
         return _null_compare(column, value)
     if oper == "*":
         value = value.split(";")
-    elif not is_version and "build_number" not in field:
-        # This is a horrible hack, because Jenkins build numbers are strings :-(
+    elif field in NUMERIC_FIELDS or (not is_version and "build_number" not in field):
+        # Always convert for numeric fields; version-like strings and Jenkins build numbers
+        # are kept as strings because they need string comparison semantics.
         value = _to_int_or_float(value)
     if is_array_field:
         return _array_compare(oper, column, value)

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -78,7 +78,9 @@ def string_to_column(field, model):
                 continue
             column = column[part]
 
-        if field not in ARRAY_FIELDS and field not in NUMERIC_FIELDS:
+        if field in NUMERIC_FIELDS:
+            column = column.as_float()
+        elif field not in ARRAY_FIELDS:
             column = column.as_string()
     else:
         try:
@@ -132,8 +134,9 @@ def convert_filter(filter_string, model):
         return _null_compare(column, value)
     if oper == "*":
         value = value.split(";")
-    elif not is_version and "build_number" not in field:
-        # This is a horrible hack, because Jenkins build numbers are strings :-(
+    elif field in NUMERIC_FIELDS or (not is_version and "build_number" not in field):
+        # Always convert for numeric fields; version-like strings and Jenkins build numbers
+        # are kept as strings because they need string comparison semantics.
         value = _to_int_or_float(value)
     if is_array_field:
         return _array_compare(oper, column, value)

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -30,7 +30,8 @@ OPER_COMPARE = {
     "~": lambda column, value: column.op("~")(value),
     "%": lambda column, value: column.ilike("%" + value + "%"),
 }
-FILTER_RE = re.compile(r"([a-zA-Z\._]+)([" + "".join(OPERATORS.keys()) + "])(.*)")
+FIELD_RE_PATTERN = r"[a-zA-Z0-9._-]+"
+FILTER_RE = re.compile(r"(" + FIELD_RE_PATTERN + r")([" + "".join(OPERATORS.keys()) + "])(.*)")
 FLOAT_RE = re.compile(r"[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?")
 VERSION_RE = re.compile("([0-9].*[0-9])")
 
@@ -79,7 +80,7 @@ def string_to_column(field, model):
             column = column[part]
 
         if field in NUMERIC_FIELDS:
-            column = column.as_float()
+            column = column.as_integer()
         elif field not in ARRAY_FIELDS:
             column = column.as_string()
     else:
@@ -118,10 +119,16 @@ def has_project_filter(filter_list):
     return False
 
 
+_TWO_CHAR_OPER_RE = re.compile(r"^(" + FIELD_RE_PATTERN + r")(>=|<=)")
+
+
 def convert_filter(filter_string, model):
-    # Normalize two-character operators to their single-char internal equivalents
-    # before regex matching, since FILTER_RE only captures one character.
-    filter_string = filter_string.replace(">=", ")").replace("<=", "(")
+    # Normalize two-character operators only in the operator position so that
+    # occurrences of >= / <= inside the value portion are left untouched.
+    filter_string = _TWO_CHAR_OPER_RE.sub(
+        lambda m: m.group(1) + (")" if m.group(2) == ">=" else "("),
+        filter_string,
+    )
     match = FILTER_RE.match(filter_string)
     if not match:
         return None

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -86,10 +86,14 @@ def update_run(run_id):
             + summary["failures"]
             + summary["skips"]
         )
+        # Canonical pass_percent formula: integer arithmetic avoids float
+        # rounding; result is floored and clamped to [0, 100].  The same
+        # formula is replicated in the migration backfill SQL and the
+        # frontend getRunPassPercent fallback (frontend/src/utilities/run.js).
         summary["pass_percent"] = (
             max(
                 min(
-                    int((summary["passes"] / summary["tests"]) * 100),
+                    (summary["passes"] * 100) // summary["tests"],
                     100,
                 ),
                 0,

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -86,6 +86,9 @@ def update_run(run_id):
             + summary["failures"]
             + summary["skips"]
         )
+        summary["pass_percent"] = (
+            int((summary["passes"] / summary["tests"]) * 100) if summary["tests"] > 0 else 0
+        )
         # determine the number of tests that didn't run
         summary["not_run"] = max(summary["collected"] - summary["tests"], 0)
 

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -87,7 +87,15 @@ def update_run(run_id):
             + summary["skips"]
         )
         summary["pass_percent"] = (
-            int((summary["passes"] / summary["tests"]) * 100) if summary["tests"] > 0 else 0
+            max(
+                min(
+                    int((summary["passes"] / summary["tests"]) * 100),
+                    100,
+                ),
+                0,
+            )
+            if summary["tests"] > 0
+            else 0
         )
         # determine the number of tests that didn't run
         summary["not_run"] = max(summary["collected"] - summary["tests"], 0)

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -31,6 +31,26 @@ def _status_to_summary(status):
     }.get(status, status)
 
 
+def compute_pass_percent(passes: int, tests: int) -> int:
+    """Canonical pass_percent formula, shared by ``update_run`` below.
+
+    floor(passes * 100 / tests), clamped to [0, 100]. Integer arithmetic
+    avoids float rounding; the result is floored and clamped to guard
+    against inconsistent/malformed inputs (e.g. passes > tests, or a
+    negative derived pass count).
+
+    This formula is also replicated in the migration backfill SQL
+    (d18de2b3253f_backfill_pass_percent_in_run_summary.py) and the frontend
+    fallback (getRunPassPercent in frontend/src/utilities/run.js), since
+    those run outside this Python process. Keep all three in sync -- see
+    test_runs.py::test_compute_pass_percent_* for the cases that must match
+    across implementations.
+    """
+    if tests <= 0:
+        return 0
+    return max(min((passes * 100) // tests, 100), 0)
+
+
 @shared_task(max_retries=1000)
 def update_run(run_id):
     """Update the run summary from the results, this task will retry 1000 times"""
@@ -86,6 +106,7 @@ def update_run(run_id):
             + summary["failures"]
             + summary["skips"]
         )
+        summary["pass_percent"] = compute_pass_percent(summary["passes"], summary["tests"])
         # determine the number of tests that didn't run
         summary["not_run"] = max(summary["collected"] - summary["tests"], 0)
 

--- a/backend/tests/controllers/test_run_controller.py
+++ b/backend/tests/controllers/test_run_controller.py
@@ -561,6 +561,166 @@ def test_get_run_list_various_filters(
     assert "runs" in response_data
 
 
+def test_filter_pass_percent_greater_than(flask_app, make_project, make_run, auth_headers):
+    """Test filtering runs where pass_percent > threshold returns only matching runs."""
+    client, jwt_token = flask_app
+
+    project = make_project(name="pass-pct-gt-project")
+
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 5, "errors": 0, "skips": 0, "pass_percent": 95},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 50, "errors": 0, "skips": 0, "pass_percent": 50},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 20, "errors": 0, "skips": 0, "pass_percent": 80},
+    )
+
+    query_string = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.pass_percent>80"),
+    ]
+    headers = auth_headers(jwt_token)
+    response = client.get("/api/run", headers=headers, params=query_string)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert len(response_data["runs"]) == 1
+    assert response_data["runs"][0]["summary"]["pass_percent"] == 95
+
+
+def test_filter_pass_percent_less_than(flask_app, make_project, make_run, auth_headers):
+    """Test filtering runs where pass_percent < threshold returns only matching runs."""
+    client, jwt_token = flask_app
+
+    project = make_project(name="pass-pct-lt-project")
+
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 5, "errors": 0, "skips": 0, "pass_percent": 95},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 50, "errors": 0, "skips": 0, "pass_percent": 50},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 20, "errors": 0, "skips": 0, "pass_percent": 80},
+    )
+
+    query_string = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.pass_percent<80"),
+    ]
+    headers = auth_headers(jwt_token)
+    response = client.get("/api/run", headers=headers, params=query_string)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert len(response_data["runs"]) == 1
+    assert response_data["runs"][0]["summary"]["pass_percent"] == 50
+
+
+def test_filter_pass_percent_equals(flask_app, make_project, make_run, auth_headers):
+    """Test filtering runs where pass_percent = exact value returns only matching runs."""
+    client, jwt_token = flask_app
+
+    project = make_project(name="pass-pct-eq-project")
+
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 5, "errors": 0, "skips": 0, "pass_percent": 95},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 50, "errors": 0, "skips": 0, "pass_percent": 50},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 20, "errors": 0, "skips": 0, "pass_percent": 80},
+    )
+
+    query_string = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.pass_percent=80"),
+    ]
+    headers = auth_headers(jwt_token)
+    response = client.get("/api/run", headers=headers, params=query_string)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert len(response_data["runs"]) == 1
+    assert response_data["runs"][0]["summary"]["pass_percent"] == 80
+
+
+def test_filter_pass_percent_gte(flask_app, make_project, make_run, auth_headers):
+    """Test filtering runs where pass_percent >= threshold includes the boundary value."""
+    client, jwt_token = flask_app
+
+    project = make_project(name="pass-pct-gte-project")
+
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 51, "errors": 0, "skips": 0, "pass_percent": 49},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 50, "errors": 0, "skips": 0, "pass_percent": 50},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 49, "errors": 0, "skips": 0, "pass_percent": 51},
+    )
+
+    query_string = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.pass_percent>=50"),
+    ]
+    headers = auth_headers(jwt_token)
+    response = client.get("/api/run", headers=headers, params=query_string)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    returned_percents = sorted(r["summary"]["pass_percent"] for r in response_data["runs"])
+    assert returned_percents == [50, 51], "49 should be excluded; 50 and 51 should be included"
+
+
+def test_filter_pass_percent_lte(flask_app, make_project, make_run, auth_headers):
+    """Test filtering runs where pass_percent <= threshold includes the boundary value."""
+    client, jwt_token = flask_app
+
+    project = make_project(name="pass-pct-lte-project")
+
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 51, "errors": 0, "skips": 0, "pass_percent": 49},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 50, "errors": 0, "skips": 0, "pass_percent": 50},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 100, "failures": 49, "errors": 0, "skips": 0, "pass_percent": 51},
+    )
+
+    query_string = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.pass_percent<=50"),
+    ]
+    headers = auth_headers(jwt_token)
+    response = client.get("/api/run", headers=headers, params=query_string)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    returned_percents = sorted(r["summary"]["pass_percent"] for r in response_data["runs"])
+    assert returned_percents == [49, 50], "51 should be excluded; 49 and 50 should be included"
+
+
 def test_get_run_not_found(flask_app, auth_headers):
     """Test get_run for non-existent run"""
     client, jwt_token = flask_app

--- a/backend/tests/tasks/test_runs.py
+++ b/backend/tests/tasks/test_runs.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from ibutsu_server.db import db
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Run
-from ibutsu_server.tasks.runs import sync_aborted_runs, update_run
+from ibutsu_server.tasks.runs import compute_pass_percent, sync_aborted_runs, update_run
 
 
 def test_update_run(make_project, make_run, make_result, flask_app, fixed_time):
@@ -55,6 +55,7 @@ def test_update_run(make_project, make_run, make_result, flask_app, fixed_time):
         assert updated_run.summary["passes"] == 1
         assert updated_run.summary["failures"] == 1
         assert updated_run.summary["errors"] == 1
+        assert updated_run.summary["pass_percent"] == 33
         assert updated_run.duration == 4.5
 
 
@@ -224,6 +225,7 @@ def test_update_run_with_none_summary(make_project, make_run, make_result, flask
         assert updated_run.summary["tests"] == 2
         assert updated_run.summary["passes"] == 1
         assert updated_run.summary["failures"] == 1
+        assert updated_run.summary["pass_percent"] == 50
 
 
 def test_update_run_with_empty_summary(make_project, make_run, make_result, flask_app):
@@ -262,3 +264,86 @@ def test_update_run_with_empty_summary(make_project, make_run, make_result, flas
         assert "tests" in updated_run.summary
         assert updated_run.summary["tests"] == 1
         assert updated_run.summary["passes"] == 1
+        assert updated_run.summary["pass_percent"] == 100
+
+
+def test_update_run_pass_percent_zero_tests(make_project, make_run, flask_app):
+    """When there are zero tests, pass_percent should be forced to 0 (no division-by-zero)."""
+    client, _ = flask_app
+
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        # collected > 0 but no results created, so tests will remain 0
+        run = make_run(
+            project_id=project.id,
+            summary={"collected": 10, "tests": 0, "failures": 0, "errors": 0},
+        )
+
+        with patch("ibutsu_server.tasks.runs.lock"):
+            update_run(str(run.id))
+
+        session.expire_all()
+        updated_run = db.session.get(Run, run.id)
+
+        assert updated_run.summary is not None
+        assert updated_run.summary["tests"] == 0
+        assert updated_run.summary["passes"] == 0
+        assert updated_run.summary["pass_percent"] == 0
+
+
+def test_update_run_pass_percent_floors(make_project, make_run, make_result, flask_app, fixed_time):
+    """Test that pass_percent is floored, not rounded -- 999/1000 should be 99, not 100."""
+    client, _ = flask_app
+
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        run = make_run(
+            project_id=project.id,
+            summary={"collected": 1000, "tests": 0, "failures": 0, "errors": 0},
+        )
+
+        for i in range(1000):
+            make_result(
+                run_id=run.id,
+                project_id=project.id,
+                result="passed" if i < 999 else "failed",
+                duration=0.01,
+                start_time=fixed_time,
+            )
+
+        with patch("ibutsu_server.tasks.runs.lock"):
+            update_run(str(run.id))
+
+        session.expire_all()
+        updated_run = db.session.get(Run, run.id)
+
+        assert updated_run.summary["tests"] == 1000
+        assert updated_run.summary["passes"] == 999
+        assert updated_run.summary["failures"] == 1
+        assert updated_run.summary["pass_percent"] == 99
+
+
+# compute_pass_percent is the single source of truth for the pass_percent
+# formula (see its docstring); it is exercised directly here so the clamping
+# behaviour can be tested against inconsistent/malformed inputs that
+# update_run's own result-counting logic can never actually produce (since
+# it derives "tests" and "passes" from the same set of Result rows, so
+# passes can never legitimately exceed tests or go negative there).
+def test_compute_pass_percent_zero_tests():
+    assert compute_pass_percent(passes=0, tests=0) == 0
+    assert compute_pass_percent(passes=5, tests=0) == 0
+
+
+def test_compute_pass_percent_floors():
+    assert compute_pass_percent(passes=999, tests=1000) == 99
+    assert compute_pass_percent(passes=1, tests=3) == 33
+
+
+def test_compute_pass_percent_clamps_above_100():
+    """passes > tests (inconsistent/malformed summary) should clamp to 100, not overflow."""
+    assert compute_pass_percent(passes=15, tests=10) == 100
+
+
+def test_compute_pass_percent_clamps_below_0():
+    """A negative derived pass count (inconsistent/malformed summary) should clamp to 0."""
+    assert compute_pass_percent(passes=-2, tests=10) == 0

--- a/backend/tests/tasks/test_runs.py
+++ b/backend/tests/tasks/test_runs.py
@@ -55,6 +55,7 @@ def test_update_run(make_project, make_run, make_result, flask_app, fixed_time):
         assert updated_run.summary["passes"] == 1
         assert updated_run.summary["failures"] == 1
         assert updated_run.summary["errors"] == 1
+        assert updated_run.summary["pass_percent"] == 33
         assert updated_run.duration == 4.5
 
 
@@ -224,6 +225,7 @@ def test_update_run_with_none_summary(make_project, make_run, make_result, flask
         assert updated_run.summary["tests"] == 2
         assert updated_run.summary["passes"] == 1
         assert updated_run.summary["failures"] == 1
+        assert updated_run.summary["pass_percent"] == 50
 
 
 def test_update_run_with_empty_summary(make_project, make_run, make_result, flask_app):
@@ -262,3 +264,60 @@ def test_update_run_with_empty_summary(make_project, make_run, make_result, flas
         assert "tests" in updated_run.summary
         assert updated_run.summary["tests"] == 1
         assert updated_run.summary["passes"] == 1
+        assert updated_run.summary["pass_percent"] == 100
+
+
+def test_update_run_pass_percent_zero_tests(make_project, make_run, flask_app):
+    """When there are zero tests, pass_percent should be forced to 0 (no division-by-zero)."""
+    client, _ = flask_app
+
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        # collected > 0 but no results created, so tests will remain 0
+        run = make_run(
+            project_id=project.id,
+            summary={"collected": 10, "tests": 0, "failures": 0, "errors": 0},
+        )
+
+        with patch("ibutsu_server.tasks.runs.lock"):
+            update_run(str(run.id))
+
+        session.expire_all()
+        updated_run = db.session.get(Run, run.id)
+
+        assert updated_run.summary is not None
+        assert updated_run.summary["tests"] == 0
+        assert updated_run.summary["passes"] == 0
+        assert updated_run.summary["pass_percent"] == 0
+
+
+def test_update_run_pass_percent_floors(make_project, make_run, make_result, flask_app, fixed_time):
+    """Test that pass_percent is floored, not rounded -- 999/1000 should be 99, not 100."""
+    client, _ = flask_app
+
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        run = make_run(
+            project_id=project.id,
+            summary={"collected": 1000, "tests": 0, "failures": 0, "errors": 0},
+        )
+
+        for i in range(1000):
+            make_result(
+                run_id=run.id,
+                project_id=project.id,
+                result="passed" if i < 999 else "failed",
+                duration=0.01,
+                start_time=fixed_time,
+            )
+
+        with patch("ibutsu_server.tasks.runs.lock"):
+            update_run(str(run.id))
+
+        session.expire_all()
+        updated_run = db.session.get(Run, run.id)
+
+        assert updated_run.summary["tests"] == 1000
+        assert updated_run.summary["passes"] == 999
+        assert updated_run.summary["failures"] == 1
+        assert updated_run.summary["pass_percent"] == 99

--- a/backend/tests/test_alembic_env.py
+++ b/backend/tests/test_alembic_env.py
@@ -156,7 +156,9 @@ def test_run_migrations_online_function_exists(reset_app_registry):
     assert "def run_migrations_online() -> None:" in env_content
     assert "connectable = db.engine" in env_content
     assert "with connectable.connect() as connection:" in env_content
-    assert "context.configure(connection=connection" in env_content
+    assert "context.configure(" in env_content
+    assert "connection=connection" in env_content
+    assert "transaction_per_migration=True" in env_content
 
 
 def test_alembic_flask_app_cached(reset_app_registry):

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import Float, String
+from sqlalchemy import Integer, String
 
 from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
 from ibutsu_server.db import db
@@ -20,13 +20,13 @@ from ibutsu_server.filters import (
 
 # NUMERIC_FIELDS that are stored as JSON sub-keys (summary.*).
 # These go through the JSON path accessor in string_to_column and therefore
-# receive an explicit as_float() cast.  A non-numeric value stored in the
+# receive an explicit as_integer() cast.  A non-numeric value stored in the
 # database for any of these keys will raise a database error at query time
 # rather than silently returning incorrect results.
 _JSON_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if f.startswith("summary.")]
 
 # NUMERIC_FIELDS that map to native ORM columns (not JSON paths).
-# These bypass the JSON accessor branch entirely, so as_float() is never
+# These bypass the JSON accessor branch entirely, so as_integer() is never
 # applied to them; their type is already enforced by the column definition.
 _DIRECT_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if not f.startswith("summary.")]
 
@@ -206,35 +206,38 @@ class TestStringToColumn:
 
 
 class TestStringToColumnCastSemantics:
-    """Explicit coverage for the JSON-cast behavior introduced by as_float() / as_string().
+    """Explicit coverage for the JSON-cast behavior introduced by as_integer() / as_string().
 
     The contract under test:
     - Every field listed in NUMERIC_FIELDS whose first segment is "summary" is
-      accessed via the Run.summary JSONB column and then cast to Float with
-      as_float().  This produces correct numeric ordering but will raise a
-      database-level error if a stored value cannot be cast to a number.
+      accessed via the Run.summary JSONB column and then cast to Integer with
+      as_integer().  This produces correct numeric ordering and matches the
+      ::int expression index, but will raise a database-level error if a stored
+      value cannot be cast to a number.
     - Non-numeric JSON fields (data.*, metadata.*, non-array summary.*) are
       cast to String via as_string(), preserving the previous text-comparison
       behaviour.
     - Array fields (metadata.tags etc.) receive neither cast; they remain raw
       JSON path expressions so that array operators (@>, ?|) work correctly.
     - Direct ORM columns (duration, start_time) never pass through the JSON
-      accessor branch and are therefore unaffected by as_float().
+      accessor branch and are therefore unaffected by as_integer().
     """
 
     @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
-    def test_json_numeric_fields_produce_float_cast(self, app_ctx, field):
-        """Every summary.* NUMERIC_FIELD must use an explicit Float cast.
+    def test_json_numeric_fields_produce_integer_cast(self, app_ctx, field):
+        """Every summary.* NUMERIC_FIELD must use an explicit Integer cast.
 
-        Verifies that the as_float() path is taken, meaning:
+        Verifies that the as_integer() path is taken, meaning:
         1. Comparisons use numeric ordering, not lexicographic ordering.
-        2. A row whose stored JSON value is not numeric will raise a database
+        2. The cast matches the ::int expression index on ix_runs_pass_percent,
+           allowing PostgreSQL to use an index scan for range filters.
+        3. A row whose stored JSON value is not numeric will raise a database
            error at query time (not silently return wrong results).
         """
         column = string_to_column(field, Run)
         assert column is not None, f"string_to_column returned None for {field!r}"
-        assert isinstance(column.type, Float), (
-            f"{field!r} expected a Float-cast column (as_float()) "
+        assert isinstance(column.type, Integer), (
+            f"{field!r} expected an Integer-cast column (as_integer()) "
             f"but got type {type(column.type).__name__!r}. "
             "Check that this field is still listed in NUMERIC_FIELDS."
         )
@@ -260,8 +263,8 @@ class TestStringToColumnCastSemantics:
             f"{field!r} expected a String-cast column (as_string()) "
             f"but got type {type(column.type).__name__!r}."
         )
-        assert not isinstance(column.type, Float), (
-            f"{field!r} must not be Float-cast; it holds string values."
+        assert not isinstance(column.type, Integer), (
+            f"{field!r} must not be Integer-cast; it holds string values."
         )
 
     @pytest.mark.parametrize("field", ARRAY_FIELDS)
@@ -273,7 +276,9 @@ class TestStringToColumnCastSemantics:
         """
         column = string_to_column(field, Run)
         assert column is not None, f"string_to_column returned None for {field!r}"
-        assert not isinstance(column.type, Float), f"Array field {field!r} must not be Float-cast."
+        assert not isinstance(column.type, Integer), (
+            f"Array field {field!r} must not be Integer-cast."
+        )
         assert not isinstance(column.type, String), (
             f"Array field {field!r} must not be String-cast."
         )
@@ -293,29 +298,35 @@ class TestStringToColumnCastSemantics:
             "If this field was moved to a JSON column, update this test."
         )
         # These are native ORM columns, not JSON path expressions, so they will
-        # NOT be Float instances from as_float() — their type comes from the
+        # NOT be Integer instances from as_integer() — their type comes from the
         # SQLAlchemy column definition (Float for duration, DateTime for start_time).
         # We only assert the column resolves without error.
 
-    def test_summary_pass_percent_uses_float_cast(self, app_ctx):
-        """Explicit regression test: summary.pass_percent must be Float-cast.
+    def test_summary_pass_percent_uses_integer_cast(self, app_ctx):
+        """Explicit regression test: summary.pass_percent must be Integer-cast.
 
-        This field was added to NUMERIC_FIELDS alongside the as_float() change.
-        A dedicated test makes the intent impossible to miss during code review.
+        pass_percent is stored as a whole-number integer (0-100) and the
+        expression index ix_runs_pass_percent is defined on
+        ((summary->>'pass_percent')::int).  The query-side cast must be
+        as_integer() so PostgreSQL can match the index expression and use an
+        index scan for range filters instead of a sequential scan.
         """
         column = string_to_column("summary.pass_percent", Run)
         assert column is not None
-        assert isinstance(column.type, Float), (
-            "summary.pass_percent must produce a Float cast so that "
-            "percentage comparisons use numeric ordering."
+        assert isinstance(column.type, Integer), (
+            "summary.pass_percent must produce an Integer cast so that "
+            "percentage comparisons use numeric ordering and the expression "
+            "index ix_runs_pass_percent can be used."
         )
 
 
 class TestConvertFilterNumericFieldSemantics:
     """Tests for the numeric comparison semantics of convert_filter on JSON fields.
 
-    The as_float() cast on NUMERIC_FIELDS means:
+    The as_integer() cast on NUMERIC_FIELDS means:
     - Comparison operators (>, <, >=, <=) behave with numeric ordering.
+    - The cast matches the ::int expression indexes, allowing PostgreSQL to use
+      index scans for range filters rather than sequential scans.
     - The filter value is also converted to int/float by _to_int_or_float.
     - Rows with non-numeric JSON values for these keys will produce a database
       error at query time.
@@ -353,9 +364,22 @@ class TestConvertFilterNumericFieldSemantics:
 
     @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
     def test_numeric_json_field_not_equal_filter(self, app_ctx, field):
-        """Numeric JSON fields must support not-equal comparisons."""
+        """Numeric JSON fields must support not-equal comparisons and cast values to int."""
         result = convert_filter(f"{field}!0", Run)
         assert result is not None, f"convert_filter returned None for '!' filter on {field!r}"
+
+        # Ensure the bound parameter value is actually an int(0), not the string "0"
+        right = getattr(result, "right", None)
+        assert right is not None, "Expected filter expression to have a .right side"
+        value = getattr(right, "value", None)
+        assert isinstance(value, int), (
+            f"Expected numeric JSON filter value for {field!r} to be int(0), "
+            f"got {value!r} ({type(value)})"
+        )
+        assert value == 0, (
+            f"Expected numeric JSON filter value for {field!r} to be int(0), "
+            f"got {value!r} ({type(value)})"
+        )
 
     def test_numeric_value_is_converted_to_int_for_integer_string(self, app_ctx):
         """Numeric field values supplied as integer strings are cast to int, not kept as str."""
@@ -363,16 +387,46 @@ class TestConvertFilterNumericFieldSemantics:
         result = convert_filter("summary.failures=3", Run)
         assert result is not None
 
-    def test_numeric_value_is_converted_to_float_for_float_string(self, app_ctx):
-        """Numeric field values supplied as float strings are cast to float."""
-        result = convert_filter("summary.pass_percent=99.5", Run)
+        # Ensure the bound parameter value is actually an int(3), not the string "3"
+        right = getattr(result, "right", None)
+        assert right is not None, "Expected filter expression to have a .right side"
+        value = getattr(right, "value", None)
+        assert isinstance(value, int), (
+            "Expected numeric filter value for 'summary.failures' to be int(3), "
+            f"got {value!r} ({type(value)})"
+        )
+        assert value == 3, (
+            "Expected numeric filter value for 'summary.failures' to be int(3), "
+            f"got {value!r} ({type(value)})"
+        )
+
+    def test_numeric_value_is_converted_to_int_for_integer_percent_string(self, app_ctx):
+        """pass_percent filter values supplied as integer strings are cast to int.
+
+        pass_percent is always stored as a whole number (0-100), so integer
+        filter values are the correct and expected input.
+        """
+        result = convert_filter("summary.pass_percent=99", Run)
         assert result is not None
+
+        # Ensure the bound parameter value is actually an int(99), not the string "99"
+        right = getattr(result, "right", None)
+        assert right is not None, "Expected filter expression to have a .right side"
+        value = getattr(right, "value", None)
+        assert isinstance(value, int), (
+            "Expected numeric filter value for 'summary.pass_percent' to be int(99), "
+            f"got {value!r} ({type(value)})"
+        )
+        assert value == 99, (
+            "Expected numeric filter value for 'summary.pass_percent' to be int(99), "
+            f"got {value!r} ({type(value)})"
+        )
 
     def test_non_numeric_string_value_on_numeric_field_is_kept_as_str(self, app_ctx):
         """A non-numeric string value for a NUMERIC_FIELD stays as a string.
 
         This exercises the _to_int_or_float fallback.  The database will still
-        apply the as_float() cast to the column side; the right-hand string
+        apply the as_integer() cast to the column side; the right-hand string
         value will be passed through as-is and may cause a type-mismatch error
         at query execution time.  The purpose here is to verify no exception is
         raised at filter *construction* time.
@@ -384,9 +438,9 @@ class TestConvertFilterNumericFieldSemantics:
         )
 
     def test_summary_pass_percent_range_filter(self, app_ctx):
-        """Regression: summary.pass_percent supports range comparisons after Float cast."""
-        above = convert_filter("summary.pass_percent)80.0", Run)
-        below = convert_filter("summary.pass_percent(100.0", Run)
+        """Regression: summary.pass_percent supports range comparisons after Integer cast."""
+        above = convert_filter("summary.pass_percent)80", Run)
+        below = convert_filter("summary.pass_percent(100", Run)
         assert above is not None, "Lower-bound filter on summary.pass_percent must not be None"
         assert below is not None, "Upper-bound filter on summary.pass_percent must not be None"
 

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -538,6 +538,23 @@ class TestConvertFilter:
         result = convert_filter('result="passed"', Result)
         assert result is not None
 
+    @pytest.mark.parametrize(
+        "filter_string",
+        [
+            "bogus_field=value",
+            "bogus_field>10",
+            "bogus_field<100",
+            "bogus_field~pattern",
+            "bogus_field!value",
+            "bogus_field%value",
+            "bogus_field@yes",
+        ],
+    )
+    def test_convert_filter_unknown_field_returns_none(self, app_ctx, filter_string):
+        """convert_filter must return None for fields that string_to_column cannot resolve."""
+        result = convert_filter(filter_string, Result)
+        assert result is None
+
 
 class TestApplyFilters:
     """Tests for the apply_filters function."""

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -3,7 +3,9 @@
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy import Float, String
 
+from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
 from ibutsu_server.db import db
 from ibutsu_server.db.models import Result, Run
 from ibutsu_server.filters import (
@@ -15,6 +17,18 @@ from ibutsu_server.filters import (
     has_project_filter,
     string_to_column,
 )
+
+# NUMERIC_FIELDS that are stored as JSON sub-keys (summary.*).
+# These go through the JSON path accessor in string_to_column and therefore
+# receive an explicit as_float() cast.  A non-numeric value stored in the
+# database for any of these keys will raise a database error at query time
+# rather than silently returning incorrect results.
+_JSON_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if f.startswith("summary.")]
+
+# NUMERIC_FIELDS that map to native ORM columns (not JSON paths).
+# These bypass the JSON accessor branch entirely, so as_float() is never
+# applied to them; their type is already enforced by the column definition.
+_DIRECT_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if not f.startswith("summary.")]
 
 
 @pytest.fixture
@@ -189,6 +203,192 @@ class TestStringToColumn:
         subquery = db.select(Run).subquery()
         column = string_to_column("env", subquery)
         assert column is not None
+
+
+class TestStringToColumnCastSemantics:
+    """Explicit coverage for the JSON-cast behavior introduced by as_float() / as_string().
+
+    The contract under test:
+    - Every field listed in NUMERIC_FIELDS whose first segment is "summary" is
+      accessed via the Run.summary JSONB column and then cast to Float with
+      as_float().  This produces correct numeric ordering but will raise a
+      database-level error if a stored value cannot be cast to a number.
+    - Non-numeric JSON fields (data.*, metadata.*, non-array summary.*) are
+      cast to String via as_string(), preserving the previous text-comparison
+      behaviour.
+    - Array fields (metadata.tags etc.) receive neither cast; they remain raw
+      JSON path expressions so that array operators (@>, ?|) work correctly.
+    - Direct ORM columns (duration, start_time) never pass through the JSON
+      accessor branch and are therefore unaffected by as_float().
+    """
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_json_numeric_fields_produce_float_cast(self, app_ctx, field):
+        """Every summary.* NUMERIC_FIELD must use an explicit Float cast.
+
+        Verifies that the as_float() path is taken, meaning:
+        1. Comparisons use numeric ordering, not lexicographic ordering.
+        2. A row whose stored JSON value is not numeric will raise a database
+           error at query time (not silently return wrong results).
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert isinstance(column.type, Float), (
+            f"{field!r} expected a Float-cast column (as_float()) "
+            f"but got type {type(column.type).__name__!r}. "
+            "Check that this field is still listed in NUMERIC_FIELDS."
+        )
+
+    @pytest.mark.parametrize(
+        ("field", "model"),
+        [
+            ("data.component", Result),
+            ("data.env", Result),
+            ("metadata.jenkins.job_name", Run),
+            ("metadata.jenkins.build_url", Run),
+        ],
+    )
+    def test_non_numeric_json_fields_produce_string_cast(self, app_ctx, field, model):
+        """Non-numeric JSON fields must use a String cast, not a Float cast.
+
+        This guards against accidentally adding a field to NUMERIC_FIELDS and
+        breaking text-comparison filters on fields that hold string values.
+        """
+        column = string_to_column(field, model)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert isinstance(column.type, String), (
+            f"{field!r} expected a String-cast column (as_string()) "
+            f"but got type {type(column.type).__name__!r}."
+        )
+        assert not isinstance(column.type, Float), (
+            f"{field!r} must not be Float-cast; it holds string values."
+        )
+
+    @pytest.mark.parametrize("field", ARRAY_FIELDS)
+    def test_array_fields_are_not_scalar_cast(self, app_ctx, field):
+        """Array fields must not receive a Float or String cast.
+
+        Array comparisons use the @> and ?| JSON operators; casting to a scalar
+        type first would make these operators unusable.
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert not isinstance(column.type, Float), f"Array field {field!r} must not be Float-cast."
+        assert not isinstance(column.type, String), (
+            f"Array field {field!r} must not be String-cast."
+        )
+
+    @pytest.mark.parametrize("field", _DIRECT_NUMERIC_FIELDS)
+    def test_direct_numeric_columns_bypass_json_accessor(self, app_ctx, field):
+        """Direct ORM columns (duration, start_time) bypass the JSON path branch.
+
+        These fields already have the correct DB type from the column definition
+        and do not need an explicit JSON cast.  Verifying they resolve to a
+        non-None column ensures they are not accidentally reclassified as JSON
+        fields.
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, (
+            f"string_to_column returned None for direct column {field!r}. "
+            "If this field was moved to a JSON column, update this test."
+        )
+        # These are native ORM columns, not JSON path expressions, so they will
+        # NOT be Float instances from as_float() — their type comes from the
+        # SQLAlchemy column definition (Float for duration, DateTime for start_time).
+        # We only assert the column resolves without error.
+
+    def test_summary_pass_percent_uses_float_cast(self, app_ctx):
+        """Explicit regression test: summary.pass_percent must be Float-cast.
+
+        This field was added to NUMERIC_FIELDS alongside the as_float() change.
+        A dedicated test makes the intent impossible to miss during code review.
+        """
+        column = string_to_column("summary.pass_percent", Run)
+        assert column is not None
+        assert isinstance(column.type, Float), (
+            "summary.pass_percent must produce a Float cast so that "
+            "percentage comparisons use numeric ordering."
+        )
+
+
+class TestConvertFilterNumericFieldSemantics:
+    """Tests for the numeric comparison semantics of convert_filter on JSON fields.
+
+    The as_float() cast on NUMERIC_FIELDS means:
+    - Comparison operators (>, <, >=, <=) behave with numeric ordering.
+    - The filter value is also converted to int/float by _to_int_or_float.
+    - Rows with non-numeric JSON values for these keys will produce a database
+      error at query time.
+    """
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_equality_filter(self, app_ctx, field):
+        """convert_filter must produce a non-None clause for equality on JSON numeric fields."""
+        result = convert_filter(f"{field}=10", Run)
+        assert result is not None, f"convert_filter returned None for equality filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_greater_than_filter(self, app_ctx, field):
+        """Numeric JSON fields must support greater-than comparisons."""
+        result = convert_filter(f"{field}>5", Run)
+        assert result is not None, f"convert_filter returned None for '>' filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_less_than_filter(self, app_ctx, field):
+        """Numeric JSON fields must support less-than comparisons."""
+        result = convert_filter(f"{field}<100", Run)
+        assert result is not None, f"convert_filter returned None for '<' filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_gte_filter(self, app_ctx, field):
+        """Numeric JSON fields must support greater-than-or-equal comparisons."""
+        result = convert_filter(f"{field})0", Run)
+        assert result is not None, f"convert_filter returned None for ')' (>=) filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_lte_filter(self, app_ctx, field):
+        """Numeric JSON fields must support less-than-or-equal comparisons."""
+        result = convert_filter(f"{field}(50", Run)
+        assert result is not None, f"convert_filter returned None for '(' (<=) filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_not_equal_filter(self, app_ctx, field):
+        """Numeric JSON fields must support not-equal comparisons."""
+        result = convert_filter(f"{field}!0", Run)
+        assert result is not None, f"convert_filter returned None for '!' filter on {field!r}"
+
+    def test_numeric_value_is_converted_to_int_for_integer_string(self, app_ctx):
+        """Numeric field values supplied as integer strings are cast to int, not kept as str."""
+        # summary.failures is a NUMERIC_FIELD; value "3" should be converted to int(3)
+        result = convert_filter("summary.failures=3", Run)
+        assert result is not None
+
+    def test_numeric_value_is_converted_to_float_for_float_string(self, app_ctx):
+        """Numeric field values supplied as float strings are cast to float."""
+        result = convert_filter("summary.pass_percent=99.5", Run)
+        assert result is not None
+
+    def test_non_numeric_string_value_on_numeric_field_is_kept_as_str(self, app_ctx):
+        """A non-numeric string value for a NUMERIC_FIELD stays as a string.
+
+        This exercises the _to_int_or_float fallback.  The database will still
+        apply the as_float() cast to the column side; the right-hand string
+        value will be passed through as-is and may cause a type-mismatch error
+        at query execution time.  The purpose here is to verify no exception is
+        raised at filter *construction* time.
+        """
+        result = convert_filter("summary.failures=not_a_number", Run)
+        assert result is not None, (
+            "Filter construction must not raise even if the value is non-numeric; "
+            "type errors surface only when the query is executed against the database."
+        )
+
+    def test_summary_pass_percent_range_filter(self, app_ctx):
+        """Regression: summary.pass_percent supports range comparisons after Float cast."""
+        above = convert_filter("summary.pass_percent)80.0", Run)
+        below = convert_filter("summary.pass_percent(100.0", Run)
+        assert above is not None, "Lower-bound filter on summary.pass_percent must not be None"
+        assert below is not None, "Upper-bound filter on summary.pass_percent must not be None"
 
 
 class TestConvertFilter:

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -3,7 +3,9 @@
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy import Integer, String
 
+from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
 from ibutsu_server.db import db
 from ibutsu_server.db.models import Result, Run
 from ibutsu_server.filters import (
@@ -15,6 +17,18 @@ from ibutsu_server.filters import (
     has_project_filter,
     string_to_column,
 )
+
+# NUMERIC_FIELDS that are stored as JSON sub-keys (summary.*).
+# These go through the JSON path accessor in string_to_column and therefore
+# receive an explicit as_integer() cast.  A non-numeric value stored in the
+# database for any of these keys will raise a database error at query time
+# rather than silently returning incorrect results.
+_JSON_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if f.startswith("summary.")]
+
+# NUMERIC_FIELDS that map to native ORM columns (not JSON paths).
+# These bypass the JSON accessor branch entirely, so as_integer() is never
+# applied to them; their type is already enforced by the column definition.
+_DIRECT_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if not f.startswith("summary.")]
 
 
 @pytest.fixture
@@ -191,6 +205,276 @@ class TestStringToColumn:
         assert column is not None
 
 
+class TestStringToColumnCastSemantics:
+    """Explicit coverage for the JSON-cast behavior introduced by as_integer() / as_string().
+
+    The contract under test:
+    - Every field listed in NUMERIC_FIELDS whose first segment is "summary" is
+      accessed via the Run.summary JSONB column and then cast to Integer with
+      as_integer().  This produces correct numeric ordering and matches the
+      ::int expression index, but will raise a database-level error if a stored
+      value cannot be cast to a number.
+    - Non-numeric JSON fields (data.*, metadata.*, non-array summary.*) are
+      cast to String via as_string(), preserving the previous text-comparison
+      behaviour.
+    - Array fields (metadata.tags etc.) receive neither cast; they remain raw
+      JSON path expressions so that array operators (@>, ?|) work correctly.
+    - Direct ORM columns (duration, start_time) never pass through the JSON
+      accessor branch and are therefore unaffected by as_integer().
+    """
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_json_numeric_fields_produce_integer_cast(self, app_ctx, field):
+        """Every summary.* NUMERIC_FIELD must use an explicit Integer cast.
+
+        Verifies that the as_integer() path is taken, meaning:
+        1. Comparisons use numeric ordering, not lexicographic ordering.
+        2. The cast matches the ::int expression index on ix_runs_pass_percent,
+           allowing PostgreSQL to use an index scan for range filters.
+        3. A row whose stored JSON value is not numeric will raise a database
+           error at query time (not silently return wrong results).
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert isinstance(column.type, Integer), (
+            f"{field!r} expected an Integer-cast column (as_integer()) "
+            f"but got type {type(column.type).__name__!r}. "
+            "Check that this field is still listed in NUMERIC_FIELDS."
+        )
+
+    @pytest.mark.parametrize(
+        ("field", "model"),
+        [
+            ("data.component", Result),
+            ("data.env", Result),
+            ("metadata.jenkins.job_name", Run),
+            ("metadata.jenkins.build_url", Run),
+        ],
+    )
+    def test_non_numeric_json_fields_produce_string_cast(self, app_ctx, field, model):
+        """Non-numeric JSON fields must use a String cast, not a Float cast.
+
+        This guards against accidentally adding a field to NUMERIC_FIELDS and
+        breaking text-comparison filters on fields that hold string values.
+        """
+        column = string_to_column(field, model)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert isinstance(column.type, String), (
+            f"{field!r} expected a String-cast column (as_string()) "
+            f"but got type {type(column.type).__name__!r}."
+        )
+        assert not isinstance(column.type, Integer), (
+            f"{field!r} must not be Integer-cast; it holds string values."
+        )
+
+    @pytest.mark.parametrize("field", ARRAY_FIELDS)
+    def test_array_fields_are_not_scalar_cast(self, app_ctx, field):
+        """Array fields must not receive a Float or String cast.
+
+        Array comparisons use the @> and ?| JSON operators; casting to a scalar
+        type first would make these operators unusable.
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert not isinstance(column.type, Integer), (
+            f"Array field {field!r} must not be Integer-cast."
+        )
+        assert not isinstance(column.type, String), (
+            f"Array field {field!r} must not be String-cast."
+        )
+
+    @pytest.mark.parametrize("field", _DIRECT_NUMERIC_FIELDS)
+    def test_direct_numeric_columns_bypass_json_accessor(self, app_ctx, field):
+        """Direct ORM columns (duration, start_time) bypass the JSON path branch.
+
+        These fields already have the correct DB type from the column definition
+        and do not need an explicit JSON cast.  Verifying they resolve to a
+        non-None column ensures they are not accidentally reclassified as JSON
+        fields.
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, (
+            f"string_to_column returned None for direct column {field!r}. "
+            "If this field was moved to a JSON column, update this test."
+        )
+        # These are native ORM columns, not JSON path expressions, so they will
+        # NOT be Integer instances from as_integer() — their type comes from the
+        # SQLAlchemy column definition (Float for duration, DateTime for start_time).
+        # We only assert the column resolves without error.
+
+    def test_summary_pass_percent_uses_integer_cast(self, app_ctx):
+        """Explicit regression test: summary.pass_percent must be Integer-cast.
+
+        pass_percent is stored as a whole-number integer (0-100) and the
+        expression index ix_runs_pass_percent is defined on
+        ((summary->>'pass_percent')::int).  The query-side cast must be
+        as_integer() so PostgreSQL can match the index expression and use an
+        index scan for range filters instead of a sequential scan.
+        """
+        column = string_to_column("summary.pass_percent", Run)
+        assert column is not None
+        assert isinstance(column.type, Integer), (
+            "summary.pass_percent must produce an Integer cast so that "
+            "percentage comparisons use numeric ordering and the expression "
+            "index ix_runs_pass_percent can be used."
+        )
+
+
+class TestConvertFilterNumericFieldSemantics:
+    """Tests for the numeric comparison semantics of convert_filter on JSON fields.
+
+    The as_integer() cast on NUMERIC_FIELDS means:
+    - Comparison operators (>, <, >=, <=) behave with numeric ordering.
+    - The cast matches the ::int expression indexes, allowing PostgreSQL to use
+      index scans for range filters rather than sequential scans.
+    - The filter value is also converted to int/float by _to_int_or_float.
+    - Rows with non-numeric JSON values for these keys will produce a database
+      error at query time.
+    """
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_equality_filter(self, app_ctx, field):
+        """convert_filter must produce a non-None clause for equality on JSON numeric fields."""
+        result = convert_filter(f"{field}=10", Run)
+        assert result is not None, f"convert_filter returned None for equality filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_greater_than_filter(self, app_ctx, field):
+        """Numeric JSON fields must support greater-than comparisons."""
+        result = convert_filter(f"{field}>5", Run)
+        assert result is not None, f"convert_filter returned None for '>' filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_less_than_filter(self, app_ctx, field):
+        """Numeric JSON fields must support less-than comparisons."""
+        result = convert_filter(f"{field}<100", Run)
+        assert result is not None, f"convert_filter returned None for '<' filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_gte_filter(self, app_ctx, field):
+        """Numeric JSON fields must support greater-than-or-equal comparisons via ')'.
+
+        ')' is the compact encoding the frontend generates for every gte filter
+        (see NUMERIC_OPERATIONS.gte.opChar in frontend/src/constants.js).
+        """
+        result = convert_filter(f"{field})0", Run)
+        assert result is not None, f"convert_filter returned None for ')' (>=) filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_lte_filter(self, app_ctx, field):
+        """Numeric JSON fields must support less-than-or-equal comparisons via '('.
+
+        '(' is the compact encoding the frontend generates for every lte filter
+        (see NUMERIC_OPERATIONS.lte.opChar in frontend/src/constants.js).
+        """
+        result = convert_filter(f"{field}(50", Run)
+        assert result is not None, f"convert_filter returned None for '(' (<=) filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_gte_operator_filter(self, app_ctx, field):
+        """Numeric JSON fields must also support the explicit '>=' operator syntax.
+
+        '>=' is accepted alongside ')' for direct/human API callers (curl, docs,
+        tests) that use conventional operator syntax instead of the frontend's
+        compact encoding. Both must resolve to the same $gte comparison.
+        """
+        result = convert_filter(f"{field}>=0", Run)
+        assert result is not None, f"convert_filter returned None for '>=' filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_lte_operator_filter(self, app_ctx, field):
+        """Numeric JSON fields must also support the explicit '<=' operator syntax.
+
+        '<=' is accepted alongside '(' for direct/human API callers (curl, docs,
+        tests) that use conventional operator syntax instead of the frontend's
+        compact encoding. Both must resolve to the same $lte comparison.
+        """
+        result = convert_filter(f"{field}<=50", Run)
+        assert result is not None, f"convert_filter returned None for '<=' filter on {field!r}"
+
+    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
+    def test_numeric_json_field_not_equal_filter(self, app_ctx, field):
+        """Numeric JSON fields must support not-equal comparisons and cast values to int."""
+        result = convert_filter(f"{field}!0", Run)
+        assert result is not None, f"convert_filter returned None for '!' filter on {field!r}"
+
+        # Ensure the bound parameter value is actually an int(0), not the string "0"
+        right = getattr(result, "right", None)
+        assert right is not None, "Expected filter expression to have a .right side"
+        value = getattr(right, "value", None)
+        assert isinstance(value, int), (
+            f"Expected numeric JSON filter value for {field!r} to be int(0), "
+            f"got {value!r} ({type(value)})"
+        )
+        assert value == 0, (
+            f"Expected numeric JSON filter value for {field!r} to be int(0), "
+            f"got {value!r} ({type(value)})"
+        )
+
+    def test_numeric_value_is_converted_to_int_for_integer_string(self, app_ctx):
+        """Numeric field values supplied as integer strings are cast to int, not kept as str."""
+        # summary.failures is a NUMERIC_FIELD; value "3" should be converted to int(3)
+        result = convert_filter("summary.failures=3", Run)
+        assert result is not None
+
+        # Ensure the bound parameter value is actually an int(3), not the string "3"
+        right = getattr(result, "right", None)
+        assert right is not None, "Expected filter expression to have a .right side"
+        value = getattr(right, "value", None)
+        assert isinstance(value, int), (
+            "Expected numeric filter value for 'summary.failures' to be int(3), "
+            f"got {value!r} ({type(value)})"
+        )
+        assert value == 3, (
+            "Expected numeric filter value for 'summary.failures' to be int(3), "
+            f"got {value!r} ({type(value)})"
+        )
+
+    def test_numeric_value_is_converted_to_int_for_integer_percent_string(self, app_ctx):
+        """pass_percent filter values supplied as integer strings are cast to int.
+
+        pass_percent is always stored as a whole number (0-100), so integer
+        filter values are the correct and expected input.
+        """
+        result = convert_filter("summary.pass_percent=99", Run)
+        assert result is not None
+
+        # Ensure the bound parameter value is actually an int(99), not the string "99"
+        right = getattr(result, "right", None)
+        assert right is not None, "Expected filter expression to have a .right side"
+        value = getattr(right, "value", None)
+        assert isinstance(value, int), (
+            "Expected numeric filter value for 'summary.pass_percent' to be int(99), "
+            f"got {value!r} ({type(value)})"
+        )
+        assert value == 99, (
+            "Expected numeric filter value for 'summary.pass_percent' to be int(99), "
+            f"got {value!r} ({type(value)})"
+        )
+
+    def test_non_numeric_string_value_on_numeric_field_is_kept_as_str(self, app_ctx):
+        """A non-numeric string value for a NUMERIC_FIELD stays as a string.
+
+        This exercises the _to_int_or_float fallback.  The database will still
+        apply the as_integer() cast to the column side; the right-hand string
+        value will be passed through as-is and may cause a type-mismatch error
+        at query execution time.  The purpose here is to verify no exception is
+        raised at filter *construction* time.
+        """
+        result = convert_filter("summary.failures=not_a_number", Run)
+        assert result is not None, (
+            "Filter construction must not raise even if the value is non-numeric; "
+            "type errors surface only when the query is executed against the database."
+        )
+
+    def test_summary_pass_percent_range_filter(self, app_ctx):
+        """Regression: summary.pass_percent supports range comparisons after Integer cast."""
+        above = convert_filter("summary.pass_percent)80", Run)
+        below = convert_filter("summary.pass_percent(100", Run)
+        assert above is not None, "Lower-bound filter on summary.pass_percent must not be None"
+        assert below is not None, "Upper-bound filter on summary.pass_percent must not be None"
+
+
 class TestConvertFilter:
     """Tests for the convert_filter function."""
 
@@ -220,14 +504,46 @@ class TestConvertFilter:
         assert result is not None
 
     def test_convert_filter_gte_operator(self, app_ctx):
-        """Test convert_filter with greater than or equal operator."""
+        """Test convert_filter with the legacy ')' greater-than-or-equal operator."""
         result = convert_filter("duration)10", Result)
         assert result is not None
 
     def test_convert_filter_lte_operator(self, app_ctx):
-        """Test convert_filter with less than or equal operator."""
+        """Test convert_filter with the legacy '(' less-than-or-equal operator."""
         result = convert_filter("duration(100", Result)
         assert result is not None
+
+    def test_convert_filter_gte_operator_standard_syntax(self, app_ctx):
+        """Test convert_filter with the explicit '>=' greater-than-or-equal operator."""
+        result = convert_filter("duration>=10", Result)
+        assert result is not None
+
+    def test_convert_filter_lte_operator_standard_syntax(self, app_ctx):
+        """Test convert_filter with the explicit '<=' less-than-or-equal operator."""
+        result = convert_filter("duration<=100", Result)
+        assert result is not None
+
+    def test_convert_filter_gte_spellings_are_equivalent(self, app_ctx):
+        """')' and '>=' must produce an identical comparison, not just a non-None result.
+
+        Both spellings are documented in OPERATORS/OPER_COMPARE as aliases of the
+        same $gte comparison; this guards against the two definitions drifting
+        apart (e.g. one accidentally becoming '>' instead of '>=').
+        """
+        legacy = convert_filter("duration)10", Result)
+        standard = convert_filter("duration>=10", Result)
+        assert str(legacy) == str(standard)
+
+    def test_convert_filter_lte_spellings_are_equivalent(self, app_ctx):
+        """'(' and '<=' must produce an identical comparison, not just a non-None result.
+
+        Both spellings are documented in OPERATORS/OPER_COMPARE as aliases of the
+        same $lte comparison; this guards against the two definitions drifting
+        apart (e.g. one accidentally becoming '<' instead of '<=').
+        """
+        legacy = convert_filter("duration(100", Result)
+        standard = convert_filter("duration<=100", Result)
+        assert str(legacy) == str(standard)
 
     def test_convert_filter_in_operator(self, app_ctx):
         """Test convert_filter with in operator."""
@@ -283,6 +599,23 @@ class TestConvertFilter:
         """Test convert_filter with quoted value."""
         result = convert_filter('result="passed"', Result)
         assert result is not None
+
+    @pytest.mark.parametrize(
+        "filter_string",
+        [
+            "bogus_field=value",
+            "bogus_field>10",
+            "bogus_field<100",
+            "bogus_field~pattern",
+            "bogus_field!value",
+            "bogus_field%value",
+            "bogus_field@yes",
+        ],
+    )
+    def test_convert_filter_unknown_field_returns_none(self, app_ctx, filter_string):
+        """convert_filter must return None for fields that string_to_column cannot resolve."""
+        result = convert_filter(filter_string, Result)
+        assert result is None
 
 
 class TestApplyFilters:

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -127,6 +127,7 @@ export const NUMERIC_RUN_FIELDS = [
   { value: 'duration', children: 'Duration' },
   { value: 'summary.errors', children: 'Summary Error Count' },
   { value: 'summary.failures', children: 'Summary Failure Count' },
+  { value: 'summary.pass_percent', children: 'Pass Percentage' },
   { value: 'summary.skips', children: 'Summary Skip Count' },
   { value: 'summary.xfailures', children: 'Summary Xfailure Count' },
   { value: 'summary.xpasses', children: 'Summary Xpasses Count' },

--- a/frontend/src/pages/run-list.js
+++ b/frontend/src/pages/run-list.js
@@ -14,7 +14,7 @@ import usePagination from '../components/hooks/use-pagination';
 import { FilterContext } from '../components/contexts/filter-context';
 import { RUN_FIELDS } from '../constants';
 
-const COLUMNS = ['Run', 'Duration', 'Summary', 'Started', ''];
+const COLUMNS = ['Run', 'Duration', 'Summary', 'Pass %', 'Started', ''];
 const HIDE = ['project_id'];
 
 // Sort functions for RunList columns

--- a/frontend/src/pages/run-list.js
+++ b/frontend/src/pages/run-list.js
@@ -14,7 +14,7 @@ import usePagination from '../components/hooks/use-pagination';
 import { FilterContext } from '../components/contexts/filter-context';
 import { RUN_FIELDS } from '../constants';
 
-const COLUMNS = ['Run', 'Duration', 'Summary', 'Started', ''];
+const COLUMNS = ['Run', 'Duration', 'Summary', 'Pass %', 'Started', ''];
 const HIDE = ['project_id'];
 
 // Sort functions for RunList columns
@@ -24,6 +24,8 @@ const sortFunctions = {
     tableSortFunctions.duration(a, b, direction, COLUMNS.indexOf('Duration')),
   started: (a, b, direction) =>
     tableSortFunctions.started(a, b, direction, COLUMNS.indexOf('Started')),
+  'pass %': (a, b, direction) =>
+    tableSortFunctions.passPercent(a, b, direction, COLUMNS.indexOf('Pass %')),
 };
 
 const RunList = () => {

--- a/frontend/src/pages/run-list.test.js
+++ b/frontend/src/pages/run-list.test.js
@@ -644,7 +644,7 @@ describe('RunList', () => {
         expect(screen.getByText('Test runs')).toBeInTheDocument();
       });
 
-      // Columns: 'Run', 'Duration', 'Summary', 'Started', ''
+      // Columns: 'Run', 'Duration', 'Summary', 'Pass %', 'Started', ''
       // These should be passed to FilterTable
     });
   });

--- a/frontend/src/pages/run-list.test.js
+++ b/frontend/src/pages/run-list.test.js
@@ -645,7 +645,7 @@ describe('RunList', () => {
         expect(screen.getByText('Test runs')).toBeInTheDocument();
       });
 
-      // Columns: 'Run', 'Duration', 'Summary', 'Started', ''
+      // Columns: 'Run', 'Duration', 'Summary', 'Pass %', 'Started', ''
       // These should be passed to FilterTable
     });
   });

--- a/frontend/src/pages/run.js
+++ b/frontend/src/pages/run.js
@@ -42,6 +42,7 @@ import {
   resultToRow,
   filtersToAPIParams,
   filtersToSearchParams,
+  getRunPassPercent,
   processPyTestPath,
   cleanPath,
 } from '../utilities';
@@ -596,6 +597,20 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               {run?.summary?.collected ||
                                                 run?.summary?.tests ||
                                                 'Summary Error'}
+                                            </DataListCell>,
+                                          ]}
+                                        />
+                                      </DataListItemRow>
+                                    </DataListItem>
+                                    <DataListItem aria-labelledby="Pass Percentage">
+                                      <DataListItemRow>
+                                        <DataListItemCells
+                                          dataListCells={[
+                                            <DataListCell key={1}>
+                                              Pass %:
+                                            </DataListCell>,
+                                            <DataListCell key={2}>
+                                              {getRunPassPercent(run.summary)}
                                             </DataListCell>,
                                           ]}
                                         />

--- a/frontend/src/pages/run.js
+++ b/frontend/src/pages/run.js
@@ -42,6 +42,7 @@ import {
   resultToRow,
   filtersToAPIParams,
   filtersToSearchParams,
+  getRunPassPercent,
   processPyTestPath,
   cleanPath,
 } from '../utilities';
@@ -593,6 +594,20 @@ const Run = ({ defaultTab = 'summary' }) => {
                                               {run?.summary?.collected ||
                                                 run?.summary?.tests ||
                                                 'Summary Error'}
+                                            </DataListCell>,
+                                          ]}
+                                        />
+                                      </DataListItemRow>
+                                    </DataListItem>
+                                    <DataListItem aria-label="Pass Percentage">
+                                      <DataListItemRow>
+                                        <DataListItemCells
+                                          dataListCells={[
+                                            <DataListCell key={1}>
+                                              Pass %:
+                                            </DataListCell>,
+                                            <DataListCell key={2}>
+                                              {getRunPassPercent(run.summary)}
                                             </DataListCell>,
                                           ]}
                                         />

--- a/frontend/src/pages/run.js
+++ b/frontend/src/pages/run.js
@@ -602,7 +602,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                         />
                                       </DataListItemRow>
                                     </DataListItem>
-                                    <DataListItem aria-labelledby="Pass Percentage">
+                                    <DataListItem aria-label="Pass Percentage">
                                       <DataListItemRow>
                                         <DataListItemCells
                                           dataListCells={[

--- a/frontend/src/utilities/index.js
+++ b/frontend/src/utilities/index.js
@@ -6,3 +6,4 @@ export * from './badges';
 export * from './projects';
 export * from './themes';
 export * from './http';
+export * from './run';

--- a/frontend/src/utilities/run.js
+++ b/frontend/src/utilities/run.js
@@ -1,0 +1,15 @@
+export const getRunPassPercent = (summary) => {
+  if (!summary) return 'N/A';
+  if (summary.pass_percent != null) return summary.pass_percent + '%';
+  if (!summary.tests) return 'N/A';
+  // Fallback for runs not yet backfilled
+  const passed =
+    summary.passes ??
+    summary.tests -
+      (summary.failures || 0) -
+      (summary.errors || 0) -
+      (summary.skips || 0) -
+      (summary.xpasses || 0) -
+      (summary.xfailures || 0);
+  return Math.floor((passed / summary.tests) * 100) + '%';
+};

--- a/frontend/src/utilities/run.js
+++ b/frontend/src/utilities/run.js
@@ -1,3 +1,10 @@
+// Canonical pass_percent formula: floor(passes * 100 / tests), clamped to
+// [0, 100].  The same formula is implemented in the backend (update_run in
+// ibutsu_server/tasks/runs.py) and the migration backfill SQL
+// (d18de2b3253f_backfill_pass_percent_in_run_summary.py).
+//
+// Non-passing outcomes subtracted when deriving passes: failures, errors,
+// skips, xpasses, xfailures.  Keep this list in sync with the backend.
 export const getRunPassPercent = (summary) => {
   if (!summary) return 'N/A';
   if (summary.pass_percent != null) return summary.pass_percent + '%';
@@ -11,5 +18,6 @@ export const getRunPassPercent = (summary) => {
       (summary.skips || 0) -
       (summary.xpasses || 0) -
       (summary.xfailures || 0);
-  return Math.floor((passed / summary.tests) * 100) + '%';
+  const pct = Math.min(Math.max(Math.floor((passed * 100) / summary.tests), 0), 100);
+  return pct + '%';
 };

--- a/frontend/src/utilities/run.js
+++ b/frontend/src/utilities/run.js
@@ -1,0 +1,35 @@
+// Canonical pass_percent formula: floor(passes * 100 / tests), clamped to
+// [0, 100].  The same formula is implemented in the backend
+// (compute_pass_percent in ibutsu_server/tasks/runs.py, used by update_run)
+// and the migration backfill SQL
+// (d18de2b3253f_backfill_pass_percent_in_run_summary.py). JS can't share
+// code with those, so if the formula changes, update all three -- see
+// test_runs.py::test_compute_pass_percent_* for the cases that must match
+// across implementations.
+//
+// Non-passing outcomes subtracted when deriving passes: failures, errors,
+// skips, xpasses, xfailures.  Keep this list in sync with the backend.
+//
+// Returns the bare numeric value as a string (e.g. "85"), or 'N/A' when a
+// percentage cannot be determined. Callers are responsible for appending a
+// '%' suffix if their display context doesn't already convey the unit
+// (e.g. via a "Pass %" column header or label).
+export const getRunPassPercent = (summary) => {
+  if (!summary) return 'N/A';
+  if (summary.pass_percent != null) return String(summary.pass_percent);
+  if (!summary.tests) return '0';
+  // Fallback for runs not yet backfilled
+  const passed =
+    summary.passes ??
+    summary.tests -
+      (summary.failures || 0) -
+      (summary.errors || 0) -
+      (summary.skips || 0) -
+      (summary.xpasses || 0) -
+      (summary.xfailures || 0);
+  const pct = Math.min(
+    Math.max(Math.floor((passed * 100) / summary.tests), 0),
+    100,
+  );
+  return String(pct);
+};

--- a/frontend/src/utilities/run.js
+++ b/frontend/src/utilities/run.js
@@ -1,7 +1,7 @@
 export const getRunPassPercent = (summary) => {
   if (!summary) return 'N/A';
   if (summary.pass_percent != null) return summary.pass_percent + '%';
-  if (!summary.tests) return 'N/A';
+  if (!summary.tests) return '0%';
   // Fallback for runs not yet backfilled
   const passed =
     summary.passes ??

--- a/frontend/src/utilities/run.test.js
+++ b/frontend/src/utilities/run.test.js
@@ -6,9 +6,9 @@ describe('getRunPassPercent', () => {
     expect(getRunPassPercent(undefined)).toBe('N/A');
   });
 
-  it('should return N/A when summary has no tests', () => {
-    expect(getRunPassPercent({})).toBe('N/A');
-    expect(getRunPassPercent({ tests: 0 })).toBe('N/A');
+  it('should return 0% when summary has no tests, matching backend semantics', () => {
+    expect(getRunPassPercent({})).toBe('0%');
+    expect(getRunPassPercent({ tests: 0 })).toBe('0%');
   });
 
   it('should return stored pass_percent when available', () => {

--- a/frontend/src/utilities/run.test.js
+++ b/frontend/src/utilities/run.test.js
@@ -1,0 +1,78 @@
+import { getRunPassPercent } from './run';
+
+describe('getRunPassPercent', () => {
+  it('should return N/A when summary is null or undefined', () => {
+    expect(getRunPassPercent(null)).toBe('N/A');
+    expect(getRunPassPercent(undefined)).toBe('N/A');
+  });
+
+  it('should return N/A when summary has no tests', () => {
+    expect(getRunPassPercent({})).toBe('N/A');
+    expect(getRunPassPercent({ tests: 0 })).toBe('N/A');
+  });
+
+  it('should return stored pass_percent when available', () => {
+    expect(getRunPassPercent({ tests: 100, pass_percent: 95 })).toBe('95%');
+    expect(getRunPassPercent({ tests: 100, pass_percent: 0 })).toBe('0%');
+  });
+
+  it('should calculate pass_percent from passes when pass_percent is missing', () => {
+    const summary = { tests: 100, passes: 80, failures: 20 };
+    expect(getRunPassPercent(summary)).toBe('80%');
+  });
+
+  it('should derive passes from counters when passes is missing', () => {
+    const summary = {
+      tests: 100,
+      failures: 10,
+      errors: 5,
+      skips: 5,
+      xpasses: 0,
+    };
+    expect(getRunPassPercent(summary)).toBe('80%');
+  });
+
+  it('should subtract xfailures when deriving passes from counters', () => {
+    // 100 tests - 10 failures - 5 xfailures = 85 passes -> 85%
+    const summary = { tests: 100, failures: 10, xfailures: 5 };
+    expect(getRunPassPercent(summary)).toBe('85%');
+  });
+
+  it('should subtract both xpasses and xfailures when deriving passes', () => {
+    // 100 tests - 10 failures - 5 errors - 5 skips - 3 xpasses - 7 xfailures = 70 passes -> 70%
+    const summary = {
+      tests: 100,
+      failures: 10,
+      errors: 5,
+      skips: 5,
+      xpasses: 3,
+      xfailures: 7,
+    };
+    expect(getRunPassPercent(summary)).toBe('70%');
+  });
+
+  it('should treat missing xfailures as 0 when deriving passes', () => {
+    // xfailures absent — should behave identically to xfailures: 0
+    const withXfailures = { tests: 100, failures: 10, xfailures: 0 };
+    const withoutXfailures = { tests: 100, failures: 10 };
+    expect(getRunPassPercent(withXfailures)).toBe(
+      getRunPassPercent(withoutXfailures),
+    );
+  });
+
+  it('should floor the percentage instead of rounding', () => {
+    const summary = { tests: 1000, passes: 999, failures: 1 };
+    expect(getRunPassPercent(summary)).toBe('99%');
+  });
+
+  it('should floor at boundary values', () => {
+    const summary = { tests: 3, passes: 1, failures: 2 };
+    // 1/3 * 100 = 33.33... -> floor = 33
+    expect(getRunPassPercent(summary)).toBe('33%');
+  });
+
+  it('should return 100% when all tests pass', () => {
+    const summary = { tests: 500, passes: 500 };
+    expect(getRunPassPercent(summary)).toBe('100%');
+  });
+});

--- a/frontend/src/utilities/run.test.js
+++ b/frontend/src/utilities/run.test.js
@@ -1,0 +1,96 @@
+import { getRunPassPercent } from './run';
+
+describe('getRunPassPercent', () => {
+  it('should return N/A when summary is null or undefined', () => {
+    expect(getRunPassPercent(null)).toBe('N/A');
+    expect(getRunPassPercent(undefined)).toBe('N/A');
+  });
+
+  it('should return 0 when summary has no tests, matching backend semantics', () => {
+    expect(getRunPassPercent({})).toBe('0');
+    expect(getRunPassPercent({ tests: 0 })).toBe('0');
+  });
+
+  it('should return stored pass_percent when available', () => {
+    expect(getRunPassPercent({ tests: 100, pass_percent: 95 })).toBe('95');
+    expect(getRunPassPercent({ tests: 100, pass_percent: 0 })).toBe('0');
+  });
+
+  it('should calculate pass_percent from passes when pass_percent is missing', () => {
+    const summary = { tests: 100, passes: 80, failures: 20 };
+    expect(getRunPassPercent(summary)).toBe('80');
+  });
+
+  it('should derive passes from counters when passes is missing', () => {
+    const summary = {
+      tests: 100,
+      failures: 10,
+      errors: 5,
+      skips: 5,
+      xpasses: 0,
+    };
+    expect(getRunPassPercent(summary)).toBe('80');
+  });
+
+  it('should subtract xfailures when deriving passes from counters', () => {
+    // 100 tests - 10 failures - 5 xfailures = 85 passes -> 85
+    const summary = { tests: 100, failures: 10, xfailures: 5 };
+    expect(getRunPassPercent(summary)).toBe('85');
+  });
+
+  it('should subtract both xpasses and xfailures when deriving passes', () => {
+    // 100 tests - 10 failures - 5 errors - 5 skips - 3 xpasses - 7 xfailures = 70 passes -> 70
+    const summary = {
+      tests: 100,
+      failures: 10,
+      errors: 5,
+      skips: 5,
+      xpasses: 3,
+      xfailures: 7,
+    };
+    expect(getRunPassPercent(summary)).toBe('70');
+  });
+
+  it('should treat missing xfailures as 0 when deriving passes', () => {
+    // xfailures absent — should behave identically to xfailures: 0
+    const withXfailures = { tests: 100, failures: 10, xfailures: 0 };
+    const withoutXfailures = { tests: 100, failures: 10 };
+    expect(getRunPassPercent(withXfailures)).toBe(
+      getRunPassPercent(withoutXfailures),
+    );
+  });
+
+  it('should floor the percentage instead of rounding', () => {
+    const summary = { tests: 1000, passes: 999, failures: 1 };
+    expect(getRunPassPercent(summary)).toBe('99');
+  });
+
+  it('should floor at boundary values', () => {
+    const summary = { tests: 3, passes: 1, failures: 2 };
+    // 1/3 * 100 = 33.33... -> floor = 33
+    expect(getRunPassPercent(summary)).toBe('33');
+  });
+
+  it('should return 100 when all tests pass', () => {
+    const summary = { tests: 500, passes: 500 };
+    expect(getRunPassPercent(summary)).toBe('100');
+  });
+
+  it('should clamp to 100 when passes exceeds tests in a malformed summary', () => {
+    const summary = { tests: 10, passes: 15 };
+    expect(getRunPassPercent(summary)).toBe('100');
+  });
+
+  it('should clamp to 0 when derived counters exceed tests in a malformed summary', () => {
+    // 10 tests - 4 failures - 4 errors - 2 skips - 1 xpass - 1 xfailure = -2 derived passes
+    const summary = {
+      tests: 10,
+      failures: 4,
+      errors: 4,
+      skips: 2,
+      xpasses: 1,
+      xfailures: 1,
+    };
+    expect(getRunPassPercent(summary)).toBe('0');
+  });
+});

--- a/frontend/src/utilities/tables.js
+++ b/frontend/src/utilities/tables.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { ICON_RESULT_MAP } from '../constants';
 import RunSummary from '../components/run-summary';
 import { buildBadge } from './badges';
+import { getRunPassPercent } from './run';
 import { toTitleCase } from './strings';
 import { filtersToSearchParams } from './filters';
 
@@ -39,6 +40,31 @@ export const tableSortFunctions = {
 
     const aValue = getDateValue(a.cells[cellIndex]);
     const bValue = getDateValue(b.cells[cellIndex]);
+    return direction === 'asc' ? aValue - bValue : bValue - aValue;
+  },
+
+  passPercent: (a, b, direction, cellIndex) => {
+    // Extract pass percentage values from cells (format: "85" or "N/A")
+    //
+    // Missing cells and explicit "N/A" text are intentionally treated the
+    // same (both map to the -1 sentinel), so both sort to the bottom in
+    // descending order alongside real 0% runs never being confused with
+    // "no data". If a caller ever needs to tell "no data" apart from a
+    // parsable value, replace this single sentinel with two distinct ones
+    // (e.g. null for missing vs. a dedicated NaN/undefined for "N/A") and
+    // update the comparison below accordingly.
+    const getPassPercentValue = (passPercentCell) => {
+      if (!passPercentCell) return -1;
+      const cellContent =
+        typeof passPercentCell === 'string'
+          ? passPercentCell
+          : passPercentCell.toString();
+      const match = cellContent.match(/(\d+(?:\.\d+)?)/);
+      return match ? parseFloat(match[1]) : -1;
+    };
+
+    const aValue = getPassPercentValue(a.cells[cellIndex]);
+    const bValue = getPassPercentValue(b.cells[cellIndex]);
     return direction === 'asc' ? aValue - bValue : bValue - aValue;
   },
 };
@@ -234,6 +260,7 @@ export const runToRow = (run, filterFunc) => {
     }
     badges.push(envBadge);
   }
+  const passPercent = getRunPassPercent(run.summary);
   return {
     cells: [
       <Fragment key="run">
@@ -241,6 +268,7 @@ export const runToRow = (run, filterFunc) => {
       </Fragment>,
       Math.ceil(run.duration) + 's',
       <RunSummary key="summary" summary={run.summary} />,
+      passPercent,
       created.toLocaleString(),
       <Link
         key="see-results"

--- a/frontend/src/utilities/tables.js
+++ b/frontend/src/utilities/tables.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { ICON_RESULT_MAP } from '../constants';
 import RunSummary from '../components/run-summary';
 import { buildBadge } from './badges';
+import { getRunPassPercent } from './run';
 import { toTitleCase } from './strings';
 import { filtersToSearchParams } from './filters';
 
@@ -234,6 +235,7 @@ export const runToRow = (run, filterFunc) => {
     }
     badges.push(envBadge);
   }
+  const passPercent = getRunPassPercent(run.summary);
   return {
     cells: [
       <Fragment key="run">
@@ -241,6 +243,7 @@ export const runToRow = (run, filterFunc) => {
       </Fragment>,
       Math.ceil(run.duration) + 's',
       <RunSummary key="summary" summary={run.summary} />,
+      passPercent,
       created.toLocaleString(),
       <Link
         key="see-results"

--- a/frontend/src/utilities/tables.test.js
+++ b/frontend/src/utilities/tables.test.js
@@ -1,0 +1,39 @@
+import { tableSortFunctions } from './tables';
+
+// Helper to build a minimal row object shaped like what PatternFly table
+// sort callbacks receive: { cells: [...] }.
+const row = (cellValue) => ({ cells: [cellValue] });
+
+describe('tableSortFunctions.passPercent', () => {
+  const sort = (aCell, bCell, direction) =>
+    tableSortFunctions.passPercent(row(aCell), row(bCell), direction, 0);
+
+  it('sorts numeric percentage strings ascending', () => {
+    expect(sort('20', '80', 'asc')).toBeLessThan(0);
+    expect(sort('80', '20', 'asc')).toBeGreaterThan(0);
+  });
+
+  it('sorts numeric percentage strings descending', () => {
+    expect(sort('20', '80', 'desc')).toBeGreaterThan(0);
+    expect(sort('80', '20', 'desc')).toBeLessThan(0);
+  });
+
+  it('treats "N/A" the same as a missing/falsy cell value', () => {
+    // Both map to the same -1 sentinel, so they compare as equal to each
+    // other regardless of direction.
+    expect(sort('N/A', null, 'asc')).toBe(0);
+    expect(sort('N/A', undefined, 'desc')).toBe(0);
+    expect(sort(null, '', 'asc')).toBe(0);
+  });
+
+  it('sorts "N/A"/missing values to the bottom in descending order', () => {
+    // Real percentages (including 0%) must rank above "no data".
+    expect(sort('N/A', '0', 'desc')).toBeGreaterThan(0);
+    expect(sort('0', 'N/A', 'desc')).toBeLessThan(0);
+  });
+
+  it('sorts "N/A"/missing values to the top in ascending order', () => {
+    expect(sort('N/A', '0', 'asc')).toBeLessThan(0);
+    expect(sort('0', 'N/A', 'asc')).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/utilities/utilities.test.js
+++ b/frontend/src/utilities/utilities.test.js
@@ -601,5 +601,51 @@ describe('Table Utilities', () => {
         expect(sorted[1].cells[1]).toBe('1/1/2023, 10:00:00 AM');
       });
     });
+
+    describe('passPercent', () => {
+      it('should sort pass percentage values correctly', () => {
+        const rows = [
+          { cells: ['test1', '75'] },
+          { cells: ['test2', '20'] },
+          { cells: ['test3', '100'] },
+        ];
+
+        const sorted = rows.sort((a, b) =>
+          tableSortFunctions.passPercent(a, b, 'asc', 1),
+        );
+        expect(sorted[0].cells[1]).toBe('20');
+        expect(sorted[2].cells[1]).toBe('100');
+      });
+
+      it('should sort in descending order', () => {
+        const rows = [{ cells: ['test1', '20'] }, { cells: ['test2', '100'] }];
+
+        const sorted = rows.sort((a, b) =>
+          tableSortFunctions.passPercent(a, b, 'desc', 1),
+        );
+        expect(sorted[0].cells[1]).toBe('100');
+        expect(sorted[1].cells[1]).toBe('20');
+      });
+
+      it('should treat N/A as lower than any percentage', () => {
+        const rows = [{ cells: ['test1', '20'] }, { cells: ['test2', 'N/A'] }];
+
+        const sorted = rows.sort((a, b) =>
+          tableSortFunctions.passPercent(a, b, 'asc', 1),
+        );
+        expect(sorted[0].cells[1]).toBe('N/A');
+        expect(sorted[1].cells[1]).toBe('20');
+      });
+
+      it('should handle missing pass percentage values', () => {
+        const rows = [{ cells: ['test1', null] }, { cells: ['test2', '60'] }];
+
+        const sorted = rows.sort((a, b) =>
+          tableSortFunctions.passPercent(a, b, 'asc', 1),
+        );
+        expect(sorted[0].cells[1]).toBe(null);
+        expect(sorted[1].cells[1]).toBe('60');
+      });
+    });
   });
 });

--- a/scripts/ibutsu-pod.sh
+++ b/scripts/ibutsu-pod.sh
@@ -71,6 +71,34 @@ function print_usage() {
     echo ""
 }
 
+# Fail immediately if a container has exited (or been removed via --rm).
+# Call from wait loops so we do not spin until timeout after a crash.
+function ensure_container_running() {
+    local name="$1"
+    local label="${2:-$1}"
+
+    if ! podman container exists "$name" 2>/dev/null; then
+        echo ""
+        echo "ERROR: ${label} container (${name}) is gone — it likely exited and was removed (--rm)."
+        echo "Start the pod again and follow logs in another terminal, e.g.:"
+        echo "  podman logs -f ${name}"
+        exit 1
+    fi
+
+    local state
+    state=$(podman inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo "unknown")
+    if [[ "$state" != "running" ]]; then
+        local exit_code
+        exit_code=$(podman inspect -f '{{.State.ExitCode}}' "$name" 2>/dev/null || echo "?")
+        echo ""
+        echo "ERROR: ${label} container (${name}) is not running (state: ${state}, exit code: ${exit_code})."
+        echo "----- ${name} logs -----"
+        podman logs "$name" 2>/dev/null || echo "(unable to read logs)"
+        echo "----- end logs -----"
+        exit 1
+    fi
+}
+
 # Resolve IMAGE_TAG once so it can be reused across the script
 function resolve_image_tag() {
     if [[ -n "${IMAGE_TAG:-}" ]]; then
@@ -328,6 +356,7 @@ if [[ $USE_IMAGES = true ]]; then
         --pod "$POD_NAME" \
         --name ibutsu-backend \
         -e JWT_SECRET="$JWT_SECRET" \
+        -e PYTHONUNBUFFERED=1 \
         "${POSTGRES_ENV_ARGS[@]}" \
         "${CELERY_ENV_ARGS[@]}" \
         -e SQLALCHEMY_WARN_20=1 \
@@ -345,6 +374,7 @@ else
         --pod "$POD_NAME" \
         --name ibutsu-backend \
         -e JWT_SECRET="$JWT_SECRET" \
+        -e PYTHONUNBUFFERED=1 \
         "${POSTGRES_ENV_ARGS[@]}" \
         "${CELERY_ENV_ARGS[@]}" \
         -e SQLALCHEMY_WARN_20=1 \
@@ -364,6 +394,7 @@ sleep 5
 BACKEND_WAIT=0
 BACKEND_TIMEOUT=600
 until curl --output /dev/null --silent --head --fail http://$LOCAL_HOST:$LOCAL_PORT_BACKEND; do
+  ensure_container_running ibutsu-backend "Backend"
   echo -n ' .'
   sleep 2
   BACKEND_WAIT=$((BACKEND_WAIT + 2))
@@ -371,7 +402,7 @@ until curl --output /dev/null --silent --head --fail http://$LOCAL_HOST:$LOCAL_P
     echo ""
     echo "ERROR: Backend failed to start within ${BACKEND_TIMEOUT}s. Container logs:"
     echo "----- ibutsu-backend logs -----"
-    podman logs ibutsu-backend
+    podman logs ibutsu-backend 2>/dev/null || echo "(unable to read logs — container may have been removed)"
     echo "----- end logs -----"
     exit 1
   fi
@@ -411,9 +442,21 @@ else
 fi
 echo -n "Waiting for celery to respond: "
 sleep 5
+CELERY_WAIT=0
+CELERY_TIMEOUT=600
 until podman exec ibutsu-worker celery inspect ping -d celery@ibutsu 2>/dev/null | grep -q pong; do
+    ensure_container_running ibutsu-worker "Celery worker"
     echo -n ' .'
     sleep 2
+    CELERY_WAIT=$((CELERY_WAIT + 2))
+    if [ $CELERY_WAIT -ge $CELERY_TIMEOUT ]; then
+        echo ""
+        echo "ERROR: Celery worker failed to respond within ${CELERY_TIMEOUT}s. Container logs:"
+        echo "----- ibutsu-worker logs -----"
+        podman logs ibutsu-worker 2>/dev/null || echo "(unable to read logs — container may have been removed)"
+        echo "----- end logs -----"
+        exit 1
+    fi
 done
 echo " celery worker up."
 
@@ -918,9 +961,21 @@ fi
 echo "done."
 
 echo -n "Waiting for frontend to respond: "
+FRONTEND_WAIT=0
+FRONTEND_TIMEOUT=600
 until curl --output /dev/null --silent --head --fail http://$LOCAL_HOST:$LOCAL_PORT_FRONTEND; do
+  ensure_container_running ibutsu-frontend "Frontend"
   printf ' .'
   sleep 5
+  FRONTEND_WAIT=$((FRONTEND_WAIT + 5))
+  if [ $FRONTEND_WAIT -ge $FRONTEND_TIMEOUT ]; then
+    echo ""
+    echo "ERROR: Frontend failed to start within ${FRONTEND_TIMEOUT}s. Container logs:"
+    echo "----- ibutsu-frontend logs -----"
+    podman logs ibutsu-frontend 2>/dev/null || echo "(unable to read logs — container may have been removed)"
+    echo "----- end logs -----"
+    exit 1
+  fi
 done
 echo " frontend available."
 


### PR DESCRIPTION
add to run page, runs table, and add index for fast filtering

FIXES #847 

## Runs Table
<img width="1526" height="410" alt="image" src="https://github.com/user-attachments/assets/1e98fc88-9cf4-4dc6-81b1-0b2031212370" />

## Run Summary
<img width="1548" height="438" alt="image" src="https://github.com/user-attachments/assets/04881f35-755e-474c-8aaf-4a24f0f3fd7c" />

## Runs Filtering

### >= 50
Includes 50% run:
<img width="2152" height="528" alt="image" src="https://github.com/user-attachments/assets/a17303ca-7747-4550-9dde-61b5e95101a9" />

### > 50
Excludes 50% run:
<img width="2152" height="528" alt="image" src="https://github.com/user-attachments/assets/b8a0c903-293a-42a4-a793-3fc29176301e" />

### <= 50
Includes 50% run:
<img width="2152" height="528" alt="image" src="https://github.com/user-attachments/assets/7017535b-7ab3-4cd6-b489-20dfbf37aa58" />

### <50
Excludes 50% run:
<img width="2152" height="528" alt="image" src="https://github.com/user-attachments/assets/917a15ee-c9ee-4286-a5ad-f9a84ef7844c" />




## Summary by Sourcery

Add pass percentage calculation and display for test runs, including backfilling existing data and indexing for efficient filtering.

New Features:
- Display run pass percentage in the run details page and runs list.
- Expose pass percentage as a numeric run field for filtering and reporting.

Enhancements:
- Compute and store pass_percent in run summaries during run updates on the backend.
- Backfill pass_percent for existing runs and add a PostgreSQL index to speed up pass percentage queries.

Tests:
- Extend backend run update tests and frontend run list tests to cover pass_percent.

## Summary by Sourcery

Add pass percentage as a first-class metric for test runs, including storage, backfill, filtering, and UI display, and improve migration and pod startup robustness.

New Features:
- Display run pass percentage in the run details page and runs list, with sortable pass % column.
- Expose summary.pass_percent as a numeric run field that can be filtered via the API and used in frontend filters.

Enhancements:
- Compute and store pass_percent in run summaries during backend run updates using a canonical clamped, floored formula shared with the frontend.
- Backfill pass_percent for existing runs via a PostgreSQL-only Alembic migration that batches JSON summary updates and adds an expression index for fast range queries.
- Tighten backend filter parsing and casting semantics for numeric JSON fields, support >= and <= operators, and ensure unknown fields are ignored instead of erroring.
- Add frontend table sort support for pass percentage values, treating missing or N/A values consistently.
- Configure Alembic to run each migration in its own transaction to support autocommit blocks and concurrent index creation.

Build:
- Enhance the ibutsu-pod startup script to detect crashed containers during wait loops, enforce timeouts for backend, worker, and frontend readiness, and run the backend with unbuffered Python output for clearer logs.

Tests:
- Extend backend tests to cover pass_percent computation edge cases, numeric filter behavior, and pass_percent-based run list filtering.
- Add frontend tests for run pass percentage calculation helper and table sorting behavior for pass % values.