### PR TITLE
routing fix for sidebar navigation

### DIFF
--- a/frontend/src/components/sidebar.js
+++ b/frontend/src/components/sidebar.js
@@ -1,6 +1,6 @@
 import { use, useEffect, useState } from 'react';
 
-import { Link } from 'react-router';
+import { Link, useParams } from 'react-router';
 import { IbutsuContext } from './contexts/ibutsu-context';
 import {
   PageSidebar,
@@ -14,6 +14,7 @@ import { Settings } from '../pages/settings';
 const IbutsuSidebar = () => {
   const context = use(IbutsuContext);
   const { primaryType, primaryObject } = context;
+  const { project_id } = useParams();
 
   const [views, setViews] = useState();
 
@@ -51,47 +52,51 @@ const IbutsuSidebar = () => {
     }
   }, [primaryObject]);
 
-  if (primaryType == 'project' && primaryObject) {
-    return (
-      <PageSidebar ouiaId="project-sidebar">
-        <PageSidebarBody isFilled>
-          <Nav aria-label="Nav" ouiaId="project-nav">
-            <NavList>
-              <li className="pf-v6-c-nav__item">
-                <Link to="dashboard" className="pf-v6-c-nav__link">
-                  Dashboard
-                </Link>
-              </li>
-              <li className="pf-v6-c-nav__item">
-                <Link to="runs/" className="pf-v6-c-nav__link">
-                  Runs
-                </Link>
-              </li>
-              <li className="pf-v6-c-nav__item">
-                <Link to="results/" className="pf-v6-c-nav__link">
-                  Test Results
-                </Link>
-              </li>
-              {views &&
-                views.map(
-                  (view) =>
-                    view.widget !== 'jenkins-analysis-view' && (
-                      <li className="pf-v6-c-nav__item" key={view.id}>
-                        <Link
-                          to={`view/${view.id}`}
-                          className="pf-v6-c-nav__link"
-                        >
-                          {view.title}
-                        </Link>
-                      </li>
-                    ),
-                )}
-            </NavList>
-          </Nav>
-        </PageSidebarBody>
-      </PageSidebar>
-    );
+  if (!project_id || primaryType !== 'project' || !primaryObject) {
+    return;
   }
+
+  const projectBasePath = `/project/${project_id}`;
+
+  return (
+    <PageSidebar ouiaId="project-sidebar">
+      <PageSidebarBody isFilled>
+        <Nav aria-label="Nav" ouiaId="project-nav">
+          <NavList>
+            <li className="pf-v6-c-nav__item">
+              <Link to={`${projectBasePath}/dashboard`} className="pf-v6-c-nav__link">
+                Dashboard
+              </Link>
+            </li>
+            <li className="pf-v6-c-nav__item">
+              <Link to={`${projectBasePath}/runs`} className="pf-v6-c-nav__link">
+                Runs
+              </Link>
+            </li>
+            <li className="pf-v6-c-nav__item">
+              <Link to={`${projectBasePath}/results`} className="pf-v6-c-nav__link">
+                Test Results
+              </Link>
+            </li>
+            {views &&
+              views.map(
+                (view) =>
+                  view.widget !== 'jenkins-analysis-view' && (
+                    <li className="pf-v6-c-nav__item" key={view.id}>
+                      <Link
+                        to={`${projectBasePath}/view/${view.id}`}
+                        className="pf-v6-c-nav__link"
+                      >
+                        {view.title}
+                      </Link>
+                    </li>
+                  ),
+              )}
+          </NavList>
+        </Nav>
+      </PageSidebarBody>
+    </PageSidebar>
+  );
 };
 
 export default IbutsuSidebar;

