### PR TITLE
Add pool kwargs for sql connection handling

### DIFF
--- a/backend/ibutsu_server/__init__.py
+++ b/backend/ibutsu_server/__init__.py
@@ -20,6 +20,13 @@ from ibutsu_server.util.jwt import decode_token
 
 FRONTEND_PATH = Path("/app/frontend")
 
+_DEFAULT_POOL_RECYCLE = 1800
+
+
+# TODO: Adopt pydantic or environs (https://github.com/sloria/environs) for
+# environment variable scoping and type casting instead of the ad-hoc
+# config.get()/int() handling here and elsewhere in this module.
+
 
 def maybe_sql_url(conf: dict[str, Any]) -> SQLA_URL | None:
     host = conf.get("host") or conf.get("hostname")
@@ -128,18 +135,27 @@ def get_app(**extra_config):
     # Load any extra config
     config.update(extra_config)
 
-    if "SQLALCHEMY_ENGINE_OPTIONS" not in config or not config["SQLALCHEMY_ENGINE_OPTIONS"]:
-        db_uri = config.get("SQLALCHEMY_DATABASE_URI", "")
-        is_sqlite = False
-        if (isinstance(db_uri, str) and db_uri.startswith("sqlite")) or (
-            isinstance(db_uri, SQLA_URL) and db_uri.drivername.startswith("sqlite")
-        ):
-            is_sqlite = True
+    db_uri = config.get("SQLALCHEMY_DATABASE_URI", "")
+    if isinstance(db_uri, SQLA_URL):
+        _drivername = db_uri.drivername
+    elif isinstance(db_uri, str):
+        _drivername = db_uri.split("://", 1)[0].split("+", 1)[0] if "://" in db_uri else ""
+    else:
+        _drivername = ""
 
-        if not is_sqlite:
-            config["SQLALCHEMY_ENGINE_OPTIONS"] = {
-                "connect_args": {"options": "-c statement_timeout=25000"}
-            }
+    if _drivername == "postgresql":
+        caller_opts = config.get("SQLALCHEMY_ENGINE_OPTIONS") or {}
+        caller_connect_args = caller_opts.pop("connect_args", {})
+
+        config["SQLALCHEMY_ENGINE_OPTIONS"] = {
+            "connect_args": {
+                "options": "-c statement_timeout=25000",
+                **caller_connect_args,
+            },
+            "pool_pre_ping": True,
+            "pool_recycle": int(config.get("SQLALCHEMY_POOL_RECYCLE", _DEFAULT_POOL_RECYCLE)),
+            **caller_opts,
+        }
 
     # Configure Celery in the Flask app config
     # Using Celery 6-compatible configuration keys

--- a/backend/tests/test_init.py
+++ b/backend/tests/test_init.py
@@ -634,6 +634,25 @@ def test_get_app_sqlite_engine_options():
     )
 
 
