### PR TITLE
Should not have checked for run outside of lock

### DIFF
--- a/backend/ibutsu_server/tasks/results.py
+++ b/backend/ibutsu_server/tasks/results.py
@@ -11,13 +11,6 @@ from ibutsu_server.util.redis_lock import is_locked, lock
 @shared_task
 def add_result_start_time(run_id: str) -> None:
     """Update all results in a run to add the 'start_time' field to a result"""
-    # Check this before touching Redis at all: a missing run is a plain DB
-    # read, so there's no reason to pay for a lock round-trip for a run_id
-    # that doesn't exist.
-    run = db.session.get(Run, run_id)
-    if not run:
-        return
-
     # Use the *same* lock key that update_run() uses for this run_id: these two
     # tasks must not run concurrently against the same run, and is_locked()
     # must check the exact key that lock() acquires, or the guard is a no-op.
@@ -28,6 +21,14 @@ def add_result_start_time(run_id: str) -> None:
 
     try:
         with lock(lock_name):
+            # Fetch the run INSIDE the lock to ensure we see the most recent
+            # committed state and avoid TOCTOU races with the same pattern as
+            # update_run(). The pre-lock optimization created a race where
+            # db.session.get() could read from a stale session under high load.
+            run = db.session.get(Run, run_id)
+            if not run:
+                return
+
             results = db.session.execute(
                 db.select(Result).where(Result.data["metadata"]["run"] == run_id)
             ).scalars()

--- a/backend/ibutsu_server/tasks/runs.py
+++ b/backend/ibutsu_server/tasks/runs.py
@@ -57,13 +57,6 @@ def compute_pass_percent(passes: int, tests: int) -> int:
 @shared_task(max_retries=1000)
 def update_run(run_id: str) -> None:
     """Update the run summary from the results, this task will retry 1000 times"""
-    # Check this before touching Redis at all: a missing run is a plain DB
-    # read, so there's no reason to pay for a lock round-trip (or block
-    # waiting on one) for a run_id that doesn't exist.
-    run = db.session.get(Run, run_id)
-    if not run:
-        return
-
     lock_name = f"update-run-lock-{run_id}"
     if is_locked(lock_name):
         logging.warning(f"{lock_name}: Already locked, discarding.")
@@ -71,6 +64,16 @@ def update_run(run_id: str) -> None:
 
     try:
         with lock(lock_name):
