### PR TITLE
Fix stuck update_run lock causing missing run metadata

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -470,7 +470,8 @@ WIDGET_TYPES = {
 
 RESPONSE_JSON_REQ = f"{HTTPStatus.BAD_REQUEST.phrase} JSON required", HTTPStatus.BAD_REQUEST
 
-LOCK_EXPIRE = 1
+LOCK_EXPIRE = 1  # seconds to wait when trying to *acquire* a lock before giving up
+LOCK_TTL = 300  # seconds before a held lock auto-expires, in case its holder crashes
 
 SOCKET_TIMEOUT = 5
 SOCKET_CONNECT_TIMEOUT = 5

--- a/backend/ibutsu_server/tasks/results.py
+++ b/backend/ibutsu_server/tasks/results.py
@@ -1,5 +1,7 @@
 import logging
 
+from redis.exceptions import LockError
+
 from ibutsu_server.db import db
 from ibutsu_server.db.models import Result, Run
 from ibutsu_server.tasks import shared_task
@@ -7,21 +9,36 @@ from ibutsu_server.util.redis_lock import is_locked, lock
 
 
 @shared_task
-def add_result_start_time(run_id):
+def add_result_start_time(run_id: str) -> None:
     """Update all results in a run to add the 'start_time' field to a result"""
-    if is_locked(run_id):
-        logging.warning(f"{run_id}: Already locked.")
+    # Check this before touching Redis at all: a missing run is a plain DB
+    # read, so there's no reason to pay for a lock round-trip for a run_id
+    # that doesn't exist.
+    run = db.session.get(Run, run_id)
+    if not run:
         return
 
-    with lock(f"update-run-lock-{run_id}"):
-        run = db.session.get(Run, run_id)
-        if not run:
-            return
-        results = db.session.execute(
-            db.select(Result).where(Result.data["metadata"]["run"] == run_id)
-        ).scalars()
-        for result in results:
-            if not result.data.get("start_time"):
-                result.data["start_time"] = result.data.get("starttime")
-                db.session.add(result)
-        db.session.commit()
+    # Use the *same* lock key that update_run() uses for this run_id: these two
+    # tasks must not run concurrently against the same run, and is_locked()
+    # must check the exact key that lock() acquires, or the guard is a no-op.
+    lock_name = f"update-run-lock-{run_id}"
+    if is_locked(lock_name):
+        logging.warning(f"{lock_name}: Already locked, discarding.")
+        return
+
+    try:
+        with lock(lock_name):
+            results = db.session.execute(
+                db.select(Result).where(Result.data["metadata"]["run"] == run_id)
+            ).scalars()
+            for result in results:
+                if not result.data.get("start_time"):
+                    result.data["start_time"] = result.data.get("starttime")
+                    db.session.add(result)
+            db.session.commit()
+    except LockError:
+        # Lost a race to acquire the lock after the is_locked() check above --
+        # another task for this run (add_result_start_time or update_run) is
+        # already in progress. Discard rather than let the uncaught exception
+        # trigger the global task-failure retry handler.
+        logging.warning(f"{lock_name}: Lock acquisition failed, discarding.")

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -57,6 +57,13 @@ def compute_pass_percent(passes: int, tests: int) -> int:
 @shared_task(max_retries=1000)
 def update_run(run_id):
     """Update the run summary from the results, this task will retry 1000 times"""
+    # Check this before touching Redis at all: a missing run is a plain DB
+    # read, so there's no reason to pay for a lock round-trip (or block
+    # waiting on one) for a run_id that doesn't exist.
+    run = db.session.get(Run, run_id)
+    if not run:
+        return
+
     lock_name = f"update-run-lock-{run_id}"
     if is_locked(lock_name):
         logging.warning(f"{lock_name}: Already locked, discarding.")
@@ -64,10 +71,6 @@ def update_run(run_id):
 
     try:
         with lock(lock_name):
-            run = db.session.get(Run, run_id)
-            if not run:
-                return
-
             # initialize some necessary variables
             summary = {
                 "errors": 0,

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -13,17 +13,17 @@ METADATA_TO_COPY = ["jenkins", "tags"]
 COLUMNS_TO_COPY = ["start_time", "env", "component", "project_id", "source"]
 
 
-def _copy_result_metadata(result, metadata, key):
+def _copy_result_metadata(result: Result, metadata: dict, key: str) -> None:
     if not metadata.get(key) and result.data and result.data.get(key):
         metadata[key] = result.data[key]
 
 
-def _copy_column(result, run, key):
+def _copy_column(result: Result, run: Run, key: str) -> None:
     if not getattr(run, key, None):
         setattr(run, key, getattr(result, key, None))
 
 
-def _status_to_summary(status):
+def _status_to_summary(status: str) -> str:
     return {
         "failed": "failures",
         "error": "errors",
@@ -55,7 +55,7 @@ def compute_pass_percent(passes: int, tests: int) -> int:
 
 
 @shared_task(max_retries=1000)
-def update_run(run_id):
+def update_run(run_id: str) -> None:
     """Update the run summary from the results, this task will retry 1000 times"""
     # Check this before touching Redis at all: a missing run is a plain DB
     # read, so there's no reason to pay for a lock round-trip (or block
@@ -135,7 +135,7 @@ def update_run(run_id):
 
 
 @shared_task(max_retries=1)
-def sync_aborted_runs():
+def sync_aborted_runs() -> None:
     """
     When test runs are prematurely aborted, e.g. due to a connection failure or outage, the number
     of tests that are stored in summary.tests on a Run will not match the number of results for that

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -1,10 +1,13 @@
+import logging
 from datetime import UTC, datetime, timedelta
+
+from redis.exceptions import LockError
 
 from ibutsu_server.constants import SYNC_RUN_TIME
 from ibutsu_server.db import db
 from ibutsu_server.db.models import Result, Run
 from ibutsu_server.tasks import shared_task
-from ibutsu_server.util.redis_lock import lock
+from ibutsu_server.util.redis_lock import is_locked, lock
 
 METADATA_TO_COPY = ["jenkins", "tags"]
 COLUMNS_TO_COPY = ["start_time", "env", "component", "project_id", "source"]
@@ -54,65 +57,78 @@ def compute_pass_percent(passes: int, tests: int) -> int:
 @shared_task(max_retries=1000)
 def update_run(run_id):
     """Update the run summary from the results, this task will retry 1000 times"""
-    with lock(f"update-run-lock-{run_id}"):
-        run = db.session.get(Run, run_id)
-        if not run:
-            return
+    lock_name = f"update-run-lock-{run_id}"
+    if is_locked(lock_name):
+        logging.warning(f"{lock_name}: Already locked, discarding.")
+        return
 
-        # initialize some necessary variables
-        summary = {
-            "errors": 0,
-            "failures": 0,
-            "skips": 0,
-            "tests": 0,
-            "xpasses": 0,
-            "xfailures": 0,
-            "collected": run.summary.get("collected", 0) if run.summary else 0,
-        }
-        run.duration = 0.0
-        metadata = run.data or {}
+    try:
+        with lock(lock_name):
+            run = db.session.get(Run, run_id)
+            if not run:
+                return
 
-        # Fetch all the results for the runs and calculate the summary
-        results = (
-            db.session.execute(
-                db.select(Result).where(Result.run_id == run_id).order_by(Result.start_time.asc())
+            # initialize some necessary variables
+            summary = {
+                "errors": 0,
+                "failures": 0,
+                "skips": 0,
+                "tests": 0,
+                "xpasses": 0,
+                "xfailures": 0,
+                "collected": run.summary.get("collected", 0) if run.summary else 0,
+            }
+            run.duration = 0.0
+            metadata = run.data or {}
+
+            # Fetch all the results for the runs and calculate the summary
+            results = (
+                db.session.execute(
+                    db.select(Result)
+                    .where(Result.run_id == run_id)
+                    .order_by(Result.start_time.asc())
+                )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
-        )
 
-        for i, result in enumerate(results):
-            if i == 0:
-                # on the first result, copy over some metadata
-                for column in COLUMNS_TO_COPY:
-                    _copy_column(result, run, column)
+            for i, result in enumerate(results):
+                if i == 0:
+                    # on the first result, copy over some metadata
+                    for column in COLUMNS_TO_COPY:
+                        _copy_column(result, run, column)
 
-                for key in METADATA_TO_COPY:
-                    _copy_result_metadata(result, metadata, key)
+                    for key in METADATA_TO_COPY:
+                        _copy_result_metadata(result, metadata, key)
 
-            key = _status_to_summary(result.result)
-            if key in summary:
-                summary[key] = summary.get(key, 0) + 1
-            # update the number of tests that actually ran
-            summary["tests"] += 1
-            if result.duration:
-                run.duration += result.duration
+                key = _status_to_summary(result.result)
+                if key in summary:
+                    summary[key] = summary.get(key, 0) + 1
+                # update the number of tests that actually ran
+                summary["tests"] += 1
+                if result.duration:
+                    run.duration += result.duration
 
-        # determine the number of passes
-        summary["passes"] = summary["tests"] - (
-            summary["errors"]
-            + summary["xpasses"]
-            + summary["xfailures"]
-            + summary["failures"]
-            + summary["skips"]
-        )
-        summary["pass_percent"] = compute_pass_percent(summary["passes"], summary["tests"])
-        # determine the number of tests that didn't run
-        summary["not_run"] = max(summary["collected"] - summary["tests"], 0)
+            # determine the number of passes
+            summary["passes"] = summary["tests"] - (
+                summary["errors"]
+                + summary["xpasses"]
+                + summary["xfailures"]
+                + summary["failures"]
+                + summary["skips"]
+            )
+            summary["pass_percent"] = compute_pass_percent(summary["passes"], summary["tests"])
+            # determine the number of tests that didn't run
+            summary["not_run"] = max(summary["collected"] - summary["tests"], 0)
 
-        run.update({"summary": summary, "data": metadata})
-        db.session.add(run)
-        db.session.commit()
+            run.update({"summary": summary, "data": metadata})
+            db.session.add(run)
+            db.session.commit()
+    except LockError:
+        # Lost a race to acquire the lock after the is_locked() check above --
+        # another update_run for this run is already in progress. Discard rather
+        # than let the uncaught exception trigger the global task-failure retry.
+        logging.warning(f"{lock_name}: Lock acquisition failed, discarding.")
 
 
 @shared_task(max_retries=1)

--- a/backend/ibutsu_server/util/redis_lock.py
+++ b/backend/ibutsu_server/util/redis_lock.py
@@ -1,6 +1,8 @@
 import logging
+from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 
+from flask import Flask
 from redis import Redis
 from redis.exceptions import LockError
 
@@ -12,7 +14,7 @@ from ibutsu_server.constants import (
 )
 
 
-def get_redis_client(app=None):
+def get_redis_client(app: Flask | None = None) -> Redis:
     if not app:
         from ibutsu_server.util.celery_task import get_flask_app  # noqa: PLC0415
 
@@ -25,13 +27,13 @@ def get_redis_client(app=None):
     )
 
 
-def is_locked(name, app=None):
+def is_locked(name: str, app: Flask | None = None) -> bool:
     redis_client = get_redis_client(app=app)
-    return redis_client.exists(name)
+    return bool(redis_client.exists(name))
 
 
 @contextmanager
-def lock(name, timeout=LOCK_EXPIRE, app=None):
+def lock(name: str, timeout: float = LOCK_EXPIRE, app: Flask | None = None) -> Iterator[None]:
     """Acquire a distributed Redis lock for the duration of the ``with`` block.
 
     ``timeout`` bounds how long to wait to *acquire* the lock (blocking_timeout).

--- a/backend/ibutsu_server/util/redis_lock.py
+++ b/backend/ibutsu_server/util/redis_lock.py
@@ -54,7 +54,15 @@ def lock(name, timeout=LOCK_EXPIRE, app=None):
 
     logging.info(f"Trying to get a lock for {name}")
     if not redis_lock.acquire(blocking=True):
-        logging.info(f"Task {name} is already locked, discarding")
+        # Acquisition can fail for reasons other than another worker holding
+        # the lock (e.g. Redis connectivity issues), so don't claim it's
+        # necessarily "already locked" -- just that we couldn't get it in time.
+        logging.warning(
+            "Failed to acquire lock for %s within %ss; this may be due to lock "
+            "contention or Redis availability issues; discarding task",
+            name,
+            timeout,
+        )
         msg = f"Unable to acquire lock for {name} within {timeout}s"
         raise LockError(msg)
 

--- a/backend/ibutsu_server/util/redis_lock.py
+++ b/backend/ibutsu_server/util/redis_lock.py
@@ -1,10 +1,15 @@
 import logging
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 from redis import Redis
 from redis.exceptions import LockError
 
-from ibutsu_server.constants import LOCK_EXPIRE, SOCKET_CONNECT_TIMEOUT, SOCKET_TIMEOUT
+from ibutsu_server.constants import (
+    LOCK_EXPIRE,
+    LOCK_TTL,
+    SOCKET_CONNECT_TIMEOUT,
+    SOCKET_TIMEOUT,
+)
 
 
 def get_redis_client(app=None):
@@ -27,13 +32,35 @@ def is_locked(name, app=None):
 
 @contextmanager
 def lock(name, timeout=LOCK_EXPIRE, app=None):
+    """Acquire a distributed Redis lock for the duration of the ``with`` block.
+
+    ``timeout`` bounds how long to wait to *acquire* the lock (blocking_timeout).
+    The lock itself is created with a TTL (``LOCK_TTL``) so that if the holder
+    dies (e.g. a worker crash/OOM) before releasing it, the lock self-expires
+    instead of being held forever.
+
+    Raises ``redis.exceptions.LockError`` if the lock can't be acquired within
+    ``timeout`` seconds, rather than swallowing it here. A generator-based
+    context manager must yield at least once for ``__enter__`` to succeed;
+    catching ``LockError`` and falling through without yielding previously
+    made this function return early, which contextlib surfaces as a confusing
+    ``RuntimeError: generator didn't yield`` instead of the real cause.
+    Callers that want to discard the work when the lock is busy should check
+    ``is_locked()`` first and/or catch ``LockError`` around their
+    ``with lock(...):`` block.
+    """
     redis_client = get_redis_client(app=app)
+    redis_lock = redis_client.lock(name, timeout=LOCK_TTL, blocking_timeout=timeout)
+
+    logging.info(f"Trying to get a lock for {name}")
+    if not redis_lock.acquire(blocking=True):
+        logging.info(f"Task {name} is already locked, discarding")
+        msg = f"Unable to acquire lock for {name} within {timeout}s"
+        raise LockError(msg)
 
     try:
-        # Get a lock so that we don't run this task concurrently
-        logging.info(f"Trying to get a lock for {name}")
-        with redis_client.lock(name, blocking_timeout=timeout):
-            yield
-    except LockError:
-        # If this task is locked, discard it so that it doesn't clog up the system
-        logging.info(f"Task {name} is already locked, discarding")
+        yield
+    finally:
+        # Already released, or expired via LOCK_TTL out from under us; nothing to do.
+        with suppress(LockError):
+            redis_lock.release()

--- a/backend/tests/tasks/test_results.py
+++ b/backend/tests/tasks/test_results.py
@@ -3,41 +3,78 @@
 from unittest.mock import patch
 
 import pytest
+from redis.exceptions import LockError
 
 from ibutsu_server.db import db
 from ibutsu_server.db.models import Result
 from ibutsu_server.tasks.results import add_result_start_time
 
 
-def test_add_result_start_time_with_locked_run(flask_app):
-    """Test that the task returns early when the run is already locked"""
+def test_add_result_start_time_with_locked_run(make_project, make_run, flask_app):
+    """Test that the task returns early -- and never touches the DB -- when the
+    per-run lock is already held.
+
+    Regression test for the is_locked()/lock() key mismatch: is_locked() must
+    be called with the *same* key ("update-run-lock-{run_id}") that lock()
+    acquires, not the bare run_id.
+    """
     client, _ = flask_app
-    run_id = "12345678-1234-5678-1234-567812345678"
 
-    with (
-        client.application.app_context(),
-        patch("ibutsu_server.tasks.results.is_locked", return_value=True) as mock_is_locked,
-    ):
-        result = add_result_start_time(run_id)
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        run = make_run(project_id=project.id)
 
-        mock_is_locked.assert_called_once_with(run_id)
+        with (
+            patch("ibutsu_server.tasks.results.is_locked", return_value=True) as mock_is_locked,
+            patch("ibutsu_server.tasks.results.lock") as mock_lock,
+        ):
+            result = add_result_start_time(str(run.id))
+
+        mock_is_locked.assert_called_once_with(f"update-run-lock-{run.id}")
+        mock_lock.assert_not_called()
         assert result is None
 
 
 def test_add_result_start_time_with_nonexistent_run(flask_app):
-    """Test that the task returns early when the run doesn't exist"""
+    """Test that the task returns early when the run doesn't exist.
+
+    The run existence check must happen before any locking, so a bogus/missing
+    run_id never touches Redis at all.
+    """
     client, _ = flask_app
     run_id = "12345678-1234-5678-1234-567812345678"
 
     with (
         client.application.app_context(),
-        patch("ibutsu_server.tasks.results.is_locked", return_value=False),
+        patch("ibutsu_server.tasks.results.is_locked") as mock_is_locked,
         patch("ibutsu_server.tasks.results.lock") as mock_lock,
     ):
         result = add_result_start_time(run_id)
 
-        # Task should enter the lock context but return when run not found
-        mock_lock.assert_called_once_with(f"update-run-lock-{run_id}")
+        assert result is None
+
+        # Never even checked/acquired the lock for a run that doesn't exist.
+        mock_is_locked.assert_not_called()
+        mock_lock.assert_not_called()
+
+
+def test_add_result_start_time_discards_on_lock_error_race(make_project, make_run, flask_app):
+    """If is_locked() races and lock() still raises LockError, the task should
+    discard cleanly instead of letting the exception propagate (which would
+    otherwise trip the global task_failure auto-retry handler)."""
+    client, _ = flask_app
+
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        run = make_run(project_id=project.id)
+
+        with (
+            patch("ibutsu_server.tasks.results.is_locked", return_value=False),
+            patch("ibutsu_server.tasks.results.lock", side_effect=LockError("busy")),
+        ):
+            # Should not raise
+            result = add_result_start_time(str(run.id))
+
         assert result is None
 
 
@@ -189,14 +226,18 @@ def test_add_result_start_time_handles_results_without_starttime(flask_app, make
     ],
 )
 def test_add_result_start_time_with_various_run_ids(flask_app, run_id):
-    """Test that the task handles various UUID formats for run_id"""
+    """Test that the task handles various UUID formats for run_id.
+
+    None of these correspond to a real Run, so the task should discard via
+    the run-existence check without ever touching Redis.
+    """
     client, _ = flask_app
 
     with (
         client.application.app_context(),
-        patch("ibutsu_server.tasks.results.is_locked", return_value=True) as mock_is_locked,
+        patch("ibutsu_server.tasks.results.is_locked") as mock_is_locked,
     ):
         result = add_result_start_time(run_id)
 
-        mock_is_locked.assert_called_once_with(run_id)
+        mock_is_locked.assert_not_called()
         assert result is None

--- a/backend/tests/tasks/test_runs.py
+++ b/backend/tests/tasks/test_runs.py
@@ -3,6 +3,8 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+from redis.exceptions import LockError
+
 from ibutsu_server.db import db
 from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Run
@@ -44,7 +46,10 @@ def test_update_run(make_project, make_run, make_result, flask_app, fixed_time):
         )
 
         # Mock the lock to prevent Redis dependency
-        with patch("ibutsu_server.tasks.runs.lock"):
+        with (
+            patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+            patch("ibutsu_server.tasks.runs.lock"),
+        ):
             update_run(str(run.id))
 
         # Refresh run from database
@@ -63,9 +68,69 @@ def test_update_run_nonexistent(flask_app):
     """Test update_run with non-existent run ID."""
     client, _ = flask_app
 
-    with client.application.app_context(), patch("ibutsu_server.tasks.runs.lock"):
+    with (
+        client.application.app_context(),
+        patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+        patch("ibutsu_server.tasks.runs.lock"),
+    ):
         # Should not raise an error
         result = update_run("00000000-0000-0000-0000-000000000000")
+        assert result is None
+
+
+def test_update_run_skips_when_already_locked(make_project, make_run, make_result, flask_app):
+    """update_run should discard early -- and never touch the DB -- when the
+    per-run lock is already held, instead of entering the lock context at all.
+
+    Regression test for the removed is_locked() guard (reintroduced a fixed
+    RuntimeError: generator didn't yield crash) and for the underlying lock()
+    bug, since is_locked() checks the *same* key ("update-run-lock-{run_id}")
+    that lock() acquires.
+    """
+    client, _ = flask_app
+
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        run = make_run(
+            project_id=project.id,
+            summary={"collected": 1, "tests": 0, "failures": 0, "errors": 0},
+        )
+        make_result(run_id=run.id, project_id=project.id, result="passed")
+
+        with (
+            patch("ibutsu_server.tasks.runs.is_locked", return_value=True) as mock_is_locked,
+            patch("ibutsu_server.tasks.runs.lock") as mock_lock,
+        ):
+            result = update_run(str(run.id))
+
+        mock_is_locked.assert_called_once_with(f"update-run-lock-{run.id}")
+        mock_lock.assert_not_called()
+        assert result is None
+
+        # The run's summary must be untouched -- update_run never ran its body.
+        session.expire_all()
+        untouched_run = db.session.get(Run, run.id)
+        assert untouched_run.summary == {"collected": 1, "tests": 0, "failures": 0, "errors": 0}
+
+
+def test_update_run_discards_on_lock_error_race(make_project, make_run, make_result, flask_app):
+    """If is_locked() races and lock() still raises LockError, update_run should
+    discard cleanly instead of letting the exception propagate (which would
+    otherwise trip the global task_failure auto-retry handler)."""
+    client, _ = flask_app
+
+    with client.application.app_context():
+        project = make_project(name="test-project")
+        run = make_run(project_id=project.id)
+        make_result(run_id=run.id, project_id=project.id, result="passed")
+
+        with (
+            patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+            patch("ibutsu_server.tasks.runs.lock", side_effect=LockError("busy")),
+        ):
+            # Should not raise
+            result = update_run(str(run.id))
+
         assert result is None
 
 
@@ -213,7 +278,10 @@ def test_update_run_with_none_summary(make_project, make_run, make_result, flask
         )
 
         # Mock the lock to prevent Redis dependency
-        with patch("ibutsu_server.tasks.runs.lock"):
+        with (
+            patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+            patch("ibutsu_server.tasks.runs.lock"),
+        ):
             update_run(str(run_id))
 
         # Refresh run from database
@@ -252,7 +320,10 @@ def test_update_run_with_empty_summary(make_project, make_run, make_result, flas
         )
 
         # Mock the lock to prevent Redis dependency
-        with patch("ibutsu_server.tasks.runs.lock"):
+        with (
+            patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+            patch("ibutsu_server.tasks.runs.lock"),
+        ):
             update_run(str(run_id))
 
         # Refresh run from database
@@ -279,7 +350,10 @@ def test_update_run_pass_percent_zero_tests(make_project, make_run, flask_app):
             summary={"collected": 10, "tests": 0, "failures": 0, "errors": 0},
         )
 
