### PR TITLE
Add default version_tag to dockerfiles

### DIFF
--- a/backend/docker/Dockerfile.backend
+++ b/backend/docker/Dockerfile.backend
@@ -1,7 +1,7 @@
 # hadolint global ignore=DL3013,DL3041,DL3059
 FROM registry.access.redhat.com/ubi9/python-312:9.8-1782966301
 
-ARG VERSION_TAG=""
+ARG VERSION_TAG="latest"
 LABEL version="${VERSION_TAG}"
 
 USER 0

--- a/backend/docker/Dockerfile.flower
+++ b/backend/docker/Dockerfile.flower
@@ -1,7 +1,7 @@
 # hadolint global ignore=DL3013,DL3041,DL3025
 FROM registry.access.redhat.com/ubi9/python-312:9.8-1782966301
 
-ARG VERSION_TAG=""
+ARG VERSION_TAG="latest"
 LABEL version="${VERSION_TAG}"
 
 # add application sources with correct perms for OCP

--- a/backend/docker/Dockerfile.scheduler
+++ b/backend/docker/Dockerfile.scheduler
@@ -1,7 +1,7 @@
 # hadolint global ignore=DL3013,DL3041
 FROM registry.access.redhat.com/ubi9/python-312:9.8-1782966301
 
-ARG VERSION_TAG=""
+ARG VERSION_TAG="latest"
 LABEL version="${VERSION_TAG}"
 
 USER 0

--- a/backend/docker/Dockerfile.worker
+++ b/backend/docker/Dockerfile.worker
@@ -1,7 +1,7 @@
 # hadolint global ignore=DL3013,DL3041
 FROM registry.access.redhat.com/ubi9/python-312:9.8-1782966301
 
-ARG VERSION_TAG=""
+ARG VERSION_TAG="latest"
 LABEL version="${VERSION_TAG}"
 
 ENV UPGRADE_PIP_TO_LATEST=1

--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -106,7 +106,7 @@ RUN CI=false GENERATE_SOURCEMAP=false yarn build
 # See: https://catalog.redhat.com/en/software/containers/ubi9/nodejs-20-minimal/64770ddd0e699534bb564b3b
 FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:9.7-1778604817
 
-ARG VERSION_TAG=""
+ARG VERSION_TAG="latest"
 LABEL version="${VERSION_TAG}"
 
 WORKDIR /opt/app-root/src


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add a default version_tag configuration to all backend and frontend Dockerfiles for consistent image tagging.