### PR TITLE
add db migration, results run project index

### DIFF
--- a/backend/alembic/versions/efdaeff6dc95_add_results_run_project_index.py
+++ b/backend/alembic/versions/efdaeff6dc95_add_results_run_project_index.py
@@ -1,0 +1,137 @@
+"""add_results_run_project_index
+
+Revision ID: efdaeff6dc95
+Revises: d18de2b3253f
+Create Date: 2026-08-24 11:50:00.658487
+
+Add composite index on (run_id, project_id) for results table to optimize
+queries on runs with missing component/env metadata. This addresses timeout
+issues when querying large result sets filtered only by run_id and project_id.
+
+"""
+
+import logging
+
+from sqlalchemy import text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "efdaeff6dc95"
+down_revision = "d18de2b3253f"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.versions.efdaeff6dc95")
+
+
+def _is_postgresql():
+    """Check if the current database is PostgreSQL."""
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _index_exists(index_name, table_name) -> bool:
+    """Check if an index already exists in PostgreSQL.
+
+    IMPORTANT: This function uses PostgreSQL-specific pg_indexes catalog.
+    It must only be called when running on PostgreSQL (after _is_postgresql() check).
+    """
+    conn = op.get_bind()
+    result = conn.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_indexes
+                WHERE indexname = :index_name
+                AND tablename = :table_name
+            )
+        """
+        ),
+        {"index_name": index_name, "table_name": table_name},
+    )
+    return result.scalar()
+
+
+def _create_index_if_not_exists(index_name, table_name, columns, **kwargs):
+    """Idempotent index creation for PostgreSQL-specific indexes.
+
+    Returns early if not on PostgreSQL or if index already exists.
+    Creates the index CONCURRENTLY to avoid blocking writes.
+    """
+    if not _is_postgresql():
+        return
+    if _index_exists(index_name, table_name):
+        logger.info(f"Index {index_name} already exists, skipping creation")
+        return
+    logger.info(f"Creating index {index_name} on {table_name} CONCURRENTLY")
+    op.create_index(
+        index_name, table_name, columns, postgresql_concurrently=True, **kwargs
+    )
+
+
+def _drop_index_if_exists(index_name, table_name):
+    """Idempotent index drop for PostgreSQL-specific indexes.
+
+    Returns early if not on PostgreSQL or if index doesn't exist.
+    """
+    if not _is_postgresql():
+        return
+    if not _index_exists(index_name, table_name):
+        logger.info(f"Index {index_name} does not exist, skipping drop")
+        return
+    logger.info(f"Dropping index {index_name} from {table_name}")
+    op.drop_index(index_name, table_name=table_name)
+
+
+def upgrade() -> None:
+    logger.info("Starting migration efdaeff6dc95")
+
+    if not _is_postgresql():
+        logger.info("Non-PostgreSQL dialect; skipping PostgreSQL-specific indexes")
+        return
+
+    logger.info("Creating composite index on (run_id, project_id) for results table")
+
+    # Create index concurrently to avoid blocking writes on large tables
+    # This requires autocommit mode (no transaction)
+    with op.get_context().autocommit_block():
+        # Composite index for run_id + project_id queries (common pattern for run pages)
+        _create_index_if_not_exists(
+            "ix_results_run_id_project_id",
+            "results",
+            ["run_id", "project_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade: drop the composite index.
+
+    NOTE: This downgrade will drop the index even if it existed before this migration.
+    We cannot reliably track index ownership across migration boundaries without
+    additional infrastructure. If the index pre-existed, downgrading will remove it.
+    For safety in production, consider keeping the index (it's relatively harmless)
+    rather than downgrading.
+    """
+    logger.info("Starting downgrade efdaeff6dc95")
+
+    if not _is_postgresql():
+        logger.info("Non-PostgreSQL dialect; skipping PostgreSQL-specific indexes")
+        return
+
+    logger.info("Dropping composite index on (run_id, project_id) from results table")
+
+    # Drop concurrently to avoid blocking writes
+    with op.get_context().autocommit_block():
+        if _index_exists("ix_results_run_id_project_id", "results"):
+            logger.info("Dropping index ix_results_run_id_project_id from results")
+            op.drop_index(
+                "ix_results_run_id_project_id",
+                table_name="results",
+                postgresql_concurrently=True,
+            )
+        else:
+            logger.info(
+                "Index ix_results_run_id_project_id does not exist, skipping drop"
+            )