-        with patch("ibutsu_server.tasks.runs.lock"):
+        with (
+            patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+            patch("ibutsu_server.tasks.runs.lock"),
+        ):
             update_run(str(run.id))
 
         session.expire_all()
@@ -311,7 +385,10 @@ def test_update_run_pass_percent_floors(make_project, make_run, make_result, fla
                 start_time=fixed_time,
             )
 
-        with patch("ibutsu_server.tasks.runs.lock"):
+        with (
+            patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+            patch("ibutsu_server.tasks.runs.lock"),
+        ):
             update_run(str(run.id))
 
         session.expire_all()

--- a/backend/tests/tasks/test_runs.py
+++ b/backend/tests/tasks/test_runs.py
@@ -65,17 +65,25 @@ def test_update_run(make_project, make_run, make_result, flask_app, fixed_time):
 
 
 def test_update_run_nonexistent(flask_app):
-    """Test update_run with non-existent run ID."""
+    """Test update_run with non-existent run ID.
+
+    The run existence check must happen before any locking, so a bogus/missing
+    run_id never touches Redis at all.
+    """
     client, _ = flask_app
 
     with (
         client.application.app_context(),
-        patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
-        patch("ibutsu_server.tasks.runs.lock"),
+        patch("ibutsu_server.tasks.runs.is_locked") as mock_is_locked,
+        patch("ibutsu_server.tasks.runs.lock") as mock_lock,
     ):
         # Should not raise an error
         result = update_run("00000000-0000-0000-0000-000000000000")
         assert result is None
