### PR TITLE
Split tests workflow

### DIFF
--- a/.github/workflows/tests-backend.yaml
+++ b/.github/workflows/tests-backend.yaml
@@ -1,12 +1,23 @@
-name: Ibutsu tests
+name: Ibutsu backend tests
 
 on:
   push:
     branches:
       - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/tests-backend.yaml'
+      - '.pre-commit-config.yaml'
+      - '.ruff.toml'
+      - 'codecov.yml'
   pull_request:
     types: ["opened", "synchronize", "reopened"]
-  create:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/tests-backend.yaml'
+      - '.pre-commit-config.yaml'
+      - '.ruff.toml'
+      - 'codecov.yml'
 
 jobs:
   lint:
@@ -20,29 +31,6 @@ jobs:
         run: pip install pre-commit
       - name: Run pre-commit
         run: pre-commit run --all --verbose
-  lint-test-frontend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: 'frontend/.nvmrc'
-          cache: 'yarn'
-          cache-dependency-path: 'frontend/yarn.lock'
-      - run: yarn install
-        working-directory: ./frontend
-      - run: yarn lint
-        working-directory: ./frontend
-      - name: Run tests with coverage
-        run: yarn test:coverage:ci
-        working-directory: ./frontend
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: frontend-coverage
-          path: frontend/coverage/
-          retention-days: 30
 
   test-backend:
     runs-on: ubuntu-latest
@@ -90,11 +78,11 @@ jobs:
 
   upload-coverage:
     runs-on: ubuntu-latest
-    needs: [test-backend, lint-test-frontend]
+    needs: test-backend
     if: always()
     steps:
       - uses: actions/checkout@v4
-      - name: Download all coverage artifacts
+      - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:
           path: coverage-reports
@@ -109,17 +97,3 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           verbose: true
-
-  build-frontend:
-    runs-on: ubuntu-latest
-    needs: lint-test-frontend
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build frontend image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          context: ./frontend
-          image: ibutsu-frontend
-          dockerfiles: |
-            ./frontend/docker/Dockerfile.frontend

--- a/.github/workflows/tests-frontend.yaml
+++ b/.github/workflows/tests-frontend.yaml
@@ -1,0 +1,77 @@
+name: Ibutsu frontend tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/tests-frontend.yaml'
+      - 'codecov.yml'
+  pull_request:
+    types: ["opened", "synchronize", "reopened"]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/tests-frontend.yaml'
+      - 'codecov.yml'
+
+jobs:
+  lint-test-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'frontend/.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'frontend/yarn.lock'
+      - run: yarn install
+        working-directory: ./frontend
+      - run: yarn lint
+        working-directory: ./frontend
+      - name: Run tests with coverage
+        run: yarn test:coverage:ci
+        working-directory: ./frontend
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          retention-days: 30
+
+  build-frontend:
+    runs-on: ubuntu-latest
+    needs: lint-test-frontend
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build frontend image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: ./frontend
+          image: ibutsu-frontend
+          dockerfiles: |
+            ./frontend/docker/Dockerfile.frontend
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    needs: lint-test-frontend
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage-reports
+          pattern: '*-coverage*'
+      - name: Display structure of downloaded files
+        run: ls -R coverage-reports
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage-reports
+          name: codecov-umbrella
+          fail_ci_if_error: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          verbose: true


### PR DESCRIPTION
limit tests, especially building pipelines, to when the relevant backend or frontend directory is modified.

use native paths: filters

## Summary by Sourcery

Split backend and frontend CI tests into separate workflows and restrict them to run only when their respective directories change.

CI:
- Limit backend tests workflow to backend path changes and rename it accordingly.
- Introduce a dedicated frontend tests workflow that only runs on frontend path changes, including linting, tests, image build, and coverage upload.
- Adjust coverage upload jobs in both workflows to download only relevant coverage artifacts and dependencies.