### PR TITLE
Use integers for pagination, stop double loading

### DIFF
--- a/frontend/src/components/hooks/use-pagination.js
+++ b/frontend/src/components/hooks/use-pagination.js
@@ -2,22 +2,45 @@ import { useState, useEffect, useCallback } from 'react';
 
 import { useSearchParams } from 'react-router';
 
-const DEFAULT_PAGE_SIZE = '20';
-const DEFAULT_PAGE = '1';
+const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE = 1;
+
+// Parse a numeric search param, falling back to `fallback` only when the
+// value is missing or not a valid number (unlike `Number(x) || fallback`,
+// this does not discard legitimate falsy numbers such as 0). Note that
+// `Number(null)` is `0`, not `NaN`, so the missing-param case (searchParams
+// returns null) must be checked explicitly rather than relying on NaN alone.
+const parseNumericParam = (value, fallback) => {
+  if (value === null || value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
 
 const usePagination = ({ setParams = true }) => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [page, setPage] = useState(searchParams.get('page') || DEFAULT_PAGE);
-  const [pageSize, setPageSize] = useState(
-    searchParams.get('pageSize') || DEFAULT_PAGE_SIZE,
+  // Keep page/pageSize as numbers (not the strings URLSearchParams.get()
+  // returns) since the API always responds with numeric pagination values.
+  // Mismatched types here make fetch effects that depend on [page, pageSize]
+  // re-fire a second time after `setPage(data.pagination.page)` etc., since
+  // e.g. '1' !== 1, causing duplicate requests and a visible double-render.
+  const [page, setPage] = useState(() =>
+    parseNumericParam(searchParams.get('page'), DEFAULT_PAGE),
+  );
+  const [pageSize, setPageSize] = useState(() =>
+    parseNumericParam(searchParams.get('pageSize'), DEFAULT_PAGE_SIZE),
   );
   const [totalItems, setTotalItems] = useState(0);
 
   useEffect(() => {
     if (setParams) {
       const newSearchParams = new URLSearchParams(searchParams);
-      newSearchParams.set('page', page);
-      newSearchParams.set('pageSize', pageSize);
+      // Explicitly stringify: URLSearchParams#set does coerce via ToString
+      // internally, but page/pageSize are numbers now, so stay explicit here
+      // to avoid relying on that implicit coercion.
+      newSearchParams.set('page', String(page));
+      newSearchParams.set('pageSize', String(pageSize));
       setSearchParams(newSearchParams.toString());
       // TODO maintain window hash for Run and Result pages to have pagination params on multiple tabs
     }

--- a/frontend/src/components/hooks/use-pagination.test.js
+++ b/frontend/src/components/hooks/use-pagination.test.js
@@ -1,0 +1,162 @@
+import { useEffect } from 'react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { MemoryRouter, useSearchParams } from 'react-router';
+
+import usePagination from './use-pagination';
+
+// Wrap the hook in a MemoryRouter since usePagination relies on
+// react-router's useSearchParams.
+const wrapper =
+  (initialEntries = ['/']) =>
+  ({ children }) => (
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  );
+
+describe('usePagination', () => {
+  describe('initial page/pageSize types', () => {
+    it('defaults page and pageSize to numbers when no search params are present', () => {
+      const { result } = renderHook(() => usePagination({}), {
+        wrapper: wrapper(['/']),
+      });
+
+      expect(result.current.page).toBe(1);
+      expect(typeof result.current.page).toBe('number');
+      expect(result.current.pageSize).toBe(20);
+      expect(typeof result.current.pageSize).toBe('number');
+    });
+
+    it('parses numeric page/pageSize search params into numbers, not strings', () => {
+      const { result } = renderHook(() => usePagination({}), {
+        wrapper: wrapper(['/?page=3&pageSize=50']),
+      });
+
+      expect(result.current.page).toBe(3);
+      expect(typeof result.current.page).toBe('number');
+      expect(result.current.pageSize).toBe(50);
+      expect(typeof result.current.pageSize).toBe('number');
+    });
+
+    it('falls back to the defaults when search params are not valid numbers', () => {
+      const { result } = renderHook(() => usePagination({}), {
+        wrapper: wrapper(['/?page=abc&pageSize=xyz']),
+      });
+
+      expect(result.current.page).toBe(1);
+      expect(result.current.pageSize).toBe(20);
+    });
+
+    it('preserves an explicit 0 value instead of falling back to the default', () => {
+      // Regression guard for using `Number(x) || fallback`, which would
+      // incorrectly discard a legitimate falsy value like 0.
+      const { result } = renderHook(() => usePagination({}), {
+        wrapper: wrapper(['/?page=0&pageSize=0']),
+      });
+
+      expect(result.current.page).toBe(0);
+      expect(result.current.pageSize).toBe(0);
+    });
+  });
+
+  describe('URL search param sync', () => {
+    it('writes page/pageSize back to the URL as strings', async () => {
+      const { result } = renderHook(
+        () => {
+          const pagination = usePagination({});
+          const [searchParams] = useSearchParams();
+          return { pagination, searchParams };
+        },
+        { wrapper: wrapper(['/']) },
+      );
+
+      await waitFor(() => {
+        expect(result.current.searchParams.get('page')).toBe('1');
+        expect(result.current.searchParams.get('pageSize')).toBe('20');
+      });
+
+      act(() => {
+        result.current.pagination.onSetPage(null, 3);
+      });
+
+      await waitFor(() => {
+        expect(result.current.pagination.page).toBe(3);
+        expect(result.current.searchParams.get('page')).toBe('3');
+      });
+    });
+
+    it('does not sync to the URL when setParams is false', () => {
+      const { result } = renderHook(
+        () => {
+          const pagination = usePagination({ setParams: false });
+          const [searchParams] = useSearchParams();
+          return { pagination, searchParams };
+        },
+        { wrapper: wrapper(['/']) },
+      );
+
+      expect(result.current.searchParams.get('page')).toBeNull();
+      expect(result.current.searchParams.get('pageSize')).toBeNull();
+    });
+  });
+
+  describe('regression: page/pageSize type mismatch causing duplicate fetches', () => {
+    // Mirrors the real-world bug: pages like UserList/RunList call
+    // setPage(data.pagination.page) / setPageSize(data.pagination.pageSize)
+    // with the *numbers* the backend returns, inside a `useEffect` that
+    // depends on [page, pageSize]. When page/pageSize started out as
+    // strings (e.g. '1'), setting them to the equal-looking number (1)
+    // was treated as a real change by React ('1' !== 1), so the effect
+    // fired a second time, causing a duplicate fetch/render. With page and
+    // pageSize consistently stored as numbers, this dependency effect
+    // should only run once for the same logical page.
+    const FetchingConsumer = ({ onFetch }) => {
+      const { page, setPage, pageSize, setPageSize } = usePagination({});
+
+      useEffect(() => {
+        onFetch(page, pageSize);
+        // Simulate an API response echoing back the current page/pageSize
+        // as numbers, just like the real pagination endpoints do.
+        setPage(1);
+        setPageSize(20);
+      }, [page, pageSize, onFetch, setPage, setPageSize]);
+
+      return null;
+    };
+
+    it('only fetches once when the URL already has the default page/pageSize', async () => {
+      const onFetch = vi.fn();
+
+      render(
+        <MemoryRouter initialEntries={['/?page=1&pageSize=20']}>
+          <FetchingConsumer onFetch={onFetch} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(onFetch).toHaveBeenCalledWith(1, 20);
+      });
+
+      // Give any (unwanted) follow-up effect a chance to run before asserting.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(onFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('only fetches once on mount with no search params present', async () => {
+      const onFetch = vi.fn();
+
+      render(
+        <MemoryRouter initialEntries={['/']}>
+          <FetchingConsumer onFetch={onFetch} />
+        </MemoryRouter>,
+      );
+
+      await waitFor(() => {
+        expect(onFetch).toHaveBeenCalledWith(1, 20);
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(onFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/pages/admin/user-list.test.js
+++ b/frontend/src/pages/admin/user-list.test.js
@@ -125,8 +125,8 @@ describe('UserList Component', () => {
         expect(HttpClient.get).toHaveBeenCalledWith(
           ['http://localhost:8080/api', 'admin', 'user'],
           expect.objectContaining({
-            page: '1',
-            pageSize: '20',
+            page: 1,
+            pageSize: 20,
           }),
         );
       });

--- a/frontend/src/pages/result-list.test.js
+++ b/frontend/src/pages/result-list.test.js
@@ -182,13 +182,12 @@ describe('ResultList', () => {
 
       await waitFor(() => {
         // Verify result endpoint is called with expected parameters
-        // Note: page/pageSize come from URL search params as strings
         expect(HttpClient.get).toHaveBeenCalledWith(
           ['http://localhost:8080', 'result'],
           expect.objectContaining({
             estimate: true,
-            page: '1',
-            pageSize: '20',
+            page: 1,
+            pageSize: 20,
             filter: [],
           }),
         );


### PR DESCRIPTION
backend returning integers, frontend storing state as strings

javascript thinks the state is changing because 1 doesn't equal '1'.

## Summary by Sourcery

Normalize frontend pagination state to use numeric values to align with backend responses and prevent duplicate fetches caused by type mismatches.

Bug Fixes:
- Fix double-loading of paginated data by keeping page and pageSize as numbers instead of strings in pagination state.

Tests:
- Update result and admin user list tests to expect numeric page and pageSize parameters in HTTP requests.