+
+        # Never even checked/acquired the lock for a run that doesn't exist.
+        mock_is_locked.assert_not_called()
+        mock_lock.assert_not_called()
 
 
 def test_update_run_skips_when_already_locked(make_project, make_run, make_result, flask_app):

--- a/backend/tests/tasks/test_tasks_init.py
+++ b/backend/tests/tasks/test_tasks_init.py
@@ -6,6 +6,7 @@ import pytest
 from celery import Celery
 from redis.exceptions import LockError
 
+from ibutsu_server.constants import LOCK_TTL
 from ibutsu_server.tasks import IbutsuTask, create_celery_app, get_celery_app, lock, task
 
 
@@ -151,52 +152,48 @@ def test_lock_successful(mock_redis_from_url, flask_app):
     # Mock only the Redis external service
     mock_redis_client = MagicMock()
     mock_lock = MagicMock()
-    mock_redis_client.lock.return_value.__enter__.return_value = mock_lock
+    mock_lock.acquire.return_value = True
+    mock_redis_client.lock.return_value = mock_lock
     mock_redis_from_url.return_value = mock_redis_client
 
+    executed = False
     with client.application.app_context(), lock("my-lock"):
         # This code should run
-        pass
+        executed = True
 
-    mock_redis_client.lock.assert_called_once_with("my-lock", blocking_timeout=1)
+    assert executed
+    mock_redis_client.lock.assert_called_once_with("my-lock", timeout=LOCK_TTL, blocking_timeout=1)
+    mock_lock.acquire.assert_called_once_with(blocking=True)
+    mock_lock.release.assert_called_once()
 
 
 @patch("logging.info")
 @patch("redis.Redis.from_url")
 def test_lock_locked(mock_redis_from_url, mock_log_info, flask_app):
