### PR TITLE
test-history, handle missing component warning

### DIFF
--- a/frontend/src/components/heat-map-wrapper.js
+++ b/frontend/src/components/heat-map-wrapper.js
@@ -27,9 +27,9 @@ const HeatMapWrapper = ({
       {/* X-axis labels row */}
       <div style={{ display: 'flex' }}>
         <div style={{ width: `${yLabelWidth}px`, flexShrink: 0 }} />
-        {xLabels.map((label) => (
+        {xLabels.map((label, xi) => (
           <div
-            key={label}
+            key={xi}
             style={{
               flex: squares ? undefined : 1,
               width: cellSize,
@@ -45,7 +45,7 @@ const HeatMapWrapper = ({
 
       {/* Data rows */}
       {yLabels.map((yLabel, yi) => (
-        <div key={yLabel} style={{ display: 'flex', alignItems: 'center' }}>
+        <div key={yi} style={{ display: 'flex', alignItems: 'center' }}>
           {/* Y-axis label */}
           <div
             style={{
@@ -68,7 +68,7 @@ const HeatMapWrapper = ({
             const style = cellStyle(null, value, min, max, data, xi, yi);
             return (
               <div
-                key={xLabel}
+                key={xi}
                 role="button"
                 tabIndex={0}
                 title={title(value, xi, yi)}

--- a/frontend/src/components/test-history.js
+++ b/frontend/src/components/test-history.js
@@ -151,6 +151,14 @@ const TestHistoryTable = ({ comparisonResults, testResult }) => {
   // Set active filters for result, test_id, component, time, and env based on test result
   useEffect(() => {
     if (testResult) {
+      const componentFilter = testResult?.component
+        ? {
+            field: 'component',
+            operator: 'eq',
+            value: testResult.component,
+          }
+        : {};
+
       const envFilter = testResult?.env
         ? {
             field: 'env',
@@ -185,11 +193,6 @@ const TestHistoryTable = ({ comparisonResults, testResult }) => {
             operator: 'eq',
             value: testResult?.test_id,
           },
-          {
-            field: 'component',
-            operator: 'eq',
-            value: testResult?.component,
-          },
           ...prevFilters.filter(
             (f) =>
               !['result', 'test_id', 'component', 'start_time', 'env'].includes(
@@ -198,7 +201,11 @@ const TestHistoryTable = ({ comparisonResults, testResult }) => {
           ),
         ];
 
-        // Only add timeFilter and envFilter if they have a field property (not empty objects)
+        // Only add componentFilter, timeFilter, and envFilter if they have a field
+        // property (not empty objects) -- the result may not have this metadata set
+        if (componentFilter?.field) {
+          newFilters.push(componentFilter);
+        }
         if (timeFilter?.field) {
           newFilters.push(timeFilter);
         }

--- a/frontend/src/components/test-history.test.js
+++ b/frontend/src/components/test-history.test.js
@@ -98,9 +98,11 @@ vi.mock('./filtering/filtered-table-card', () => {
   return { default: MockFilterTable };
 });
 
+const activeFiltersMock = vi.fn();
 vi.mock('./filtering/active-filters', () => {
   return {
-    default: function ActiveFilters() {
+    default: function ActiveFilters(props) {
+      activeFiltersMock(props);
       return <div data-ouia-component-id="active-filters">Active Filters</div>;
     },
   };
@@ -466,6 +468,63 @@ describe('TestHistoryTable', () => {
       await waitFor(() => {
         expect(screen.getByTestId('filter-table')).toBeInTheDocument();
       });
+    });
+
+    it('should not build a malformed component filter when testResult has no component', async () => {
+      activeFiltersMock.mockClear();
+      const testResultNoComponent = createMockResult({
+        test_id: 'test.module.test_func',
+        component: undefined,
+      });
+
+      render(
+        <MemoryRouter>
+          <TestHistoryTable testResult={testResultNoComponent} />
+        </MemoryRouter>,
+      );
+      vi.advanceTimersByTime(100);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('filter-table')).toBeInTheDocument();
+      });
+
+      // ActiveFilters should still be invoked with an activeFilters array
+      expect(activeFiltersMock).toHaveBeenCalled();
+      expect(activeFiltersMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeFilters: expect.any(Array),
+        }),
+      );
+
+      // None of the activeFilters passed down should ever include a
+      // component filter with a null/undefined value
+      for (const call of activeFiltersMock.mock.calls) {
+        const passedFilters = call[0]?.activeFilters || [];
+        const componentFilter = passedFilters.find(
+          (f) => f.field === 'component',
+        );
+        expect(componentFilter).toBeUndefined();
+      }
+
+      // The non-component filters derived from the test result (result,
+      // test_id, env) should still be passed through in the final state
+      const lastCallFilters =
+        activeFiltersMock.mock.calls[activeFiltersMock.mock.calls.length - 1][0]
+          ?.activeFilters || [];
+
+      expect(lastCallFilters).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: 'result' }),
+          expect.objectContaining({
+            field: 'test_id',
+            value: testResultNoComponent.test_id,
+          }),
+          expect.objectContaining({
+            field: 'env',
+            value: testResultNoComponent.env,
+          }),
+        ]),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary by Sourcery

Handle missing component metadata when building active filters in the test history table and add coverage to prevent malformed component filters.

Bug Fixes:
- Avoid creating a component filter when a test result lacks component metadata to prevent malformed filters downstream.

Tests:
- Add a regression test ensuring no component filter is built when the test result has no component and verifying active filters passed to the child component.