### PR TITLE
Release 3.1.2

### DIFF
--- a/backend/ibutsu_server/openapi/openapi.yaml
+++ b/backend/ibutsu_server/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Ibutsu API
-  version: 3.1.1
+  version: 3.1.2
 servers:
   - url: /api
 security:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "3.1.1"
+version = "3.1.2"
 name = "ibutsu_server"
 description = "A system to store and query test results and artifacts"
 authors = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibutsu-frontend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "description": "Ibutsu Frontend",
   "dependencies": {


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump the backend, frontend, and OpenAPI versions to 3.1.2.