-    """Test that the lock handles LockError gracefully."""
+    """Test that a busy lock raises LockError cleanly, instead of the previous
+    behavior of silently swallowing it (which manifested as an unrelated
+    ``RuntimeError: generator didn't yield``)."""
     client, _ = flask_app
 
-    # Mock Redis to raise LockError when trying to acquire lock
+    # Mock Redis so the lock cannot be acquired
     mock_redis_client = MagicMock()
     mock_lock = MagicMock()
-    mock_lock.__enter__.side_effect = LockError("Already locked")
+    mock_lock.acquire.return_value = False
     mock_redis_client.lock.return_value = mock_lock
     mock_redis_from_url.return_value = mock_redis_client
 
     with client.application.app_context():
-        # When a lock cannot be acquired (LockError), the lock context manager
-        # catches it and doesn't yield. This means the code inside the 'with' never runs.
-        # We can test this by checking that the log message was generated.
-
-        # Before the lock call, clear previous log calls
         mock_log_info.reset_mock()
 
-        # Try to use the lock - this will catch LockError internally
         executed = False
-        try:
-            # Create the context manager
-            cm = lock("my-lock")
-            # Try to enter it - this will catch the LockError
-            with cm:
-                executed = True
-        except StopIteration, RuntimeError:
-            # Context manager doesn't yield when lock fails, which is correct
-            pass
+        with pytest.raises(LockError), lock("my-lock"):
+            executed = True
 
