### PR TITLE
add buildarg for corepack envvar

### DIFF
--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -20,6 +20,11 @@ RUN if [ -n "${NPM_REGISTRY}" ]; then npm config set registry "${NPM_REGISTRY}";
     npm install -g "corepack@${COREPACK_VERSION}" && \
     corepack enable
 
+# When an internal registry is specified, redirect corepack's package-manager
+# downloads through the same proxy (avoids direct access to repo.yarnpkg.com).
+ARG COREPACK_NPM_REGISTRY=""
+ENV COREPACK_NPM_REGISTRY=${COREPACK_NPM_REGISTRY}
+
 # Skip downloading the Cypress binary — it is only needed for e2e tests,
 # not for the production build, and it consumes ~300 MB of memory/disk.
 ENV CYPRESS_INSTALL_BINARY=0


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust frontend Dockerfile to introduce or modify build arguments for configuring the corepack-related environment variable.