### PR TITLE
Add options for yarn building in CI

### DIFF
--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -39,13 +39,38 @@ ENV NODE_OPTIONS="--max-old-space-size=3072"
 # Changes to source code won't invalidate the dependency install layer.
 COPY --chown=1001:0 .yarnrc.yml package.json yarn.lock ./
 
+# Yarn Berry network tuning for internal registry proxies (e.g. Nexus).
+# Proxied fetches are significantly slower than direct npmjs.org access;
+# these defaults prevent silent hangs and reduce the chance of CI timeouts.
+#
+# IMPORTANT: ARG names must NOT start with YARN_ — Yarn Berry interprets
+# all YARN_* environment variables as config overrides (snake_case → camelCase),
+# and unrecognised keys cause a fatal error when enableStrictSettings is true.
+ARG PROXY_HTTP_TIMEOUT="300000"
+ARG PROXY_HTTP_RETRY="5"
+ARG PROXY_NETWORK_CONCURRENCY="8"
+
+# Opt-in Node.js HTTP debug tracing for the fetch step. Yarn Berry 4.x has
+# no --verbose flag (yarnpkg/berry#6187); setting NODE_DEBUG=http,https is
+# the only way to see individual HTTP requests during yarn install.
+# Pass --build-arg FETCH_DEBUG=http,https to enable.
+ARG FETCH_DEBUG=""
+
 # When an internal registry is specified, configure Yarn Berry to use it for
-# package downloads. Yarn Berry reads npmRegistryServer from .yarnrc.yml,
-# not NPM_CONFIG_REGISTRY.
+# package downloads and apply network tuning. Yarn Berry reads
+# npmRegistryServer from .yarnrc.yml, not NPM_CONFIG_REGISTRY.
+# Telemetry is unconditionally disabled: the buildah build context does not
+# inherit CI=true from the GitLab runner, so Yarn defaults to telemetry=on
+# and the request to repo.yarnpkg.com hangs for up to 10 minutes in
+# restricted networks.
 RUN if [ -n "${NPM_REGISTRY}" ]; then \
       yarn config set npmRegistryServer "${NPM_REGISTRY}"; \
+      yarn config set httpTimeout "${PROXY_HTTP_TIMEOUT}"; \
+      yarn config set httpRetry "${PROXY_HTTP_RETRY}"; \
+      yarn config set networkConcurrency "${PROXY_NETWORK_CONCURRENCY}"; \
+      yarn config set enableTelemetry false; \
     fi && \
-    yarn install --immutable
+    NODE_DEBUG="${FETCH_DEBUG}" yarn install --immutable
 
 # Copy the rest of the source code (bin/ needed for build script)
 COPY --chown=1001:0 . .


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust frontend Dockerfile configuration to enable customizable Yarn-based build steps in CI.