-        # Code inside should not have executed
+        # Code inside should not have executed, and the lock was never released
+        # since it was never acquired.
         assert not executed
+        mock_lock.release.assert_not_called()
 
-    # Verify the correct log messages were generated
+    # An informative log message should still be emitted before raising.
     log_calls = [call[0][0] for call in mock_log_info.call_args_list]
     assert any("already locked" in msg.lower() for msg in log_calls)

--- a/backend/tests/tasks/test_tasks_init.py
+++ b/backend/tests/tasks/test_tasks_init.py
@@ -167,9 +167,9 @@ def test_lock_successful(mock_redis_from_url, flask_app):
     mock_lock.release.assert_called_once()
 
 
-@patch("logging.info")
+@patch("logging.warning")
 @patch("redis.Redis.from_url")
-def test_lock_locked(mock_redis_from_url, mock_log_info, flask_app):
+def test_lock_locked(mock_redis_from_url, mock_log_warning, flask_app):
     """Test that a busy lock raises LockError cleanly, instead of the previous
     behavior of silently swallowing it (which manifested as an unrelated
     ``RuntimeError: generator didn't yield``)."""
@@ -183,7 +183,7 @@ def test_lock_locked(mock_redis_from_url, mock_log_info, flask_app):
     mock_redis_from_url.return_value = mock_redis_client
 
     with client.application.app_context():
