### PR TITLE
Add licenses to containers

### DIFF
--- a/backend/docker/Dockerfile.backend
+++ b/backend/docker/Dockerfile.backend
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi9/python-314-minimal:9.8-1784609205
 
 USER 0
 COPY . /app
+COPY licenses/ /licenses/
 RUN /usr/bin/fix-permissions /app
 
 WORKDIR /app

--- a/backend/docker/Dockerfile.flower
+++ b/backend/docker/Dockerfile.flower
@@ -7,6 +7,7 @@ RUN microdnf install --nodocs -y file-libs && \
     microdnf clean all
 
 COPY . /app
+COPY licenses/ /licenses/
 RUN /usr/bin/fix-permissions /app
 
 USER 1001

--- a/backend/docker/Dockerfile.scheduler
+++ b/backend/docker/Dockerfile.scheduler
@@ -9,6 +9,7 @@ RUN microdnf install --nodocs -y file-libs && \
     microdnf clean all
 
 COPY . /app
+COPY licenses/ /licenses/
 
 WORKDIR /app
 RUN python -m pip install --no-cache-dir -U pip wheel setuptools && \

--- a/backend/docker/Dockerfile.worker
+++ b/backend/docker/Dockerfile.worker
@@ -9,6 +9,7 @@ RUN microdnf install --nodocs -y file-libs && \
     microdnf clean all
 
 COPY . /app
+COPY licenses/ /licenses/
 
 WORKDIR /app
 RUN python -m pip install --no-cache-dir -U pip wheel setuptools && \

--- a/backend/licenses/LICENSE
+++ b/backend/licenses/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/frontend/docker/Dockerfile.frontend
+++ b/frontend/docker/Dockerfile.frontend
@@ -106,6 +106,8 @@ COPY --from=builder --chown=1001:0 /opt/app-root/src/build /opt/app-root/src/bui
 ARG SERVE_VERSION="14.2.6"
 RUN npm install -g "serve@${SERVE_VERSION}"
 
+COPY licenses/ /licenses/
+
 # Copy the entrypoint script for runtime configuration
 # Use --chmod to set executable permissions directly (avoids permission issues in minimal image)
 COPY --chmod=755 ./docker/entrypoint.sh /opt/app-root/bin/entrypoint.sh

--- a/frontend/licenses/LICENSE
+++ b/frontend/licenses/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
## Summary by Sourcery

Remove SAST Snyk checks from Tekton pipelines and update container builds to include license files.

Build:
- Update backend and frontend Dockerfiles to incorporate newly added license files into built container images.

CI:
- Remove sast-snyk-check tasks from all pull-request and push Tekton pipelines for backend, frontend, worker, scheduler, and flower components.

Chores:
- Add LICENSE files for backend and frontend to support container licensing compliance.