--- a/backend/alembic/versions/efdaeff6dc95_add_results_run_project_index.py
+++ b/backend/alembic/versions/efdaeff6dc95_add_results_run_project_index.py
@@ -1,20 +1,21 @@
 """add_results_run_project_index
 
-Revision ID: efdaeff6dc95
-Revises: d18de2b3253f
-Create Date: 2026-08-24 11:50:00.658487
-
 Add composite index on (run_id, project_id) for results table to optimize
 queries on runs with missing component/env metadata. This addresses timeout
 issues when querying large result sets filtered only by run_id and project_id.
 
+Revision ID: efdaeff6dc95
+Revises: d18de2b3253f
+Create Date: 2026-08-24 11:50:00.658487
+
 """
 
+import contextlib
 import logging
 
-from sqlalchemy import text
+import sqlalchemy as sa
 
-from alembic import op
+from alembic import context, op
 
 # revision identifiers, used by Alembic.
 revision = "efdaeff6dc95"
@@ -24,114 +25,110 @@ depends_on = None
 
 logger = logging.getLogger("alembic.versions.efdaeff6dc95")
 
+INDEX_NAME = "ix_results_run_id_project_id"
+TABLE_NAME = "results"
+COLUMNS = ["run_id", "project_id"]
 
-def _is_postgresql():
-    """Check if the current database is PostgreSQL."""
-    return op.get_bind().dialect.name == "postgresql"
-
-
-def _index_exists(index_name, table_name) -> bool:
-    """Check if an index already exists in PostgreSQL.
-
-    IMPORTANT: This function uses PostgreSQL-specific pg_indexes catalog.
-    It must only be called when running on PostgreSQL (after _is_postgresql() check).
+_INVALID_INDEX_SQL = sa.text(
     """
+    SELECT i.indisvalid
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = :index_name
+      AND n.nspname = current_schema()
+    """
+)
+
+
+def _is_postgresql() -> bool:
+    """Check if the current database dialect is PostgreSQL."""
+    bind = op.get_bind()
+    if bind:
+        return bind.dialect.name == "postgresql"
+    return op.get_context().dialect.name == "postgresql"
+
+
+def _is_offline() -> bool:
+    """Check if Alembic is running in offline mode."""
+    with contextlib.suppress(NameError, AttributeError):
+        return context.is_offline_mode()
+    return getattr(op.get_context(), "as_sql", False)
+
+
+def _cleanup_invalid_index() -> None:
+    """Drop index if left in an INVALID state by an interrupted concurrent run."""
+    if _is_offline():
+        return
     conn = op.get_bind()
-    result = conn.execute(
-        text(
-            """
-            SELECT EXISTS (
-                SELECT 1
-                FROM pg_indexes
-                WHERE indexname = :index_name
-                AND tablename = :table_name
-            )
-        """
-        ),
-        {"index_name": index_name, "table_name": table_name},
-    )
-    return result.scalar()
-
-
-def _create_index_if_not_exists(index_name, table_name, columns, **kwargs):
-    """Idempotent index creation for PostgreSQL-specific indexes.
-
-    Returns early if not on PostgreSQL or if index already exists.
-    Creates the index CONCURRENTLY to avoid blocking writes.
-    """
-    if not _is_postgresql():
+    if conn is None:
         return
-    if _index_exists(index_name, table_name):
-        logger.info(f"Index {index_name} already exists, skipping creation")
-        return
-    logger.info(f"Creating index {index_name} on {table_name} CONCURRENTLY")
-    op.create_index(
-        index_name, table_name, columns, postgresql_concurrently=True, **kwargs
-    )
-
-
-def _drop_index_if_exists(index_name, table_name):
-    """Idempotent index drop for PostgreSQL-specific indexes.
-
-    Returns early if not on PostgreSQL or if index doesn't exist.
-    """
-    if not _is_postgresql():
-        return
-    if not _index_exists(index_name, table_name):
-        logger.info(f"Index {index_name} does not exist, skipping drop")
-        return
-    logger.info(f"Dropping index {index_name} from {table_name}")
-    op.drop_index(index_name, table_name=table_name)
+    row = conn.execute(_INVALID_INDEX_SQL, {"index_name": INDEX_NAME}).fetchone()
+    if row and not row[0]:
+        logger.warning("Found invalid index %s; dropping before recreating", INDEX_NAME)
+        op.drop_index(
+            INDEX_NAME,
+            table_name=TABLE_NAME,
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
 
 
 def upgrade() -> None:
-    logger.info("Starting migration efdaeff6dc95")
+    logger.info("Starting migration %s", revision)
 
-    if not _is_postgresql():
-        logger.info("Non-PostgreSQL dialect; skipping PostgreSQL-specific indexes")
-        return
-
-    logger.info("Creating composite index on (run_id, project_id) for results table")
-
-    # Create index concurrently to avoid blocking writes on large tables
-    # This requires autocommit mode (no transaction)
-    with op.get_context().autocommit_block():
-        # Composite index for run_id + project_id queries (common pattern for run pages)
-        _create_index_if_not_exists(
-            "ix_results_run_id_project_id",
-            "results",
-            ["run_id", "project_id"],
+    if _is_postgresql():
+        logger.info(
+            "Creating index %s on %s CONCURRENTLY (PostgreSQL)",
+            INDEX_NAME,
+            TABLE_NAME,
+        )
+        # Create index concurrently in an autocommit block to avoid blocking writes
+        with op.get_context().autocommit_block():
+            _cleanup_invalid_index()
+            op.create_index(
+                INDEX_NAME,
+                TABLE_NAME,
+                COLUMNS,
+                unique=False,
+                postgresql_concurrently=True,
+                if_not_exists=True,
+            )
+    else:
+        logger.info("Creating index %s on %s (non-PostgreSQL)", INDEX_NAME, TABLE_NAME)
+        op.create_index(
+            INDEX_NAME,
+            TABLE_NAME,
+            COLUMNS,
             unique=False,
+            if_not_exists=True,
         )
 
 
 def downgrade() -> None:
-    """Downgrade: drop the composite index.
+    logger.info("Starting downgrade %s", revision)
 
