### PR TITLE
depend on success for coverage upload

### DIFF
--- a/.github/workflows/tests-backend.yaml
+++ b/.github/workflows/tests-backend.yaml
@@ -79,7 +79,7 @@ jobs:
   upload-coverage:
     runs-on: ubuntu-latest
     needs: test-backend
-    if: always()
+    if: needs['test-backend'].result == 'success'
     steps:
       - uses: actions/checkout@v4
       - name: Download coverage artifacts

--- a/.github/workflows/tests-frontend.yaml
+++ b/.github/workflows/tests-frontend.yaml
@@ -57,7 +57,7 @@ jobs:
   upload-coverage:
     runs-on: ubuntu-latest
     needs: lint-test-frontend
-    if: always()
+    if: needs['lint-test-frontend'].result == 'success'
     steps:
       - uses: actions/checkout@v4
       - name: Download coverage artifacts


### PR DESCRIPTION
## Summary by Sourcery

Restrict coverage upload jobs in CI workflows to run only when their dependent test jobs succeed.

CI:
- Update backend coverage upload job to depend on a successful backend test run instead of always executing.
- Update frontend coverage upload job to depend on a successful lint/test run instead of always executing.