### PR TITLE
3.1.0 versioning

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ibutsu API
-  version: 3.0.11
+  version: 3.1.0
 servers:
   - url: /api
 security:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "3.0.11"
+version = "3.1.0"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "3.0.11",
+  "version": "3.1.0",
   "private": true,
   "description": "Ibutsu Frontend",
   "dependencies": {


### PR DESCRIPTION
## Summary by Sourcery

Bump the project version to 3.1.0 across backend API spec, backend project configuration, and frontend package metadata.

Enhancements:
- Align versioning between backend and frontend components to 3.1.0 for the new release.

Build:
- Update backend pyproject and frontend package.json version fields to 3.1.0.