-    NOTE: This downgrade will drop the index even if it existed before this migration.
-    We cannot reliably track index ownership across migration boundaries without
-    additional infrastructure. If the index pre-existed, downgrading will remove it.
-    For safety in production, consider keeping the index (it's relatively harmless)
-    rather than downgrading.
-    """
-    logger.info("Starting downgrade efdaeff6dc95")
-
-    if not _is_postgresql():
-        logger.info("Non-PostgreSQL dialect; skipping PostgreSQL-specific indexes")
-        return
-
-    logger.info("Dropping composite index on (run_id, project_id) from results table")
-
-    # Drop concurrently to avoid blocking writes
-    with op.get_context().autocommit_block():
-        if _index_exists("ix_results_run_id_project_id", "results"):
-            logger.info("Dropping index ix_results_run_id_project_id from results")
+    if _is_postgresql():
+        logger.info(
+            "Dropping index %s from %s CONCURRENTLY (PostgreSQL)",
+            INDEX_NAME,
+            TABLE_NAME,
+        )
+        with op.get_context().autocommit_block():
             op.drop_index(
-                "ix_results_run_id_project_id",
-                table_name="results",
+                INDEX_NAME,
+                table_name=TABLE_NAME,
                 postgresql_concurrently=True,
+                if_exists=True,
             )
-        else:
-            logger.info(
-                "Index ix_results_run_id_project_id does not exist, skipping drop"
-            )
+    else:
+        logger.info(
+            "Dropping index %s from %s (non-PostgreSQL)",
+            INDEX_NAME,
+            TABLE_NAME,
+        )
+        op.drop_index(
+            INDEX_NAME,
+            table_name=TABLE_NAME,
+            if_exists=True,
+        )

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -205,7 +205,8 @@ class Result(Model, ModelMixin):
     1. Added to the Alembic migration with dialect checks
     2. Documented in this comment block
 
-    Current PostgreSQL-only indexes (managed via migration):
+    Current indexes (managed via migration):
+    PostgreSQL-only:
     - ix_results_assignee: Index on data->>'assignee'
     - ix_results_classification: Index on data->>'classification'
     - ix_results_exception_name: Index on data->>'exception_name'
@@ -216,6 +217,8 @@ class Result(Model, ModelMixin):
     - ix_results_result_satver_project_id_run_id_snapver: Composite with JSON fields
     - ix_results_requirements: GIN index on data->'requirements'
     - ix_results_tags: GIN index on data->'tags'
+    Cross-dialect:
+    - ix_results_run_id_project_id: Composite index on (run_id, project_id)
     """
 
     __tablename__ = "results"

--- a/backend/tests/test_migration_efdaeff6dc95.py
+++ b/backend/tests/test_migration_efdaeff6dc95.py
@@ -1,0 +1,116 @@
+import importlib.util
+import io
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from ibutsu_server.db.models import Result
+
+
+@pytest.fixture
+def migration_module():
+    """Load the efdaeff6dc95 migration module dynamically."""
+    migration_path = (
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "efdaeff6dc95_add_results_run_project_index.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_efdaeff6dc95", migration_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sqlite_upgrade_and_downgrade(migration_module, monkeypatch):
+    """Test upgrade and downgrade operations on a SQLite database."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text("CREATE TABLE results (id TEXT PRIMARY KEY, run_id TEXT, project_id TEXT)")
+        )
+
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        monkeypatch.setattr(migration_module.op, "_proxy", Operations(ctx), raising=False)
+
+        # Test upgrade creates the index
+        migration_module.upgrade()
+        indexes = conn.execute(
+            sa.text("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='results'")
+        ).fetchall()
+        index_names = [row[0] for row in indexes]
+        assert "ix_results_run_id_project_id" in index_names
+
+        # Test downgrade drops the index
+        migration_module.downgrade()
+        indexes = conn.execute(
+            sa.text("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='results'")
+        ).fetchall()
+        index_names = [row[0] for row in indexes]
+        assert "ix_results_run_id_project_id" not in index_names
+
+
+@pytest.mark.parametrize("bind_returns_none", [False, True])
+def test_postgresql_offline_upgrade_and_downgrade(migration_module, monkeypatch, bind_returns_none):
+    """Test SQL generation in offline mode for PostgreSQL dialect."""
+    buf = io.StringIO()
+    ctx = MigrationContext.configure(
+        url="postgresql://user:pass@localhost/db",
+        opts={"as_sql": True, "output_buffer": buf},
+    )
+    monkeypatch.setattr(migration_module.op, "_proxy", Operations(ctx), raising=False)
+    if bind_returns_none:
+        monkeypatch.setattr(migration_module.op, "get_bind", lambda: None)
+
+    migration_module.upgrade()
+    upgrade_sql = buf.getvalue()
+    assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_run_id_project_id" in upgrade_sql
+
+    buf.seek(0)
+    buf.truncate(0)
+
+    migration_module.downgrade()
+    downgrade_sql = buf.getvalue()
+    assert "DROP INDEX CONCURRENTLY IF EXISTS ix_results_run_id_project_id" in downgrade_sql
+
+
+@pytest.mark.parametrize(
+    ("row_result", "should_drop"),
+    [
+        ((False,), True),
+        ((True,), False),
+        (None, False),
+    ],
+)
+def test_cleanup_invalid_index(migration_module, monkeypatch, row_result, should_drop):
+    """Test that invalid indexes are dropped and valid/missing indexes are untouched."""
+    mock_bind = MagicMock()
+    mock_bind.execute.return_value.fetchone.return_value = row_result
+    mock_drop = MagicMock()
+
+    monkeypatch.setattr(migration_module.op, "get_bind", MagicMock(return_value=mock_bind))
+    monkeypatch.setattr(migration_module.op, "drop_index", mock_drop)
+    monkeypatch.setattr(migration_module, "_is_offline", lambda: False)
+
+    migration_module._cleanup_invalid_index()
+
+    assert mock_drop.called == should_drop
+    if should_drop:
+        mock_drop.assert_called_once_with(
+            migration_module.INDEX_NAME,
+            table_name=migration_module.TABLE_NAME,
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def test_models_documentation():
+    """Ensure ix_results_run_id_project_id is documented in Result docstring."""
+    assert Result.__doc__ is not None
+    doc_entry = "- ix_results_run_id_project_id: Composite index on (run_id, project_id)"
+    assert doc_entry in Result.__doc__


### PR DESCRIPTION
Add index for results, filtering by run id and project id only

## Summary by Sourcery

Add a composite index on results by run ID and project ID to optimize filtered result queries.

Bug Fixes:
- Improve query performance for results filtered by run ID and project ID, helping prevent timeouts on large result sets.

Enhancements:
- Add cross-dialect migration support for the composite results index, including safe concurrent PostgreSQL creation and cleanup of interrupted indexes.

Tests:
- Add migration tests covering SQLite index lifecycle, PostgreSQL SQL generation, and invalid-index cleanup.