+def test_get_app_mysql_engine_options_skipped():
+    """Test that PostgreSQL-specific engine options are NOT applied to MySQL URIs"""
+    with (
+        patch("ibutsu_server.db.db.init_app"),
+        patch("ibutsu_server.add_superadmin"),
+    ):
+        app = get_app(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI="mysql+pymysql://user:pass@localhost/testdb",
+            CELERY_BROKER_URL="redis://localhost:6379/0",
+            CELERY_RESULT_BACKEND="redis://localhost:6379/0",
+        )
+
+        engine_opts = app.app.config.get("SQLALCHEMY_ENGINE_OPTIONS", {})
+        assert "connect_args" not in engine_opts
+        assert "pool_pre_ping" not in engine_opts
+        assert "pool_recycle" not in engine_opts
+
+
 def test_get_app_postgresql_engine_options():
     """Test get_app sets statement_timeout for PostgreSQL"""
     db_url = SQLA_URL.create(
@@ -661,6 +680,147 @@ def test_get_app_postgresql_engine_options():
         assert "SQLALCHEMY_ENGINE_OPTIONS" in app.app.config
         assert "connect_args" in app.app.config["SQLALCHEMY_ENGINE_OPTIONS"]
         assert "options" in app.app.config["SQLALCHEMY_ENGINE_OPTIONS"]["connect_args"]
+
+
+def test_get_app_postgresql_pool_defaults():
+    """Test get_app sets pool_pre_ping and pool_recycle defaults for PostgreSQL"""
+    db_url = SQLA_URL.create(
+        drivername="postgresql",
+        host="localhost",
+        database="testdb",
+        username="testuser",
+        password="testpass",
+    )
+
+    with (
+        patch("ibutsu_server.db.db.init_app"),
+        patch("ibutsu_server.add_superadmin"),
+    ):
+        app = get_app(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI=db_url,
+            CELERY_BROKER_URL="redis://localhost:6379/0",
+            CELERY_RESULT_BACKEND="redis://localhost:6379/0",
+        )
+
+        engine_opts = app.app.config["SQLALCHEMY_ENGINE_OPTIONS"]
+        assert engine_opts["pool_pre_ping"] is True
+        assert engine_opts["pool_recycle"] == 1800
+
+
+def test_get_app_postgresql_pool_recycle_from_string():
+    """Test pool_recycle is correctly parsed from a string env var value"""
+    db_url = SQLA_URL.create(
+        drivername="postgresql",
+        host="localhost",
+        database="testdb",
+        username="testuser",
+        password="testpass",
+    )
+
+    with (
+        patch("ibutsu_server.db.db.init_app"),
+        patch("ibutsu_server.add_superadmin"),
+    ):
+        app = get_app(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI=db_url,
+            SQLALCHEMY_POOL_RECYCLE="900",
+            CELERY_BROKER_URL="redis://localhost:6379/0",
+            CELERY_RESULT_BACKEND="redis://localhost:6379/0",
+        )
+
+        assert app.app.config["SQLALCHEMY_ENGINE_OPTIONS"]["pool_recycle"] == 900
+
+
+def test_get_app_postgresql_pool_recycle_invalid_raises():
+    """Test a non-numeric pool_recycle value raises instead of silently falling back.
+
+    See the TODO in ibutsu_server.__init__: proper envvar type casting
+    (e.g. via pydantic or environs) should replace this bare int() cast.
+    """
+    db_url = SQLA_URL.create(
+        drivername="postgresql",
+        host="localhost",
+        database="testdb",
+        username="testuser",
+        password="testpass",
+    )
+
+    with (
+        patch("ibutsu_server.db.db.init_app"),
+        patch("ibutsu_server.add_superadmin"),
+        pytest.raises(ValueError, match="30m"),
+    ):
+        get_app(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI=db_url,
+            SQLALCHEMY_POOL_RECYCLE="30m",
+            CELERY_BROKER_URL="redis://localhost:6379/0",
+            CELERY_RESULT_BACKEND="redis://localhost:6379/0",
+        )
+
+
+def test_get_app_postgresql_caller_engine_options_preserved():
+    """Test caller-supplied SQLALCHEMY_ENGINE_OPTIONS keys are preserved"""
+    db_url = SQLA_URL.create(
+        drivername="postgresql",
+        host="localhost",
+        database="testdb",
+        username="testuser",
+        password="testpass",
+    )
+
+    with (
+        patch("ibutsu_server.db.db.init_app"),
+        patch("ibutsu_server.add_superadmin"),
+    ):
+        app = get_app(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI=db_url,
+            SQLALCHEMY_ENGINE_OPTIONS={"pool_size": 20, "pool_pre_ping": False},
+            CELERY_BROKER_URL="redis://localhost:6379/0",
+            CELERY_RESULT_BACKEND="redis://localhost:6379/0",
+        )
+
+        engine_opts = app.app.config["SQLALCHEMY_ENGINE_OPTIONS"]
+        # Caller override wins
+        assert engine_opts["pool_size"] == 20
+        assert engine_opts["pool_pre_ping"] is False
+        # Defaults still present for non-overridden keys
+        assert engine_opts["pool_recycle"] == 1800
+        assert "options" in engine_opts["connect_args"]
+
+
+def test_get_app_postgresql_caller_connect_args_merged():
+    """Test caller connect_args are merged with default statement_timeout"""
+    db_url = SQLA_URL.create(
+        drivername="postgresql",
+        host="localhost",
+        database="testdb",
+        username="testuser",
+        password="testpass",
+    )
+
+    with (
+        patch("ibutsu_server.db.db.init_app"),
+        patch("ibutsu_server.add_superadmin"),
+    ):
+        app = get_app(
+            TESTING=True,
+            SQLALCHEMY_DATABASE_URI=db_url,
+            SQLALCHEMY_ENGINE_OPTIONS={
+                "connect_args": {"sslmode": "require"},
+            },
+            CELERY_BROKER_URL="redis://localhost:6379/0",
+            CELERY_RESULT_BACKEND="redis://localhost:6379/0",
+        )
+
+        connect_args = app.app.config["SQLALCHEMY_ENGINE_OPTIONS"]["connect_args"]
+        # Caller's connect_args merged in
+        assert connect_args["sslmode"] == "require"
+        # Default statement_timeout preserved
+        assert connect_args["options"] == "-c statement_timeout=25000"
 
 
 def test_get_app_celery_config():


### PR DESCRIPTION
include pre-ping and recycle to check the pool state before trying to use a stale connection, and pro-actively recycle connections idle for 30min

## Summary by Sourcery

Improve PostgreSQL connection pool handling to detect stale connections and recycle idle connections proactively.

New Features:
- Configure PostgreSQL connection pools to pre-ping connections and recycle them after a configurable interval, defaulting to 30 minutes.

Bug Fixes:
- Prevent PostgreSQL-specific engine options from being applied to non-PostgreSQL database connections.

Enhancements:
- Merge caller-provided PostgreSQL engine and connection options while preserving the default statement timeout and allowing pool settings to be overridden.

Tests:
- Add coverage for database-specific pool defaults, environment-based recycle configuration, invalid values, and caller option merging.