-        mock_log_info.reset_mock()
+        mock_log_warning.reset_mock()
 
         executed = False
         with pytest.raises(LockError), lock("my-lock"):
@@ -194,6 +194,8 @@ def test_lock_locked(mock_redis_from_url, mock_log_info, flask_app):
         assert not executed
         mock_lock.release.assert_not_called()
 
-    # An informative log message should still be emitted before raising.
-    log_calls = [call[0][0] for call in mock_log_info.call_args_list]
-    assert any("already locked" in msg.lower() for msg in log_calls)
+    # An informative log message should still be emitted before raising --
+    # phrased as a timeout/ambiguous-cause warning, not "already locked",
+    # since acquisition can also fail for non-contention reasons.
+    log_calls = [call.args[0] % call.args[1:] for call in mock_log_warning.call_args_list]
+    assert any("failed to acquire lock" in msg.lower() for msg in log_calls)

--- a/backend/tests/util/test_redis_lock.py
+++ b/backend/tests/util/test_redis_lock.py
@@ -121,3 +121,13 @@ def test_is_locked_checks_key_existence():
         assert is_locked("some-lock")
 
     mock_client.exists.assert_called_once_with("some-lock")
+
+
+def test_is_locked_returns_false_when_key_missing():
+    mock_client = MagicMock()
+    mock_client.exists.return_value = 0
+
+    with patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client):
+        assert not is_locked("some-lock")
+
+    mock_client.exists.assert_called_once_with("some-lock")

