### PR TITLE
Remove redundant buildah image build jobs from GitHub Actions

### DIFF
--- a/.github/workflows/tests-backend.yaml
+++ b/.github/workflows/tests-backend.yaml
@@ -59,23 +59,6 @@ jobs:
           path: backend/coverage.xml
           retention-days: 30
 
-  build-backend:
-    runs-on: ubuntu-latest
-    needs: test-backend
-    if: github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        app: [backend, scheduler, worker]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build image ${{ matrix.app }}
-        uses: redhat-actions/buildah-build@v2
-        with:
-          context: ./backend
-          image: ibutsu-${{ matrix.app }}
-          dockerfiles: |
-            ./backend/docker/Dockerfile.${{ matrix.app }}
-
   upload-coverage:
     runs-on: ubuntu-latest
     needs: test-backend

--- a/.github/workflows/tests-frontend.yaml
+++ b/.github/workflows/tests-frontend.yaml
@@ -39,20 +39,6 @@ jobs:
           path: frontend/coverage/
           retention-days: 30
 
-  build-frontend:
-    runs-on: ubuntu-latest
-    needs: lint-test-frontend
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build frontend image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          context: ./frontend
-          image: ibutsu-frontend
-          dockerfiles: |
-            ./frontend/docker/Dockerfile.frontend
-
   upload-coverage:
     runs-on: ubuntu-latest
     needs: lint-test-frontend


### PR DESCRIPTION
Image builds are being migrated to Konflux (Pipelines as Code). Once Konflux PaC is configured and building images for PRs and main branch pushes, these GitHub Actions buildah smoke-test jobs are no longer needed.

Removed:
- build-backend job (backend, scheduler, worker) from tests-backend.yaml
- build-frontend job from tests-frontend.yaml

Lint, unit test, and coverage upload jobs are preserved unchanged.

## Summary by Sourcery

Remove redundant image build jobs from GitHub Actions workflows now that image builds are handled elsewhere.

CI:
- Delete backend buildah image build job from tests-backend GitHub Actions workflow.
- Delete frontend buildah image build job from tests-frontend GitHub Actions workflow.