--- a/frontend/src/components/sidebar.test.js
+++ b/frontend/src/components/sidebar.test.js
@@ -1,0 +1,223 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import IbutsuSidebar from './sidebar';
+import { IbutsuContext } from './contexts/ibutsu-context';
+import { HttpClient } from '../utilities/http';
+import { createMockProject } from '../test-utils';
+
+vi.mock('../utilities/http');
+vi.mock('../pages/settings', () => ({
+  Settings: {
+    serverUrl: 'http://localhost:8080/api',
+  },
+}));
+
+describe('IbutsuSidebar', () => {
+  const mockProject = createMockProject({
+    id: 'project-abc-123',
+    name: 'test-project',
+    title: 'Test Project',
+  });
+
+  const projectId = 'project-abc-123';
+
+  const defaultContextValue = {
+    primaryObject: mockProject,
+    defaultDashboard: null,
+    primaryType: 'project',
+    setPrimaryType: vi.fn(),
+    setPrimaryObject: vi.fn(),
+    setDefaultDashboard: vi.fn(),
+    darkTheme: false,
+    setDarkTheme: vi.fn(),
+  };
+
+  const renderSidebar = (
+    contextValue = {},
+    initialRoute = `/project/${projectId}/dashboard/dash-1`,
+  ) => {
+    const mergedContext = { ...defaultContextValue, ...contextValue };
+
+    return render(
+      <MemoryRouter initialEntries={[initialRoute]}>
+        <IbutsuContext value={mergedContext}>
+          <Routes>
+            <Route
+              path="/project/:project_id/*"
+              element={<IbutsuSidebar />}
+            />
+          </Routes>
+        </IbutsuContext>
+      </MemoryRouter>,
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    HttpClient.get.mockResolvedValue({
+      ok: true,
+      json: async () => ({ widgets: [] }),
+    });
+
+    HttpClient.handleResponse.mockImplementation(async (response) => {
+      if (response.ok) {
+        return response.json();
+      }
+      throw new Error('Response not ok');
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('Navigation link targets', () => {
+    it('should render absolute Dashboard link under the project base path', async () => {
+      renderSidebar();
+      vi.advanceTimersByTime(100);
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: 'Dashboard' });
+        expect(link).toHaveAttribute(
+          'href',
+          `/project/${projectId}/dashboard`,
+        );
+      });
+    });
+
+    it('should render absolute Runs link under the project base path', async () => {
+      renderSidebar();
+      vi.advanceTimersByTime(100);
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: 'Runs' });
+        expect(link).toHaveAttribute('href', `/project/${projectId}/runs`);
+      });
+    });
+
+    it('should render absolute Results link under the project base path', async () => {
+      renderSidebar();
+      vi.advanceTimersByTime(100);
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: 'Test Results' });
+        expect(link).toHaveAttribute(
+          'href',
+          `/project/${projectId}/results`,
+        );
+      });
+    });
+
+    it('should not append link paths to the current route', async () => {
+      renderSidebar({}, `/project/${projectId}/dashboard/some-uuid`);
+      vi.advanceTimersByTime(100);
+
+      await waitFor(() => {
+        const runsLink = screen.getByRole('link', { name: 'Runs' });
+        expect(runsLink).toHaveAttribute(
+          'href',
+          `/project/${projectId}/runs`,
+        );
+        expect(runsLink.getAttribute('href')).not.toContain('dashboard');
+      });
+    });
+  });
+
+  describe('View navigation links', () => {
+    const mockViews = [
+      { id: 'view-1', title: 'Accessibility', widget: 'accessibility-view' },
+      { id: 'view-2', title: 'Build Trends', widget: 'build-trends-view' },
+    ];
+
+    beforeEach(() => {
+      HttpClient.get.mockResolvedValue({
+        ok: true,
+        json: async () => ({ widgets: mockViews }),
+      });
+    });
+
+    it('should render absolute view links under the project base path', async () => {
+      renderSidebar();
+      vi.advanceTimersByTime(100);
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: 'Accessibility' });
+        expect(link).toHaveAttribute(
+          'href',
+          `/project/${projectId}/view/view-1`,
+        );
+      });
+
+      const trendsLink = screen.getByRole('link', { name: 'Build Trends' });
+      expect(trendsLink).toHaveAttribute(
+        'href',
+        `/project/${projectId}/view/view-2`,
+      );
+    });
+
+    it('should not render jenkins-analysis-view entries', async () => {
+      HttpClient.get.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          widgets: [
+            ...mockViews,
+            {
+              id: 'view-3',
+              title: 'Jenkins Analysis',
+              widget: 'jenkins-analysis-view',
+            },
+          ],
+        }),
+      });
+
+      renderSidebar();
+      vi.advanceTimersByTime(100);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: 'Accessibility' }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole('link', { name: 'Jenkins Analysis' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Render guards', () => {
+    it('should not render when primaryObject is null', () => {
+      renderSidebar({ primaryObject: null });
+
+      expect(
+        screen.queryByRole('link', { name: 'Runs' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not render when primaryType is not project', () => {
+      renderSidebar({ primaryType: 'other' });
+
+      expect(
+        screen.queryByRole('link', { name: 'Runs' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not render when project_id param is missing', () => {
+      render(
+        <MemoryRouter initialEntries={['/somewhere']}>
+          <IbutsuContext value={defaultContextValue}>
+            <Routes>
+              <Route path="/*" element={<IbutsuSidebar />} />
+            </Routes>
+          </IbutsuContext>
+        </MemoryRouter>,
+      );
+
+      expect(
+        screen.queryByRole('link', { name: 'Runs' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
urls were getting appended resulting in invalid paths

## Summary by Sourcery

Fix sidebar navigation routing to use full project-scoped paths for all links.

Bug Fixes:
- Prevent sidebar links from appending relative paths that resulted in invalid URLs when navigating within a project.

Enhancements:
- Use the current project_id from route params to generate consistent, project-specific sidebar navigation links.