--- a/backend/tests/util/test_redis_lock.py
+++ b/backend/tests/util/test_redis_lock.py
@@ -1,0 +1,123 @@
+"""Tests for ibutsu_server.util.redis_lock module"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from redis.exceptions import LockError
+
+from ibutsu_server.constants import LOCK_EXPIRE, LOCK_TTL
+from ibutsu_server.util.redis_lock import is_locked, lock
+
+
+def _mock_redis_client(acquire_return=True):
+    """Build a mock Redis client whose .lock().acquire() returns the given value."""
+    mock_redis_lock = MagicMock()
+    mock_redis_lock.acquire.return_value = acquire_return
+    mock_client = MagicMock()
+    mock_client.lock.return_value = mock_redis_lock
+    return mock_client, mock_redis_lock
+
+
+def test_lock_yields_once_on_success():
+    """When the lock is acquired, the context manager should yield exactly once
+    and release the lock on exit."""
+    mock_client, mock_redis_lock = _mock_redis_client(acquire_return=True)
+
+    with patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client):
+        entered = False
+        with lock("some-lock"):
+            entered = True
+
+    assert entered
+    mock_redis_lock.acquire.assert_called_once_with(blocking=True)
+    mock_redis_lock.release.assert_called_once()
+
+
+def test_lock_sets_ttl_and_blocking_timeout():
+    """The underlying Redis lock must get a real expiry (LOCK_TTL) distinct from
+    the acquire-wait timeout (blocking_timeout), so a crashed holder can't leave
+    the lock stuck forever."""
+    mock_client, _ = _mock_redis_client(acquire_return=True)
+
+    with (
+        patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client),
+        lock("some-lock", timeout=7),
+    ):
+        pass
+
+    mock_client.lock.assert_called_once_with("some-lock", timeout=LOCK_TTL, blocking_timeout=7)
+
+
+def test_lock_uses_default_timeout():
+    mock_client, _ = _mock_redis_client(acquire_return=True)
+
+    with (
+        patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client),
+        lock("some-lock"),
+    ):
+        pass
+
+    mock_client.lock.assert_called_once_with(
+        "some-lock", timeout=LOCK_TTL, blocking_timeout=LOCK_EXPIRE
+    )
+
+
+def test_lock_raises_lock_error_when_busy_without_crashing():
+    """When the lock can't be acquired, lock() must raise a clean LockError
+    instead of returning without yielding (which contextlib would otherwise
+    surface as RuntimeError: generator didn't yield)."""
+    mock_client, mock_redis_lock = _mock_redis_client(acquire_return=False)
+
+    def _enter_lock():
+        with lock("some-lock"):
+            pytest.fail("lock body should never execute when the lock isn't acquired")
+
+    with (
+        patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client),
+        pytest.raises(LockError),
+    ):
+        _enter_lock()
+
+    # Never acquired, so release should never be attempted.
+    mock_redis_lock.release.assert_not_called()
+
+
+def test_lock_releases_even_if_body_raises():
+    """The lock must still be released if the wrapped code raises."""
+    mock_client, mock_redis_lock = _mock_redis_client(acquire_return=True)
+
+    def _raise_inside_lock():
+        with lock("some-lock"):
+            msg = "boom"
+            raise ValueError(msg)
+
+    with (
+        patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client),
+        pytest.raises(ValueError, match="boom"),
+    ):
+        _raise_inside_lock()
+
+    mock_redis_lock.release.assert_called_once()
+
+
+def test_lock_release_lock_error_is_swallowed():
+    """If the lock already expired (LOCK_TTL) or was released elsewhere by the
+    time we try to release it, that LockError on release must not propagate."""
+    mock_client, mock_redis_lock = _mock_redis_client(acquire_return=True)
+    mock_redis_lock.release.side_effect = LockError("already unlocked")
+
+    with (
+        patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client),
+        lock("some-lock"),
+    ):
+        pass  # should not raise on exit despite release() failing
+
+
+def test_is_locked_checks_key_existence():
+    mock_client = MagicMock()
+    mock_client.exists.return_value = 1
+
+    with patch("ibutsu_server.util.redis_lock.get_redis_client", return_value=mock_client):
+        assert is_locked("some-lock")
+
+    mock_client.exists.assert_called_once_with("some-lock")