+            # Fetch the run INSIDE the lock to ensure we see the most recent
+            # committed state and avoid TOCTOU races. The pre-lock optimization
+            # of checking run existence before acquiring the lock created a race
+            # where db.session.get() could read from a stale session under high
+            # load, causing update_run to exit early for runs that actually exist,
+            # leading to missing metadata and cascading database issues.
+            run = db.session.get(Run, run_id)
+            if not run:
+                return
+
             # initialize some necessary variables
             summary = {
                 "errors": 0,

--- a/backend/ibutsu_server/util/login.py
+++ b/backend/ibutsu_server/util/login.py
@@ -13,6 +13,6 @@ def validate_activation_code(activation_code):
         decoded_value = base64.urlsafe_b64decode(activation_code)
         if not decoded_value:
             raise ValueError("Decoded value is empty")
-    except binascii.Error, ValueError:
+    except (binascii.Error, ValueError):
         return f"Activation code {activation_code} is not valid", HTTPStatus.BAD_REQUEST
     return None

--- a/backend/ibutsu_server/util/login.py
+++ b/backend/ibutsu_server/util/login.py
@@ -13,6 +13,6 @@ def validate_activation_code(activation_code):
         decoded_value = base64.urlsafe_b64decode(activation_code)
         if not decoded_value:
             raise ValueError("Decoded value is empty")
-    except (binascii.Error, ValueError):
+    except binascii.Error, ValueError:
         return f"Activation code {activation_code} is not valid", HTTPStatus.BAD_REQUEST
     return None

--- a/backend/tests/tasks/test_results.py
+++ b/backend/tests/tasks/test_results.py
@@ -38,24 +38,21 @@ def test_add_result_start_time_with_locked_run(make_project, make_run, flask_app
 def test_add_result_start_time_with_nonexistent_run(flask_app):
     """Test that the task returns early when the run doesn't exist.
 
-    The run existence check must happen before any locking, so a bogus/missing
-    run_id never touches Redis at all.
+    The run existence check happens inside the lock to avoid TOCTOU races.
+    The lock is acquired, the run is checked, and if it doesn't exist,
+    the function returns early without processing.
     """
     client, _ = flask_app
     run_id = "12345678-1234-5678-1234-567812345678"
 
     with (
         client.application.app_context(),
-        patch("ibutsu_server.tasks.results.is_locked") as mock_is_locked,
-        patch("ibutsu_server.tasks.results.lock") as mock_lock,
+        patch("ibutsu_server.tasks.results.is_locked", return_value=False),
+        patch("ibutsu_server.tasks.results.lock"),
     ):
         result = add_result_start_time(run_id)
 
         assert result is None
-
-        # Never even checked/acquired the lock for a run that doesn't exist.
-        mock_is_locked.assert_not_called()
-        mock_lock.assert_not_called()
 
 
 def test_add_result_start_time_discards_on_lock_error_race(make_project, make_run, flask_app):
@@ -228,16 +225,16 @@ def test_add_result_start_time_handles_results_without_starttime(flask_app, make
 def test_add_result_start_time_with_various_run_ids(flask_app, run_id):
     """Test that the task handles various UUID formats for run_id.
 
-    None of these correspond to a real Run, so the task should discard via
-    the run-existence check without ever touching Redis.
+    None of these correspond to a real Run, so the task will acquire the lock,
+    check for the run inside the lock, and return early when not found.
     """
     client, _ = flask_app
 
     with (
         client.application.app_context(),
-        patch("ibutsu_server.tasks.results.is_locked") as mock_is_locked,
+        patch("ibutsu_server.tasks.results.is_locked", return_value=False),
+        patch("ibutsu_server.tasks.results.lock"),
     ):
         result = add_result_start_time(run_id)
 
-        mock_is_locked.assert_not_called()
         assert result is None

--- a/backend/tests/tasks/test_results.py
+++ b/backend/tests/tasks/test_results.py
@@ -45,12 +45,42 @@ def test_add_result_start_time_with_nonexistent_run(flask_app):
     client, _ = flask_app
     run_id = "12345678-1234-5678-1234-567812345678"
 
+    # Track whether db.session.get was called inside the lock context
+    lock_entered = False
+    db_queried_inside_lock = False
+
+    def track_lock_entry(*args, **kwargs):
+        nonlocal lock_entered
+        lock_entered = True
+
+    def track_lock_exit(*args, **kwargs):
+        nonlocal lock_entered
+        lock_entered = False
+
+    def track_db_query(model, run_id):
+        """Track when db.session.get is called"""
+        nonlocal db_queried_inside_lock
+        if lock_entered:
+            db_queried_inside_lock = True
+        return None  # Simulate nonexistent run
+
     with (
         client.application.app_context(),
         patch("ibutsu_server.tasks.results.is_locked", return_value=False),
-        patch("ibutsu_server.tasks.results.lock"),
+        patch("ibutsu_server.tasks.results.lock") as mock_lock,
+        patch("ibutsu_server.tasks.results.db.session.get", side_effect=track_db_query),
     ):
+        # Configure the mock to track context manager entry/exit
+        mock_lock.return_value.__enter__ = track_lock_entry
+        mock_lock.return_value.__exit__ = track_lock_exit
+
         result = add_result_start_time(run_id)
+
+        # Verify lock was called with the correct key
+        mock_lock.assert_called_once_with(f"update-run-lock-{run_id}")
+
+        # Verify the database query happened inside the lock context
+        assert db_queried_inside_lock, "db.session.get must be called inside the lock context"
 
         assert result is None
 
@@ -230,11 +260,41 @@ def test_add_result_start_time_with_various_run_ids(flask_app, run_id):
     """
     client, _ = flask_app
 
+    # Track whether db.session.get was called inside the lock context
+    lock_entered = False
+    db_queried_inside_lock = False
+
+    def track_lock_entry(*args, **kwargs):
+        nonlocal lock_entered
+        lock_entered = True
+
+    def track_lock_exit(*args, **kwargs):
+        nonlocal lock_entered
+        lock_entered = False
+
+    def track_db_query(model, run_id_param):
+        """Track when db.session.get is called"""
+        nonlocal db_queried_inside_lock
+        if lock_entered:
+            db_queried_inside_lock = True
+        return None  # Simulate nonexistent run
+
     with (
         client.application.app_context(),
         patch("ibutsu_server.tasks.results.is_locked", return_value=False),
-        patch("ibutsu_server.tasks.results.lock"),
+        patch("ibutsu_server.tasks.results.lock") as mock_lock,
+        patch("ibutsu_server.tasks.results.db.session.get", side_effect=track_db_query),
     ):
+        # Configure the mock to track context manager entry/exit
+        mock_lock.return_value.__enter__ = track_lock_entry
+        mock_lock.return_value.__exit__ = track_lock_exit
+
         result = add_result_start_time(run_id)
+
+        # Verify lock was called with the correct key
+        mock_lock.assert_called_once_with(f"update-run-lock-{run_id}")
+
+        # Verify the database query happened inside the lock context
+        assert db_queried_inside_lock, "db.session.get must be called inside the lock context"
 
         assert result is None

--- a/backend/tests/tasks/test_results.py
+++ b/backend/tests/tasks/test_results.py
@@ -62,7 +62,6 @@ def test_add_result_start_time_with_nonexistent_run(flask_app):
         nonlocal db_queried_inside_lock
         if lock_entered:
             db_queried_inside_lock = True
-        return None  # Simulate nonexistent run
 
     with (
         client.application.app_context(),
@@ -277,7 +276,6 @@ def test_add_result_start_time_with_various_run_ids(flask_app, run_id):
         nonlocal db_queried_inside_lock
         if lock_entered:
             db_queried_inside_lock = True
-        return None  # Simulate nonexistent run
 
     with (
         client.application.app_context(),

--- a/backend/tests/tasks/test_runs.py
+++ b/backend/tests/tasks/test_runs.py
@@ -67,23 +67,20 @@ def test_update_run(make_project, make_run, make_result, flask_app, fixed_time):
 def test_update_run_nonexistent(flask_app):
     """Test update_run with non-existent run ID.
 
-    The run existence check must happen before any locking, so a bogus/missing
-    run_id never touches Redis at all.
+    The run existence check happens inside the lock to avoid TOCTOU races.
+    The lock is acquired, the run is checked, and if it doesn't exist,
+    the function returns early without processing.
     """
     client, _ = flask_app
 
     with (
         client.application.app_context(),
-        patch("ibutsu_server.tasks.runs.is_locked") as mock_is_locked,
-        patch("ibutsu_server.tasks.runs.lock") as mock_lock,
+        patch("ibutsu_server.tasks.runs.is_locked", return_value=False),
+        patch("ibutsu_server.tasks.runs.lock"),
     ):
         # Should not raise an error
         result = update_run("00000000-0000-0000-0000-000000000000")
         assert result is None
-
-        # Never even checked/acquired the lock for a run that doesn't exist.
-        mock_is_locked.assert_not_called()
-        mock_lock.assert_not_called()
 
 
 def test_update_run_skips_when_already_locked(make_project, make_run, make_result, flask_app):


### PR DESCRIPTION
## Summary by Sourcery

Move run-existence checks inside per-run locks to prevent stale reads from skipping valid task updates.

Bug Fixes:
- Prevent run update tasks from exiting based on stale run-existence checks by performing database reads while holding the per-run lock.

Enhancements:
- Align result timestamp and run summary task locking behavior to avoid time-of-check/time-of-use races.

Tests:
- Update task tests to verify nonexistent runs are checked inside the lock and that the expected lock is acquired.