### PR TITLE
Add version tag label for all images

### DIFF
--- a/backend/docker/Dockerfile.backend
+++ b/backend/docker/Dockerfile.backend
@@ -1,6 +1,9 @@
 # hadolint global ignore=DL3013,DL3041,DL3059
 FROM registry.access.redhat.com/ubi9/python-312:9.8
 
+ARG VERSION_TAG=""
+LABEL version="${VERSION_TAG}"
+
 USER 0
 COPY . /app
 RUN /usr/bin/fix-permissions /app

--- a/backend/docker/Dockerfile.flower
+++ b/backend/docker/Dockerfile.flower
@@ -1,6 +1,9 @@
 # hadolint global ignore=DL3013,DL3041,DL3025
 FROM registry.access.redhat.com/ubi9/python-312:9.8
 
+ARG VERSION_TAG=""
+LABEL version="${VERSION_TAG}"
+
 # add application sources with correct perms for OCP
 USER 0
 RUN dnf install -y libpq-devel gcc && \

--- a/backend/docker/Dockerfile.scheduler
+++ b/backend/docker/Dockerfile.scheduler
@@ -1,5 +1,9 @@
 # hadolint global ignore=DL3013,DL3041
 FROM registry.access.redhat.com/ubi9/python-312:9.8
+
+ARG VERSION_TAG=""
+LABEL version="${VERSION_TAG}"
+
 USER 0
 
 ENV UPGRADE_PIP_TO_LATEST=1

--- a/backend/docker/Dockerfile.worker
+++ b/backend/docker/Dockerfile.worker
@@ -1,6 +1,9 @@
 # hadolint global ignore=DL3013,DL3041
 FROM registry.access.redhat.com/ubi9/python-312:9.8
 
+ARG VERSION_TAG=""
+LABEL version="${VERSION_TAG}"
+
 ENV UPGRADE_PIP_TO_LATEST=1
 
 USER 0

--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -106,6 +106,9 @@ RUN CI=false GENERATE_SOURCEMAP=false yarn build
 # See: https://catalog.redhat.com/en/software/containers/ubi9/nodejs-20-minimal/64770ddd0e699534bb564b3b
 FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:9.7
 
+ARG VERSION_TAG=""
+LABEL version="${VERSION_TAG}"
+
 WORKDIR /opt/app-root/src
 
 # Copy only the compiled static files from the builder stage.


### PR DESCRIPTION
## Summary by Sourcery

Add version tag labels to all backend and frontend Docker images to standardize image metadata.

Build:
- Add consistent version label metadata to backend Docker images.
- Add consistent version label metadata to frontend Docker images.