### PR DESCRIPTION
## Summary

We identified a production run whose Ibutsu run summary/metadata (`component`, `env`, etc.) never got populated. Investigation on the cluster showed `update_run` repeatedly failing with:

```
RuntimeError: generator didn't yield
```

and Redis showing the per-run lock key with `TTL == -1` (i.e. held forever, no expiry).

### Root cause

1. `redis_lock.lock()` used `with redis_client.lock(name, blocking_timeout=timeout): yield`, wrapped in `try/except LockError: log`. When the lock couldn't be acquired, `LockError` was swallowed and the generator returned **without yielding**. `contextlib` converts that into `RuntimeError: generator didn't yield` at the `with lock(...):` call site — a confusing, uncatchable-by-type failure.
2. The Redis lock was created with no `timeout` (TTL) at all, only a `blocking_timeout` (how long to *wait* to acquire it). If a worker died while holding the lock, the lock could never expire, permanently wedging every future `update_run` for that run.
3. `update_run`'s `is_locked()` pre-check (originally added in #468 specifically to avoid hitting the buggy `lock()` swallow-path) was accidentally dropped in c74efc2, reintroducing the crash for any run whose `update_run` overlapped with another in-flight task for the same run — e.g. via the global `task_failure` auto-retry handler retrying a task that raced another instance.

### Fix

- `redis_lock.lock()`:
  - Gives the acquired lock a real TTL (`LOCK_TTL`, 5 minutes) separate from the acquire wait time (`LOCK_EXPIRE`), so a crashed/OOM-killed holder can no longer wedge the lock forever.
  - Always either yields exactly once (success) or raises a clean `redis.exceptions.LockError` *before* yielding -- it can never again silently return without yielding.
- `tasks/runs.py::update_run`:
  - Restores the `is_locked()` guard (using the exact same lock key that `lock()` acquires) to skip cleanly when another `update_run` for the run is already in progress.
  - Also catches `LockError` around the `with lock(...):` block as a defense against the residual acquire-time race, so a rare race can no longer escape as an uncaught exception into the global retry handler.

### Tests

- Added `backend/tests/util/test_redis_lock.py` covering: successful acquire/yield/release, TTL/blocking_timeout passed to Redis correctly, clean `LockError` on failed acquire (no crash), release on body exception, and swallowing a `LockError` on release (already expired/released).
- Added regression tests in `backend/tests/tasks/test_runs.py` for the restored `is_locked()` guard (never touches the DB when locked) and for discarding cleanly on a `LockError` race.
- Updated `backend/tests/tasks/test_tasks_init.py`'s `test_lock_successful`/`test_lock_locked`, which had encoded the old (buggy) contract as expected behavior, to assert the new one.

## Test plan

- [x] `pytest` full backend suite passes (1128 passed)
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [ ] Deploy and confirm no more `RuntimeError: generator didn't yield` in worker logs, and no more permanently-stuck `update-run-lock-*` keys in Redis

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Prevent stuck per-run locks from blocking run metadata updates and causing misleading task failures.

Bug Fixes:
- Prevent run-update and result-start-time tasks from failing or retrying when their per-run Redis lock is already held.
- Ensure Redis locks automatically expire after five minutes so crashed workers cannot permanently block run processing.

Enhancements:
- Make lock acquisition raise a clean LockError and reliably release acquired locks, including when the wrapped operation fails.
- Restore consistent per-run lock checks and handle acquisition races before accessing or updating run data.

Tests:
- Add coverage for Redis lock acquisition, expiration settings, release behavior, failed acquisition, and lock state checks.
- Add regression coverage for locked runs, missing runs, and lock-acquisition races in run and result tasks.