### PR TITLE
Update to react-router v8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^19.2.8",
     "react-error-boundary": "^6.1.2",
     "react-password-strength-bar": "^0.4.1",
-    "react-router": "^7.18.2",
+    "react-router": "^8.3.0",
     "react-simple-oauth2-login": "^0.5.4",
     "react-toastify": "^11.1.0",
     "serve": "^14.2.6",

--- a/frontend/src/components/sidebar.js
+++ b/frontend/src/components/sidebar.js
@@ -64,17 +64,26 @@ const IbutsuSidebar = () => {
         <Nav aria-label="Nav" ouiaId="project-nav">
           <NavList>
             <li className="pf-v6-c-nav__item">
-              <Link to={`${projectBasePath}/dashboard`} className="pf-v6-c-nav__link">
+              <Link
+                to={`${projectBasePath}/dashboard`}
+                className="pf-v6-c-nav__link"
+              >
                 Dashboard
               </Link>
             </li>
             <li className="pf-v6-c-nav__item">
-              <Link to={`${projectBasePath}/runs`} className="pf-v6-c-nav__link">
+              <Link
+                to={`${projectBasePath}/runs`}
+                className="pf-v6-c-nav__link"
+              >
                 Runs
               </Link>
             </li>
             <li className="pf-v6-c-nav__item">
-              <Link to={`${projectBasePath}/results`} className="pf-v6-c-nav__link">
+              <Link
+                to={`${projectBasePath}/results`}
+                className="pf-v6-c-nav__link"
+              >
                 Test Results
               </Link>
             </li>

--- a/frontend/src/components/sidebar.test.js
+++ b/frontend/src/components/sidebar.test.js
@@ -42,10 +42,7 @@ describe('IbutsuSidebar', () => {
       <MemoryRouter initialEntries={[initialRoute]}>
         <IbutsuContext value={mergedContext}>
           <Routes>
-            <Route
-              path="/project/:project_id/*"
-              element={<IbutsuSidebar />}
-            />
+            <Route path="/project/:project_id/*" element={<IbutsuSidebar />} />
           </Routes>
         </IbutsuContext>
       </MemoryRouter>,
@@ -80,10 +77,7 @@ describe('IbutsuSidebar', () => {
 
       await waitFor(() => {
         const link = screen.getByRole('link', { name: 'Dashboard' });
-        expect(link).toHaveAttribute(
-          'href',
-          `/project/${projectId}/dashboard`,
-        );
+        expect(link).toHaveAttribute('href', `/project/${projectId}/dashboard`);
       });
     });
 
@@ -103,10 +97,7 @@ describe('IbutsuSidebar', () => {
 
       await waitFor(() => {
         const link = screen.getByRole('link', { name: 'Test Results' });
-        expect(link).toHaveAttribute(
-          'href',
-          `/project/${projectId}/results`,
-        );
+        expect(link).toHaveAttribute('href', `/project/${projectId}/results`);
       });
     });
 
@@ -116,10 +107,7 @@ describe('IbutsuSidebar', () => {
 
       await waitFor(() => {
         const runsLink = screen.getByRole('link', { name: 'Runs' });
-        expect(runsLink).toHaveAttribute(
-          'href',
-          `/project/${projectId}/runs`,
-        );
+        expect(runsLink).toHaveAttribute('href', `/project/${projectId}/runs`);
         expect(runsLink.getAttribute('href')).not.toContain('dashboard');
       });
     });

--- a/frontend/src/routes/base.js
+++ b/frontend/src/routes/base.js
@@ -30,8 +30,10 @@ export const Base = () => (
             Admin/Profile/App each mount their own descendant <Routes>, so
             their Route path must keep the combined "x/*" form here. Links
             inside those pages use absolute paths (e.g. "/admin/users")
-            rather than relative ones, per React Router v7's
-            v7_relativeSplatPath resolution rules for splat routes.
+            rather than relative ones, since relative link/navigate
+            resolution for splat routes is resolved against the full
+            matched splat path (standard behavior since React Router v7,
+            unchanged in v8).
           */}
           <Route
             path="profile/*"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2601,10 +2601,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.0.1":
-  version: 1.1.1
-  resolution: "cookie@npm:1.1.1"
-  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
+"cookie-es@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "cookie-es@npm:3.1.1"
+  checksum: 10c0/62cf0c325cc547b52477b351e9b5d068b3ffc74f7d143cdf7af854648dd1015fca3aed1498b355365e24b0746333f0b15688ed3a535abecc5ed0a046ae956a84
   languageName: node
   linkType: hard
 
@@ -3979,7 +3979,7 @@ __metadata:
     react-dom: "npm:^19.2.8"
     react-error-boundary: "npm:^6.1.2"
     react-password-strength-bar: "npm:^0.4.1"
-    react-router: "npm:^7.18.2"
+    react-router: "npm:^8.3.0"
     react-simple-oauth2-login: "npm:^0.5.4"
     react-toastify: "npm:^11.1.0"
     serve: "npm:^14.2.6"
@@ -5608,19 +5608,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:^7.18.2":
-  version: 7.18.2
-  resolution: "react-router@npm:7.18.2"
+"react-router@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "react-router@npm:8.3.0"
   dependencies:
-    cookie: "npm:^1.0.1"
-    set-cookie-parser: "npm:^2.6.0"
+    cookie-es: "npm:^3.1.1"
   peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
+    react: ">=19.2.7"
+    react-dom: ">=19.2.7"
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/513b04adf020fcf95124557418e003d16b175765045332858d5817b045e49dfe33b529c4871c57b0cddf24fa5432589ffc45d1a9a5b398b069f02adb755fab15
+  checksum: 10c0/c1277d6a75ff1b77e759bc0142e3257b6cea1eb683595a64a19d7fb341a7b9ba30c81ef8fc426e437c7fbec043bde683462b2463a055b0f58c8e5ad19cdee2ad
   languageName: node
   linkType: hard
 
@@ -5919,13 +5918,6 @@ __metadata:
   bin:
     serve: build/main.js
   checksum: 10c0/7e1668e0d187719dbe4f3de967012ce2263c967f6135d9c630f803b0f173334e1442ab326fcc4c8e6cd4e293d8bd8c773aebab2746ecaa0fb1ab29a36079763b
-  languageName: node
-  linkType: hard
-
-"set-cookie-parser@npm:^2.6.0":
-  version: 2.7.2
-  resolution: "set-cookie-parser@npm:2.7.2"
-  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the frontend routing library to react-router v8 and adjust sidebar code and tests for consistency.

Enhancements:
- Reformat sidebar component and associated tests without changing behavior.

Build:
- Upgrade frontend react-router dependency from v7.18.2 to v8.3.0.

<!-- Generated by sourcery-ai[bot]: start fixed-security -->
- Resolves [GHSA-qwww-vcr4-c8h2 — React Router: RSC Mode CSRF Bypass Allows Action Execution Before 400 Response](https://app.sourcery.ai/dashboard/security/issues?groupId=63522809&issueIds=93767530)
<!-- Generated by sourcery-ai[bot]: end fixed-security -->