### PR TITLE
Update backend and frontend, run/result handling

### DIFF
--- a/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
+++ b/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
@@ -14,7 +14,7 @@ Create Date: 2026-08-27 00:00:00.000000
 
 import logging
 
-from sqlalchemy import text
+from sqlalchemy import inspect
 
 from alembic import op
 
@@ -27,57 +27,25 @@ depends_on = None
 logger = logging.getLogger("alembic.versions.c4d5e6f7a8b9")
 
 
-def _is_postgresql():
-    """Check if the current database is PostgreSQL."""
-    return op.get_bind().dialect.name == "postgresql"
+def _index_exists(index_name: str, table_name: str) -> bool:
+    """Check if an index already exists using dialect-agnostic inspection."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return any(idx.get("name") == index_name for idx in inspector.get_indexes(table_name))
 
 
-def _index_exists(index_name, table_name) -> bool:
-    """Check if an index already exists in PostgreSQL."""
-    conn = op.get_bind()
-    result = conn.execute(
-        text(
-            """
-            SELECT EXISTS (
-                SELECT 1
-                FROM pg_indexes
-                WHERE indexname = :index_name
-                AND tablename = :table_name
-            )
-        """
-        ),
-        {"index_name": index_name, "table_name": table_name},
-    )
-    return result.scalar()
-
-
-def _create_index_if_not_exists(index_name, table_name, columns, **kwargs):
-    """Idempotent index creation."""
-    if not _is_postgresql():
-        # Generic create index for non-PostgreSQL (e.g. SQLite)
-        # Wrap in try/except since SQLite doesn't have a simple index existence check
-        try:
-            op.create_index(index_name, table_name, columns, **kwargs)
-        except Exception as e:
-            # Index may already exist - log and continue
-            logger.warning(f"Could not create index {index_name}: {e}")
-        return
+def _create_index_if_not_exists(index_name: str, table_name: str, columns: list, **kwargs) -> None:
+    """Idempotent index creation across all supported database dialects."""
     if _index_exists(index_name, table_name):
+        logger.info(f"Index {index_name} already exists on {table_name}, skipping creation")
         return
     op.create_index(index_name, table_name, columns, **kwargs)
 
 
-def _drop_index_if_exists(index_name, table_name):
-    """Idempotent index drop."""
-    if not _is_postgresql():
-        # Wrap in try/except for SQLite since we can't check existence easily
-        try:
-            op.drop_index(index_name, table_name=table_name)
-        except Exception as e:
-            # Index may not exist - log and continue
-            logger.warning(f"Could not drop index {index_name}: {e}")
-        return
+def _drop_index_if_exists(index_name: str, table_name: str) -> None:
+    """Idempotent index drop across all supported database dialects."""
     if not _index_exists(index_name, table_name):
+        logger.info(f"Index {index_name} does not exist on {table_name}, skipping drop")
         return
     op.drop_index(index_name, table_name=table_name)
 

--- a/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
+++ b/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
@@ -1,0 +1,108 @@
+"""add_composite_indexes_artifacts_idempotency
+
+Add composite indexes backing the archive-import idempotency lookups, which
+fetch a single existing artifact by (result_id, filename) or (run_id, filename)
+before deciding whether to update its content or insert a new row. The existing
+single-column indexes on result_id/run_id/filename force the planner to scan and
+filter; the composite indexes let the lookup resolve directly.
+
+Revision ID: c4d5e6f7a8b9
+Revises: d18de2b3253f
+Create Date: 2026-08-27 00:00:00.000000
+
+"""
+
+import logging
+
+from sqlalchemy import text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c4d5e6f7a8b9"
+down_revision = "d18de2b3253f"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.versions.c4d5e6f7a8b9")
+
+
+def _is_postgresql():
+    """Check if the current database is PostgreSQL."""
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def _index_exists(index_name, table_name) -> bool:
+    """Check if an index already exists in PostgreSQL."""
+    conn = op.get_bind()
+    result = conn.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_indexes
+                WHERE indexname = :index_name
+                AND tablename = :table_name
+            )
+        """
+        ),
+        {"index_name": index_name, "table_name": table_name},
+    )
+    return result.scalar()
+
+
+def _create_index_if_not_exists(index_name, table_name, columns, **kwargs):
+    """Idempotent index creation."""
+    if not _is_postgresql():
+        # Generic create index for non-PostgreSQL (e.g. SQLite)
+        # Wrap in try/except since SQLite doesn't have a simple index existence check
+        try:
+            op.create_index(index_name, table_name, columns, **kwargs)
+        except Exception as e:
+            # Index may already exist - log and continue
+            logger.warning(f"Could not create index {index_name}: {e}")
+        return
+    if _index_exists(index_name, table_name):
+        return
+    op.create_index(index_name, table_name, columns, **kwargs)
+
+
+def _drop_index_if_exists(index_name, table_name):
+    """Idempotent index drop."""
+    if not _is_postgresql():
+        # Wrap in try/except for SQLite since we can't check existence easily
+        try:
+            op.drop_index(index_name, table_name=table_name)
+        except Exception as e:
+            # Index may not exist - log and continue
+            logger.warning(f"Could not drop index {index_name}: {e}")
+        return
+    if not _index_exists(index_name, table_name):
+        return
+    op.drop_index(index_name, table_name=table_name)
+
+
+def upgrade() -> None:
+    """Create composite indexes on artifacts for import idempotency lookups."""
+    logger.info("Creating composite index ix_artifacts_result_id_filename on artifacts")
+    _create_index_if_not_exists(
+        "ix_artifacts_result_id_filename",
+        "artifacts",
+        ["result_id", "filename"],
+        unique=False,
+    )
+    logger.info("Creating composite index ix_artifacts_run_id_filename on artifacts")
+    _create_index_if_not_exists(
+        "ix_artifacts_run_id_filename",
+        "artifacts",
+        ["run_id", "filename"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop composite indexes on artifacts."""
+    logger.info("Dropping composite index ix_artifacts_run_id_filename from artifacts")
+    _drop_index_if_exists("ix_artifacts_run_id_filename", "artifacts")
+    logger.info("Dropping composite index ix_artifacts_result_id_filename from artifacts")
+    _drop_index_if_exists("ix_artifacts_result_id_filename", "artifacts")

--- a/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
+++ b/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
@@ -1,13 +1,11 @@
 """add_composite_indexes_artifacts_idempotency
 
-Add composite indexes backing the archive-import idempotency lookups, which
-fetch a single existing artifact by (result_id, filename) or (run_id, filename)
-before deciding whether to update its content or insert a new row. The existing
-single-column indexes on result_id/run_id/filename force the planner to scan and
-filter; the composite indexes let the lookup resolve directly.
+Add composite indexes backing importer idempotency lookups:
+- on artifacts: (result_id, filename) and (run_id, filename) for archive imports
+- on results: (run_id, test_id) for JUnit importer per-testcase lookups
 
 Revision ID: c4d5e6f7a8b9
-Revises: d18de2b3253f
+Revises: efdaeff6dc95
 Create Date: 2026-08-27 00:00:00.000000
 
 """
@@ -51,7 +49,7 @@ def _drop_index_if_exists(index_name: str, table_name: str) -> None:
 
 
 def upgrade() -> None:
-    """Create composite indexes on artifacts for import idempotency lookups."""
+    """Create composite indexes on artifacts and results for import idempotency lookups."""
     logger.info("Creating composite index ix_artifacts_result_id_filename on artifacts")
     _create_index_if_not_exists(
         "ix_artifacts_result_id_filename",
@@ -66,10 +64,19 @@ def upgrade() -> None:
         ["run_id", "filename"],
         unique=False,
     )
+    logger.info("Creating composite index ix_results_run_id_test_id on results")
+    _create_index_if_not_exists(
+        "ix_results_run_id_test_id",
+        "results",
+        ["run_id", "test_id"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:
-    """Drop composite indexes on artifacts."""
+    """Drop composite indexes on artifacts and results."""
+    logger.info("Dropping composite index ix_results_run_id_test_id from results")
+    _drop_index_if_exists("ix_results_run_id_test_id", "results")
     logger.info("Dropping composite index ix_artifacts_run_id_filename from artifacts")
     _drop_index_if_exists("ix_artifacts_run_id_filename", "artifacts")
     logger.info("Dropping composite index ix_artifacts_result_id_filename from artifacts")

--- a/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
+++ b/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
@@ -20,7 +20,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c4d5e6f7a8b9"
-down_revision = "d18de2b3253f"
+down_revision = "efdaeff6dc95"
 branch_labels = None
 depends_on = None
 

--- a/backend/ibutsu_server/celery_utils.py
+++ b/backend/ibutsu_server/celery_utils.py
@@ -244,6 +244,9 @@ def create_flask_celery_app(app=None, name="ibutsu_server"):
         task = kwargs.get("sender")
         einfo = kwargs.get("einfo")
         logging.warning("Uncaught exception: %r for task %s", einfo, task)
+        # Do not retry tasks configured with no retries (e.g. non-transient import processing)
+        if not task or getattr(task, "max_retries", None) == 0:
+            return
         # Incremental backoff, starts at a minute and maxes out at 1 hour.
         backoff = min(2**task.request.retries, 3600)
         task.retry(countdown=backoff)

--- a/backend/ibutsu_server/celery_utils.py
+++ b/backend/ibutsu_server/celery_utils.py
@@ -249,10 +249,17 @@ def retry_task_on_exception(*_args, **kwargs):
     einfo = kwargs.get("einfo")
     logging.warning("Uncaught exception: %r for task %s", einfo, task)
     # Do not retry tasks configured with no retries (e.g. non-transient import processing)
-    if not task or getattr(task, "max_retries", None) == 0:
+    if not task:
+        return
+    max_retries = getattr(task, "max_retries", None)
+    if max_retries == 0:
+        return
+    request = getattr(task, "request", None)
+    retries = getattr(request, "retries", 0) if request else 0
+    if max_retries is not None and retries >= max_retries:
         return
     # Incremental backoff, starts at a minute and maxes out at 1 hour.
-    backoff = min(2**task.request.retries, 3600)
+    backoff = min(2**retries, 3600)
     task.retry(countdown=backoff)
 
 

--- a/backend/ibutsu_server/celery_utils.py
+++ b/backend/ibutsu_server/celery_utils.py
@@ -238,20 +238,22 @@ def create_flask_celery_app(app=None, name="ibutsu_server"):
         },
     }
 
-    @signals.task_failure.connect
-    def retry_task_on_exception(*_args, **kwargs):
-        """Retry a task automatically when it fails"""
-        task = kwargs.get("sender")
-        einfo = kwargs.get("einfo")
-        logging.warning("Uncaught exception: %r for task %s", einfo, task)
-        # Do not retry tasks configured with no retries (e.g. non-transient import processing)
-        if not task or getattr(task, "max_retries", None) == 0:
-            return
-        # Incremental backoff, starts at a minute and maxes out at 1 hour.
-        backoff = min(2**task.request.retries, 3600)
-        task.retry(countdown=backoff)
+    signals.task_failure.connect(retry_task_on_exception)
 
     return celery_app
 
 
-__all__ = ["create_broker_celery_app", "create_flask_celery_app"]
+def retry_task_on_exception(*_args, **kwargs):
+    """Retry a task automatically when it fails"""
+    task = kwargs.get("sender")
+    einfo = kwargs.get("einfo")
+    logging.warning("Uncaught exception: %r for task %s", einfo, task)
+    # Do not retry tasks configured with no retries (e.g. non-transient import processing)
+    if not task or getattr(task, "max_retries", None) == 0:
+        return
+    # Incremental backoff, starts at a minute and maxes out at 1 hour.
+    backoff = min(2**task.request.retries, 3600)
+    task.retry(countdown=backoff)
+
+
+__all__ = ["create_broker_celery_app", "create_flask_celery_app", "retry_task_on_exception"]

--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -32,18 +32,21 @@ OAUTH_CONFIG = {
 }
 ALLOWED_TRUE_BOOLEANS = ["y", "t", "1"]
 ARRAY_FIELDS = ["metadata.tags", "metadata.markers", "metadata.annotations"]
-NUMERIC_FIELDS = [
+INTEGER_FIELDS = {
+    "summary.pass_percent",
+}
+FLOAT_FIELDS = {
     "duration",
     "start_time",
     "summary.failures",
     "summary.errors",
-    "summary.pass_percent",
     "summary.passes",
     "summary.skips",
     "summary.tests",
     "summary.xfailures",
     "summary.xpasses",
-]
+}
+NUMERIC_FIELDS = INTEGER_FIELDS | FLOAT_FIELDS
 MAX_PAGE_SIZE = 500  # max page size API can return, page_sizes over this are sent to a worker
 HEATMAP_MAX_BUILDS = 40  # max for number of builds that are possible to display in heatmap
 BARCHART_MAX_BUILDS = 150  # max for number of builds possible to display in bar chart

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -92,9 +92,14 @@ class ModelMixin:
         # missing keys from old, so incoming values win while existing-only keys
         # are preserved.
         # Example: existing={a:1, b:2}, incoming={b:3, c:4} → result={a:1, b:3, c:4}
-        if "metadata" in values_dict and "metadata" in record_dict:
-            merge_dicts(values_dict["metadata"], record_dict["metadata"])
-            values_dict["metadata"] = record_dict.pop("metadata")
+        if "metadata" in record_dict:
+            incoming_meta = record_dict.pop("metadata")
+            existing_meta = values_dict.get("metadata")
+            if isinstance(existing_meta, dict) and isinstance(incoming_meta, dict):
+                merge_dicts(existing_meta, incoming_meta)
+                values_dict["metadata"] = incoming_meta
+            elif incoming_meta is not None:
+                values_dict["metadata"] = incoming_meta
         values_dict.update(record_dict)
         if "metadata" in values_dict:
             values_dict["data"] = values_dict.pop("metadata")

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -78,6 +78,13 @@ class ModelMixin:
     def update(self, record_dict):
         if "id" in record_dict:
             record_dict.pop("id")
+        # Parse datetime strings to datetime objects
+        mapper = inspect(self.__class__)
+        for column in mapper.columns:
+            if isinstance(column.type, DateTime) and column.key in record_dict:
+                value = record_dict[column.key]
+                if isinstance(value, str):
+                    record_dict[column.key] = datetime.fromisoformat(value.replace("Z", "+00:00"))
         values_dict = self.to_dict()
         # Deep merge metadata to preserve existing fields not in the update
         if "metadata" in values_dict and "metadata" in record_dict:

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -55,12 +55,8 @@ class ModelMixin:
         return record_dict
 
     @classmethod
-    def from_dict(cls, **record_dict):
-        # because metadata is a reserved attr name, translate it to data
-        if "metadata" in record_dict:
-            record_dict["data"] = record_dict.pop("metadata") or {}
-
-        # Parse datetime strings to datetime objects
+    def _parse_datetime_fields(cls, record_dict):
+        """Parse datetime string fields to datetime objects in-place"""
         mapper = inspect(cls)
         for column in mapper.columns:
             if isinstance(column.type, DateTime) and column.key in record_dict:
@@ -68,6 +64,15 @@ class ModelMixin:
                 if isinstance(value, str):
                     # Parse ISO format datetime strings
                     record_dict[column.key] = datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+    @classmethod
+    def from_dict(cls, **record_dict):
+        # because metadata is a reserved attr name, translate it to data
+        if "metadata" in record_dict:
+            record_dict["data"] = record_dict.pop("metadata") or {}
+
+        # Parse datetime strings to datetime objects
+        cls._parse_datetime_fields(record_dict)
 
         # remove empty keys
         for key in list(record_dict.keys()):
@@ -79,14 +84,14 @@ class ModelMixin:
         if "id" in record_dict:
             record_dict.pop("id")
         # Parse datetime strings to datetime objects
-        mapper = inspect(self.__class__)
-        for column in mapper.columns:
-            if isinstance(column.type, DateTime) and column.key in record_dict:
-                value = record_dict[column.key]
-                if isinstance(value, str):
-                    record_dict[column.key] = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        self.__class__._parse_datetime_fields(record_dict)
         values_dict = self.to_dict()
-        # Deep merge metadata to preserve existing fields not in the update
+        # Deep merge metadata so keys already stored on the record survive an
+        # update that doesn't mention them (e.g. an archive re-import that lacks
+        # metadata a user set later). merge_dicts(old, new) mutates new by adding
+        # missing keys from old, so incoming values win while existing-only keys
+        # are preserved.
+        # Example: existing={a:1, b:2}, incoming={b:3, c:4} → result={a:1, b:3, c:4}
         if "metadata" in values_dict and "metadata" in record_dict:
             merge_dicts(values_dict["metadata"], record_dict["metadata"])
             values_dict["metadata"] = record_dict.pop("metadata")

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 # SQLAlchemy 2.0+ imports
 from sqlalchemy import (
+    Index,
     Text as sa_text,  # noqa: N813
     cast as sa_cast,
     delete as sqlalchemy_delete,
@@ -81,6 +82,7 @@ class ModelMixin:
         return cls(**record_dict)
 
     def update(self, record_dict):
+        record_dict = record_dict.copy()
         if "id" in record_dict:
             record_dict.pop("id")
         # Normalize data to metadata so callers using either key are handled
@@ -125,6 +127,10 @@ class FileMixin(ModelMixin):
 
 class Artifact(Model, FileMixin):
     __tablename__ = "artifacts"
+    __table_args__ = (
+        Index("ix_artifacts_result_id_filename", "result_id", "filename"),
+        Index("ix_artifacts_run_id_filename", "run_id", "filename"),
+    )
     result_id = Column(PortableUUID(), ForeignKey("results.id"), index=True)
     run_id = Column(PortableUUID(), ForeignKey("runs.id"), index=True)
     filename = Column(Text, index=True)

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -1,9 +1,9 @@
+import copy
 from datetime import datetime
 from uuid import uuid4
 
 # SQLAlchemy 2.0+ imports
 from sqlalchemy import (
-    Index,
     Text as sa_text,  # noqa: N813
     cast as sa_cast,
     delete as sqlalchemy_delete,
@@ -100,7 +100,7 @@ class ModelMixin:
         # are preserved.
         # Example: existing={a:1, b:2}, incoming={b:3, c:4} → result={a:1, b:3, c:4}
         if "metadata" in record_dict:
-            incoming_meta = record_dict.pop("metadata")
+            incoming_meta = copy.deepcopy(record_dict.pop("metadata"))
             existing_meta = values_dict.get("metadata")
             if isinstance(existing_meta, dict) and isinstance(incoming_meta, dict):
                 merge_dicts(existing_meta, incoming_meta)
@@ -126,11 +126,15 @@ class FileMixin(ModelMixin):
 
 
 class Artifact(Model, FileMixin):
+    """
+    Artifact model representing files associated with runs or results.
+
+    Composite indexes managed via Alembic migrations (c4d5e6f7a8b9):
+    - ix_artifacts_result_id_filename: Composite index on (result_id, filename)
+    - ix_artifacts_run_id_filename: Composite index on (run_id, filename)
+    """
+
     __tablename__ = "artifacts"
-    __table_args__ = (
-        Index("ix_artifacts_result_id_filename", "result_id", "filename"),
-        Index("ix_artifacts_run_id_filename", "run_id", "filename"),
-    )
     result_id = Column(PortableUUID(), ForeignKey("results.id"), index=True)
     run_id = Column(PortableUUID(), ForeignKey("runs.id"), index=True)
     filename = Column(Text, index=True)
@@ -247,6 +251,7 @@ class Result(Model, ModelMixin):
     - ix_results_tags: GIN index on data->'tags'
     Cross-dialect:
     - ix_results_run_id_project_id: Composite index on (run_id, project_id)
+    - ix_results_run_id_test_id: Composite index on (run_id, test_id)
     """
 
     __tablename__ = "results"

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -83,6 +83,11 @@ class ModelMixin:
     def update(self, record_dict):
         if "id" in record_dict:
             record_dict.pop("id")
+        # Normalize data to metadata so callers using either key are handled
+        if "data" in record_dict and "metadata" not in record_dict:
+            record_dict["metadata"] = record_dict.pop("data")
+        elif "data" in record_dict and "metadata" in record_dict:
+            record_dict.pop("data")
         # Parse datetime strings to datetime objects
         self.__class__._parse_datetime_fields(record_dict)
         values_dict = self.to_dict()

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from sqlalchemy import Text, cast
 from sqlalchemy.dialects.postgresql import array
 
-from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
+from ibutsu_server.constants import ARRAY_FIELDS, FLOAT_FIELDS, INTEGER_FIELDS, NUMERIC_FIELDS
 from ibutsu_server.db.types import PortableUUID
 
 # gte/lte each have two operator spellings, and both are actively used (not
@@ -96,8 +96,10 @@ def string_to_column(field, model):
                 continue
             column = column[part]
 
-        if field in NUMERIC_FIELDS:
+        if field in INTEGER_FIELDS:
             column = column.as_integer()
+        elif field in FLOAT_FIELDS:
+            column = column.as_float()
         elif field not in ARRAY_FIELDS:
             column = column.as_string()
     else:

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -25,42 +25,58 @@ uuid_pattern = re.compile(
 
 @shared_task
 def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=None):
-    """Create a result with artifacts, used in the archive importer"""
+    """Create or update a result with artifacts, used in the archive importer"""
     old_id = None
     result_id = result.get("id")
     result_record = db.session.get(Result, result_id) if is_uuid(result_id) else None
+
+    # Merge metadata
+    if metadata:
+        result["metadata"] = result.get("metadata", {})
+        result["metadata"].update(metadata)
+    # promote user_properties to the level of metadata
+    if "user_properties" in result.get("metadata", {}):
+        user_properties = result["metadata"].pop("user_properties")
+        result["metadata"].update(user_properties)
+
+    # Support both top-level and metadata for component and env
+    result["env"] = result.get("env") or result.get("metadata", {}).get("env")
+    result["component"] = result.get("component") or result.get("metadata", {}).get("component")
+    result["run_id"] = run_id
+    if project_id:
+        result["project_id"] = project_id
+
     if result_record:
-        result_record.run_id = run_id
+        result_record.update(result)
     else:
-        old_id = result["id"]
-        if "id" in result:
-            result.pop("id")
-        result["run_id"] = run_id
-        if project_id:
-            result["project_id"] = project_id
-        if metadata:
-            result["metadata"] = result.get("metadata", {})
-            result["metadata"].update(metadata)
-        # promote user_properties to the level of metadata
-        if "user_properties" in result.get("metadata", {}):
-            user_properties = result["metadata"].pop("user_properties")
-            result["metadata"].update(user_properties)
-        result["env"] = result.get("metadata", {}).get("env")
-        result["component"] = result.get("metadata", {}).get("component")
+        if not is_uuid(result_id) and "id" in result:
+            old_id = result.pop("id")
         result_record = Result.from_dict(**result)
-    db.session.add(result_record)
-    db.session.commit()
-    result = result_record.to_dict()
+        db.session.add(result_record)
+
+    db.session.flush()
+
     for artifact in artifacts:
-        db.session.add(
-            Artifact(
-                filename=artifact.name.split("/")[-1],
-                result_id=result["id"],
-                data={"contentType": "text/plain", "resultId": result["id"]},
-                content=tar.extractfile(artifact).read(),
+        filename = artifact.name.split("/")[-1]
+        existing_artifact = db.session.execute(
+            db.select(Artifact).where(
+                Artifact.result_id == result_record.id,
+                Artifact.filename == filename,
             )
-        )
-    db.session.commit()
+        ).scalar_one_or_none()
+        content = tar.extractfile(artifact).read()
+        if existing_artifact:
+            existing_artifact.content = content
+        else:
+            db.session.add(
+                Artifact(
+                    filename=filename,
+                    result_id=result_record.id,
+                    data={"contentType": "text/plain", "resultId": result_record.id},
+                    content=content,
+                )
+            )
+    db.session.flush()
     return old_id
 
 
@@ -337,7 +353,7 @@ def run_junit_import(import_):  # noqa: PLR0912
 
             result = Result.from_dict(**result_dict)
             db.session.add(result)
-            db.session.commit()
+            db.session.flush()
             _add_artifacts(result, testcase, traceback)
 
             if traceback:
@@ -369,7 +385,7 @@ def run_junit_import(import_):  # noqa: PLR0912
                         content=system_err,
                     )
                 )
-            db.session.commit()
+            db.session.flush()
 
     # Check if we need to update the run
     if not run.duration:
@@ -485,14 +501,25 @@ def run_archive_import(import_):  # noqa: PLR0912
         import_record.data["run_id"] = [run.id]
         # Loop through any artifacts associated with the run and upload them
         for artifact in run_artifacts:
-            db.session.add(
-                Artifact(
-                    filename=artifact.name.split("/")[-1],
-                    run_id=run.id,
-                    data={"contentType": "text/plain", "runId": run.id},
-                    content=tar.extractfile(artifact).read(),
+            filename = artifact.name.split("/")[-1]
+            existing_artifact = db.session.execute(
+                db.select(Artifact).where(
+                    Artifact.run_id == run.id,
+                    Artifact.filename == filename,
                 )
-            )
+            ).scalar_one_or_none()
+            content = tar.extractfile(artifact).read()
+            if existing_artifact:
+                existing_artifact.content = content
+            else:
+                db.session.add(
+                    Artifact(
+                        filename=filename,
+                        run_id=run.id,
+                        data={"contentType": "text/plain", "runId": run.id},
+                        content=content,
+                    )
+                )
         # Now loop through all the results, and create or update them
         for result in results:
             artifacts = result_artifacts.get(result["id"], [])
@@ -504,6 +531,7 @@ def run_archive_import(import_):  # noqa: PLR0912
                 project_id=run_dict.get("project_id") or import_record.data.get("project_id"),
                 metadata=metadata,
             )
+        db.session.commit()
     # Update the import record
     log.info("Setting import status to done")
     _update_import_status(import_record, "done")

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -1,6 +1,7 @@
 import json
 import re
 import tarfile
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from io import BytesIO
 
@@ -30,18 +31,19 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
     result_id = result.get("id")
     result_record = db.session.get(Result, result_id) if is_uuid(result_id) else None
 
-    # Merge metadata
+    # Merge metadata - normalize to dict to handle null metadata gracefully
+    result_metadata = result.get("metadata") or {}
     if metadata:
-        result["metadata"] = result.get("metadata", {})
-        result["metadata"].update(metadata)
+        result_metadata.update(metadata)
+        result["metadata"] = result_metadata
     # promote user_properties to the level of metadata
-    if "user_properties" in result.get("metadata", {}):
-        user_properties = result["metadata"].pop("user_properties")
-        result["metadata"].update(user_properties)
+    if "user_properties" in result_metadata:
+        user_properties = result_metadata.pop("user_properties")
+        result_metadata.update(user_properties)
 
     # Support both top-level and metadata for component and env
-    result["env"] = result.get("env") or result.get("metadata", {}).get("env")
-    result["component"] = result.get("component") or result.get("metadata", {}).get("component")
+    result["env"] = result.get("env") or result_metadata.get("env")
+    result["component"] = result.get("component") or result_metadata.get("component")
     result["run_id"] = run_id
     if project_id:
         result["project_id"] = project_id
@@ -58,12 +60,25 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
 
     for artifact in artifacts:
         filename = artifact.name.split("/")[-1]
-        existing_artifact = db.session.execute(
-            db.select(Artifact).where(
-                Artifact.result_id == result_record.id,
-                Artifact.filename == filename,
+        # Handle potential legacy duplicates by fetching all matching artifacts
+        existing_artifacts = (
+            db.session.execute(
+                db.select(Artifact)
+                .where(
+                    Artifact.result_id == result_record.id,
+                    Artifact.filename == filename,
+                )
+                .order_by(Artifact.upload_date, Artifact.id)
             )
-        ).scalar_one_or_none()
+            .scalars()
+            .all()
+        )
+
+        existing_artifact = existing_artifacts[0] if existing_artifacts else None
+        # Clean up any legacy duplicates
+        for duplicate in existing_artifacts[1:]:
+            db.session.delete(duplicate)
+
         content = tar.extractfile(artifact).read()
         if existing_artifact:
             existing_artifact.content = content
@@ -92,6 +107,27 @@ def _update_import_status(import_record, status):
         db.session.commit()
     else:
         log.error(f"Could not find import with ID {import_record.id} to update status to {status}")
+
+
+@contextmanager
+def _import_failure_handling(import_record):
+    """Roll back and mark an import as errored if processing raises.
+
+    The importers build up the run and all of its results/artifacts inside a
+    single transaction, committing only once everything has been staged. If any
+    step fails part-way through -- an unexpected exception, a malformed archive,
+    or a Celery soft time limit -- roll the whole transaction back so we never
+    leave a run committed without its results/artifacts, and flip the import
+    status to ``error`` so it isn't left stuck in ``running``. The original
+    exception is re-raised so Celery still records the task as failed.
+    """
+    try:
+        yield
+    except Exception:
+        log.exception(f"Import {import_record.id} failed during processing")
+        db.session.rollback()
+        _update_import_status(import_record, "error")
+        raise
 
 
 def _get_ts_element(tree):
@@ -161,7 +197,9 @@ def _add_artifacts(result, testcase, traceback):
                 content=system_err,
             )
         )
-    db.session.commit()
+    # Flush rather than commit so these artifacts remain part of the importing
+    # task's transaction and roll back with the run/result if a later step fails.
+    db.session.flush()
 
 
 def _get_properties(xml_element: objectify.Element) -> dict:
@@ -239,171 +277,149 @@ def run_junit_import(import_):  # noqa: PLR0912
     if not import_file:
         _update_import_status(import_record, "error")
         return
-    # Parse the XML and create a run object(s)
-    tree = objectify.fromstring(import_file.content)
-    import_record.data["run_id"] = []
-    # Use current time as start time if no start time is present
-    start_time = parser.parse(tree.get("timestamp")) if tree.get("timestamp") else datetime.now(UTC)
-    run_dict = {
-        "created": datetime.now(UTC),
-        "start_time": start_time,
-        "duration": float(tree.get("time", 0.0)),
-        "summary": {
-            "errors": int(tree.get("errors", 0)),
-            "failures": int(tree.get("failures", 0)),
-            "skips": int(tree.get("skipped", 0)),
-            "xfailures": int(tree.get("xfailures", 0)),
-            "xpasses": int(tree.get("xpasses", 0)),
-            "tests": int(tree.get("tests", 0)),
-        },
-    }
+    # Process the JUnit file within a single transaction so a failure part-way
+    # through rolls back cleanly and marks the import as errored.
+    with _import_failure_handling(import_record):
+        # Parse the XML and create a run object(s)
+        tree = objectify.fromstring(import_file.content)
+        import_record.data["run_id"] = []
+        # Use current time as start time if no start time is present
+        start_time = (
+            parser.parse(tree.get("timestamp")) if tree.get("timestamp") else datetime.now(UTC)
+        )
+        run_dict = {
+            "created": datetime.now(UTC),
+            "start_time": start_time,
+            "duration": float(tree.get("time", 0.0)),
+            "summary": {
+                "errors": int(tree.get("errors", 0)),
+                "failures": int(tree.get("failures", 0)),
+                "skips": int(tree.get("skipped", 0)),
+                "xfailures": int(tree.get("xfailures", 0)),
+                "xpasses": int(tree.get("xpasses", 0)),
+                "tests": int(tree.get("tests", 0)),
+            },
+        }
 
-    # If the filename contains a uuid4, let's use that for the run ID
-    if match := uuid_pattern.search(import_record.filename):
-        run_dict["id"] = match.group(1)
+        # If the filename contains a uuid4, let's use that for the run ID
+        if match := uuid_pattern.search(import_record.filename):
+            run_dict["id"] = match.group(1)
 
-    # Get metadata from the XML file
-    metadata = _get_properties(tree)
+        # Get metadata from the XML file
+        metadata = _get_properties(tree)
 
-    # Update metadata from import data
-    if import_record.data.get("metadata"):
-        metadata.update(import_record.data["metadata"])
+        # Update metadata from import data
+        if import_record.data.get("metadata"):
+            metadata.update(import_record.data["metadata"])
 
-    # Populate metadata
-    run_dict["data"] = metadata
-    # add env and component directly to the run dict if it exists in the metadata
-    run_dict["env"] = metadata.get("env")
-    run_dict["component"] = metadata.get("component")
-    run_dict["source"] = metadata.get("source")
+        # Populate metadata
+        run_dict["data"] = metadata
+        # add env and component directly to the run dict if it exists in the metadata
+        run_dict["env"] = metadata.get("env")
+        run_dict["component"] = metadata.get("component")
+        run_dict["source"] = metadata.get("source")
 
-    # Set the project if it exists
-    if metadata.get("project"):
-        run_dict["project_id"] = get_project_id(metadata["project"])
+        # Set the project if it exists
+        if metadata.get("project"):
+            run_dict["project_id"] = get_project_id(metadata["project"])
 
-    # If there are any properties set by the importer, overwrite with those
-    if import_record.data.get("project_id"):
-        run_dict["project_id"] = import_record.data["project_id"]
-    if import_record.data.get("source"):
-        run_dict["source"] = import_record.data["source"]
+        # If there are any properties set by the importer, overwrite with those
+        if import_record.data.get("project_id"):
+            run_dict["project_id"] = import_record.data["project_id"]
+        if import_record.data.get("source"):
+            run_dict["source"] = import_record.data["source"]
 
-    # Insert the run, and then update the import with the run id
-    run = Run.from_dict(**run_dict)
-    db.session.add(run)
-    db.session.commit()
-    run_dict = run.to_dict()
-    import_record.run_id = run.id
-    import_record.data["run_id"].append(run.id)
+        # Insert the run, and then update the import with the run id. Flush (not
+        # commit) so the run gets an ID while staying in the same transaction as
+        # its results/artifacts -- a later failure then rolls the run back too.
+        run = Run.from_dict(**run_dict)
+        db.session.add(run)
+        db.session.flush()
+        run_dict = run.to_dict()
+        import_record.run_id = run.id
+        import_record.data["run_id"].append(run.id)
 
-    # If the top level "testsuites" element doesn't have these, we'll need to build them manually
-    run_data = {
-        "duration": 0.0,
-        "errors": 0,
-        "failures": 0,
-        "skips": 0,
-        "xfailures": 0,
-        "xpasses": 0,
-        "tests": 0,
-    }
+        # If the top level "testsuites" element doesn't have these, build them manually
+        run_data = {
+            "duration": 0.0,
+            "errors": 0,
+            "failures": 0,
+            "skips": 0,
+            "xfailures": 0,
+            "xpasses": 0,
+            "tests": 0,
+        }
 
-    # Handle structures where testsuite is/isn't the top level tag
-    testsuites = _get_ts_element(tree)
+        # Handle structures where testsuite is/isn't the top level tag
+        testsuites = _get_ts_element(tree)
 
-    # Run through the test suites and import all the test results
-    for ts in testsuites:
-        run_data["duration"] += float(ts.get("time", 0.0))
-        run_data["errors"] += int(ts.get("errors", 0))
-        run_data["failures"] += int(ts.get("failures", 0))
-        run_data["skips"] += int(ts.get("skipped", 0))
-        run_data["xfailures"] += int(ts.get("xfailures", 0))
-        run_data["xpasses"] += int(ts.get("xpasses", 0))
-        run_data["tests"] += int(ts.get("tests", 0))
-        fspath = ts.get("file")
-        run_properties = _get_properties(ts)
+        # Run through the test suites and import all the test results
+        for ts in testsuites:
+            run_data["duration"] += float(ts.get("time", 0.0))
+            run_data["errors"] += int(ts.get("errors", 0))
+            run_data["failures"] += int(ts.get("failures", 0))
+            run_data["skips"] += int(ts.get("skipped", 0))
+            run_data["xfailures"] += int(ts.get("xfailures", 0))
+            run_data["xpasses"] += int(ts.get("xpasses", 0))
+            run_data["tests"] += int(ts.get("tests", 0))
+            fspath = ts.get("file")
+            run_properties = _get_properties(ts)
 
-        for testcase in ts.iterchildren(tag="testcase"):
-            test_name, backup_fspath = _get_test_name_path(testcase)
-            result_dict = {
-                "test_id": test_name,
-                "start_time": run_dict["start_time"],
-                "duration": float(testcase.get("time") or 0),
-                "run_id": run.id,
-                "metadata": {
-                    "run": run.id,
-                    "fspath": fspath or testcase.get("file") or backup_fspath,
-                    "line": testcase.get("line"),
-                },
-                "params": {},
-                "source": ts.get("name"),
-            }
+            for testcase in ts.iterchildren(tag="testcase"):
+                test_name, backup_fspath = _get_test_name_path(testcase)
+                result_dict = {
+                    "test_id": test_name,
+                    "start_time": run_dict["start_time"],
+                    "duration": float(testcase.get("time") or 0),
+                    "run_id": run.id,
+                    "metadata": {
+                        "run": run.id,
+                        "fspath": fspath or testcase.get("file") or backup_fspath,
+                        "line": testcase.get("line"),
+                    },
+                    "params": {},
+                    "source": ts.get("name"),
+                }
 
-            # If there are any properties set by the importer, overwrite with those
-            if import_record.data.get("project_id"):
-                result_dict["project_id"] = import_record.data["project_id"]
-            if import_record.data.get("source"):
-                result_dict["source"] = import_record.data["source"]
+                # If there are any properties set by the importer, overwrite with those
+                if import_record.data.get("project_id"):
+                    result_dict["project_id"] = import_record.data["project_id"]
+                if import_record.data.get("source"):
+                    result_dict["source"] = import_record.data["source"]
 
-            # If the JUnit XML has a properties object, add those properties in
-            result_properties = {}
-            result_properties.update(metadata)
-            result_properties.update(run_properties)
-            result_properties.update(_get_properties(testcase))
+                # If the JUnit XML has a properties object, add those properties in
+                result_properties = {}
+                result_properties.update(metadata)
+                result_properties.update(run_properties)
+                result_properties.update(_get_properties(testcase))
 
-            _populate_result_metadata(run_dict, result_dict, result_properties)
-            result_dict, traceback = _process_result(result_dict, testcase)
+                _populate_result_metadata(run_dict, result_dict, result_properties)
+                result_dict, traceback = _process_result(result_dict, testcase)
 
-            result = Result.from_dict(**result_dict)
-            db.session.add(result)
-            db.session.flush()
-            _add_artifacts(result, testcase, traceback)
+                result = Result.from_dict(**result_dict)
+                db.session.add(result)
+                db.session.flush()
+                # _add_artifacts stages the traceback, system-out and system-err
+                # artifacts for this result -- don't duplicate that work here.
+                _add_artifacts(result, testcase, traceback)
 
-            if traceback:
-                db.session.add(
-                    Artifact(
-                        filename="traceback.log",
-                        result_id=result.id,
-                        data={"contentType": "text/plain", "resultId": result.id},
-                        content=traceback,
-                    )
-                )
-            if testcase.find("system-out") is not None:
-                system_out = bytes(str(testcase["system-out"]), "utf8")
-                db.session.add(
-                    Artifact(
-                        filename="system-out.log",
-                        result_id=result.id,
-                        data={"contentType": "text/plain", "resultId": result.id},
-                        content=system_out,
-                    )
-                )
-            if testcase.find("system-err") is not None:
-                system_err = bytes(str(testcase["system-err"]), "utf8")
-                db.session.add(
-                    Artifact(
-                        filename="system-err.log",
-                        result_id=result.id,
-                        data={"contentType": "text/plain", "resultId": result.id},
-                        content=system_err,
-                    )
-                )
-            db.session.flush()
-
-    # Check if we need to update the run
-    if not run.duration:
-        run.duration = run_data["duration"]
-    if not run.summary["errors"]:
-        run.summary["errors"] = run_data["errors"]
-    if not run.summary["failures"]:
-        run.summary["failures"] = run_data["failures"]
-    if not run.summary["skips"]:
-        run.summary["skips"] = run_data["skips"]
-    if not run.summary["xfailures"]:
-        run.summary["xfailures"] = run_data["xfailures"]
-    if not run.summary["xpasses"]:
-        run.summary["xpasses"] = run_data["xpasses"]
-    if not run.summary["tests"]:
-        run.summary["tests"] = run_data["tests"]
-    db.session.add(run)
-    db.session.commit()
+        # Check if we need to update the run
+        if not run.duration:
+            run.duration = run_data["duration"]
+        if not run.summary["errors"]:
+            run.summary["errors"] = run_data["errors"]
+        if not run.summary["failures"]:
+            run.summary["failures"] = run_data["failures"]
+        if not run.summary["skips"]:
+            run.summary["skips"] = run_data["skips"]
+        if not run.summary["xfailures"]:
+            run.summary["xfailures"] = run_data["xfailures"]
+        if not run.summary["xpasses"]:
+            run.summary["xpasses"] = run_data["xpasses"]
+        if not run.summary["tests"]:
+            run.summary["tests"] = run_data["tests"]
+        db.session.add(run)
+        db.session.commit()
 
     # Update the status of the import, now that we're all done
     _update_import_status(import_record, "done")
@@ -440,7 +456,10 @@ def run_archive_import(import_):  # noqa: PLR0912
     result_artifacts = {}
     start_time = None
     file_object = BytesIO(import_file.content)
-    with tarfile.open(fileobj=file_object) as tar:
+    # Process the archive within a single transaction so a failure part-way
+    # through rolls back cleanly and marks the import as errored -- the run is
+    # never committed without its results/artifacts.
+    with _import_failure_handling(import_record), tarfile.open(fileobj=file_object) as tar:
         for member in tar.getmembers():
             # We don't care about directories, skip them
             if member.isdir():
@@ -496,18 +515,33 @@ def run_archive_import(import_):  # noqa: PLR0912
         else:
             run = Run.from_dict(**run_dict)
         db.session.add(run)
-        db.session.commit()
+        # Flush (not commit) so the run receives an ID while staying in the same
+        # transaction as its results/artifacts -- committed together at the end.
+        db.session.flush()
         import_record.run_id = run.id
         import_record.data["run_id"] = [run.id]
         # Loop through any artifacts associated with the run and upload them
         for artifact in run_artifacts:
             filename = artifact.name.split("/")[-1]
-            existing_artifact = db.session.execute(
-                db.select(Artifact).where(
-                    Artifact.run_id == run.id,
-                    Artifact.filename == filename,
+            # Handle potential legacy duplicates by fetching all matching artifacts
+            existing_artifacts = (
+                db.session.execute(
+                    db.select(Artifact)
+                    .where(
+                        Artifact.run_id == run.id,
+                        Artifact.filename == filename,
+                    )
+                    .order_by(Artifact.upload_date, Artifact.id)
                 )
-            ).scalar_one_or_none()
+                .scalars()
+                .all()
+            )
+
+            existing_artifact = existing_artifacts[0] if existing_artifacts else None
+            # Clean up any legacy duplicates
+            for duplicate in existing_artifacts[1:]:
+                db.session.delete(duplicate)
+
             content = tar.extractfile(artifact).read()
             if existing_artifact:
                 existing_artifact.content = content

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -24,6 +24,68 @@ uuid_pattern = re.compile(
 )
 
 
+def _upsert_result_artifact(result_id, filename, content):
+    """Insert or update a result artifact, deduplicating any legacy duplicate rows."""
+    existing_artifacts = (
+        db.session.execute(
+            db.select(Artifact)
+            .where(
+                Artifact.result_id == result_id,
+                Artifact.filename == filename,
+            )
+            .order_by(Artifact.upload_date, Artifact.id)
+        )
+        .scalars()
+        .all()
+    )
+    existing_artifact = existing_artifacts[0] if existing_artifacts else None
+    for duplicate in existing_artifacts[1:]:
+        db.session.delete(duplicate)
+
+    if existing_artifact:
+        existing_artifact.content = content
+    else:
+        db.session.add(
+            Artifact(
+                filename=filename,
+                result_id=result_id,
+                data={"contentType": "text/plain", "resultId": result_id},
+                content=content,
+            )
+        )
+
+
+def _upsert_run_artifact(run_id, filename, content):
+    """Insert or update a run artifact, deduplicating any legacy duplicate rows."""
+    existing_artifacts = (
+        db.session.execute(
+            db.select(Artifact)
+            .where(
+                Artifact.run_id == run_id,
+                Artifact.filename == filename,
+            )
+            .order_by(Artifact.upload_date, Artifact.id)
+        )
+        .scalars()
+        .all()
+    )
+    existing_artifact = existing_artifacts[0] if existing_artifacts else None
+    for duplicate in existing_artifacts[1:]:
+        db.session.delete(duplicate)
+
+    if existing_artifact:
+        existing_artifact.content = content
+    else:
+        db.session.add(
+            Artifact(
+                filename=filename,
+                run_id=run_id,
+                data={"contentType": "text/plain", "runId": run_id},
+                content=content,
+            )
+        )
+
+
 @shared_task
 def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=None):
     """Create or update a result with artifacts, used in the archive importer"""
@@ -35,11 +97,11 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
     result_metadata = result.get("metadata") or {}
     if metadata:
         result_metadata.update(metadata)
-        result["metadata"] = result_metadata
     # promote user_properties to the level of metadata
     if "user_properties" in result_metadata:
         user_properties = result_metadata.pop("user_properties")
         result_metadata.update(user_properties)
+    result["metadata"] = result_metadata
 
     # Support both top-level and metadata for component and env
     result["env"] = result.get("env") or result_metadata.get("env")
@@ -60,37 +122,8 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
 
     for artifact in artifacts:
         filename = artifact.name.split("/")[-1]
-        # Handle potential legacy duplicates by fetching all matching artifacts
-        existing_artifacts = (
-            db.session.execute(
-                db.select(Artifact)
-                .where(
-                    Artifact.result_id == result_record.id,
-                    Artifact.filename == filename,
-                )
-                .order_by(Artifact.upload_date, Artifact.id)
-            )
-            .scalars()
-            .all()
-        )
-
-        existing_artifact = existing_artifacts[0] if existing_artifacts else None
-        # Clean up any legacy duplicates
-        for duplicate in existing_artifacts[1:]:
-            db.session.delete(duplicate)
-
         content = tar.extractfile(artifact).read()
-        if existing_artifact:
-            existing_artifact.content = content
-        else:
-            db.session.add(
-                Artifact(
-                    filename=filename,
-                    result_id=result_record.id,
-                    data={"contentType": "text/plain", "resultId": result_record.id},
-                    content=content,
-                )
-            )
+        _upsert_result_artifact(result_record.id, filename, content)
     db.session.flush()
     return old_id
 
@@ -169,34 +202,13 @@ def _process_result(result_dict, testcase):
 def _add_artifacts(result, testcase, traceback):
     """To reduce cognitive complexity"""
     if traceback:
-        db.session.add(
-            Artifact(
-                filename="traceback.log",
-                result_id=result.id,
-                data={"contentType": "text/plain", "resultId": result.id},
-                content=traceback,
-            )
-        )
+        _upsert_result_artifact(result.id, "traceback.log", traceback)
     if testcase.find("system-out") is not None:
         system_out = bytes(str(testcase["system-out"]), "utf8")
-        db.session.add(
-            Artifact(
-                filename="system-out.log",
-                result_id=result.id,
-                data={"contentType": "text/plain", "resultId": result.id},
-                content=system_out,
-            )
-        )
+        _upsert_result_artifact(result.id, "system-out.log", system_out)
     if testcase.find("system-err") is not None:
         system_err = bytes(str(testcase["system-err"]), "utf8")
-        db.session.add(
-            Artifact(
-                filename="system-err.log",
-                result_id=result.id,
-                data={"contentType": "text/plain", "resultId": result.id},
-                content=system_err,
-            )
-        )
+        _upsert_result_artifact(result.id, "system-err.log", system_err)
     # Flush rather than commit so these artifacts remain part of the importing
     # task's transaction and roll back with the run/result if a later step fails.
     db.session.flush()
@@ -264,7 +276,7 @@ def _get_test_name_path(testcase):
     return test_name, backup_fspath
 
 
-@shared_task
+@shared_task(max_retries=0)
 def run_junit_import(import_):  # noqa: PLR0912
     """Import a test run from a JUnit file"""
     # Update the status of the import
@@ -301,8 +313,18 @@ def run_junit_import(import_):  # noqa: PLR0912
             },
         }
 
-        # If the filename contains a uuid4, let's use that for the run ID
-        if match := uuid_pattern.search(import_record.filename):
+        # If import_record already has a run_id or filename has a uuid4, use that
+        existing_run_id = None
+        if import_record.data and import_record.data.get("run_id"):
+            run_ids = import_record.data["run_id"]
+            if isinstance(run_ids, list) and run_ids:
+                existing_run_id = run_ids[0]
+            elif isinstance(run_ids, str):
+                existing_run_id = run_ids
+
+        if existing_run_id and is_uuid(str(existing_run_id)):
+            run_dict["id"] = str(existing_run_id)
+        elif match := uuid_pattern.search(import_record.filename):
             run_dict["id"] = match.group(1)
 
         # Get metadata from the XML file
@@ -329,15 +351,19 @@ def run_junit_import(import_):  # noqa: PLR0912
         if import_record.data.get("source"):
             run_dict["source"] = import_record.data["source"]
 
-        # Insert the run, and then update the import with the run id. Flush (not
+        # Insert or update the run, and then update the import with the run id. Flush (not
         # commit) so the run gets an ID while staying in the same transaction as
         # its results/artifacts -- a later failure then rolls the run back too.
-        run = Run.from_dict(**run_dict)
+        run = db.session.get(Run, run_dict["id"]) if is_uuid(run_dict.get("id")) else None
+        if run:
+            run.update(run_dict)
+        else:
+            run = Run.from_dict(**run_dict)
         db.session.add(run)
         db.session.flush()
         run_dict = run.to_dict()
-        import_record.run_id = run.id
-        import_record.data["run_id"].append(run.id)
+        if run.id not in import_record.data["run_id"]:
+            import_record.data["run_id"].append(run.id)
 
         # If the top level "testsuites" element doesn't have these, build them manually
         run_data = {
@@ -396,8 +422,22 @@ def run_junit_import(import_):  # noqa: PLR0912
                 _populate_result_metadata(run_dict, result_dict, result_properties)
                 result_dict, traceback = _process_result(result_dict, testcase)
 
-                result = Result.from_dict(**result_dict)
-                db.session.add(result)
+                existing_result = (
+                    db.session.execute(
+                        db.select(Result).where(
+                            Result.run_id == run.id,
+                            Result.test_id == test_name,
+                        )
+                    )
+                    .scalars()
+                    .first()
+                )
+                if existing_result:
+                    existing_result.update(result_dict)
+                    result = existing_result
+                else:
+                    result = Result.from_dict(**result_dict)
+                    db.session.add(result)
                 db.session.flush()
                 # _add_artifacts stages the traceback, system-out and system-err
                 # artifacts for this result -- don't duplicate that work here.
@@ -419,6 +459,8 @@ def run_junit_import(import_):  # noqa: PLR0912
         if not run.summary["tests"]:
             run.summary["tests"] = run_data["tests"]
         db.session.add(run)
+        import_record.status = "done"
+        db.session.add(import_record)
         db.session.commit()
 
     # Update the status of the import, now that we're all done
@@ -429,7 +471,7 @@ def run_junit_import(import_):  # noqa: PLR0912
     clear_import_file_content.delay(import_record.id)
 
 
-@shared_task
+@shared_task(max_retries=0)
 def run_archive_import(import_):  # noqa: PLR0912
     """Import a test run from an Ibutsu archive file"""
     # Update the status of the import
@@ -481,6 +523,8 @@ def run_archive_import(import_):  # noqa: PLR0912
                 raise ValueError(msg)
             if member.name.endswith("result.json"):
                 result = json.loads(tar.extractfile(member).read())
+                if not result.get("id") and is_uuid(result_id):
+                    result["id"] = result_id
                 result_start_time = result.get("start_time")
                 if not start_time or start_time > result_start_time:
                     start_time = result_start_time
@@ -491,6 +535,7 @@ def run_archive_import(import_):  # noqa: PLR0912
                 except KeyError:
                     result_artifacts[result_id] = [member]
         run_dict = run or {
+            "id": run_id,
             "duration": 0,
             "summary": {
                 "errors": 0,
@@ -501,6 +546,8 @@ def run_archive_import(import_):  # noqa: PLR0912
                 "tests": 0,
             },
         }
+        if not run_dict.get("id") and is_uuid(run_id):
+            run_dict["id"] = run_id
         # patch things up a bit, if necessary
         run_dict["metadata"] = run_dict.get("metadata", {})
         run_dict["metadata"].update(metadata)
@@ -518,45 +565,15 @@ def run_archive_import(import_):  # noqa: PLR0912
         # Flush (not commit) so the run receives an ID while staying in the same
         # transaction as its results/artifacts -- committed together at the end.
         db.session.flush()
-        import_record.run_id = run.id
         import_record.data["run_id"] = [run.id]
         # Loop through any artifacts associated with the run and upload them
         for artifact in run_artifacts:
             filename = artifact.name.split("/")[-1]
-            # Handle potential legacy duplicates by fetching all matching artifacts
-            existing_artifacts = (
-                db.session.execute(
-                    db.select(Artifact)
-                    .where(
-                        Artifact.run_id == run.id,
-                        Artifact.filename == filename,
-                    )
-                    .order_by(Artifact.upload_date, Artifact.id)
-                )
-                .scalars()
-                .all()
-            )
-
-            existing_artifact = existing_artifacts[0] if existing_artifacts else None
-            # Clean up any legacy duplicates
-            for duplicate in existing_artifacts[1:]:
-                db.session.delete(duplicate)
-
             content = tar.extractfile(artifact).read()
-            if existing_artifact:
-                existing_artifact.content = content
-            else:
-                db.session.add(
-                    Artifact(
-                        filename=filename,
-                        run_id=run.id,
-                        data={"contentType": "text/plain", "runId": run.id},
-                        content=content,
-                    )
-                )
+            _upsert_run_artifact(run.id, filename, content)
         # Now loop through all the results, and create or update them
         for result in results:
-            artifacts = result_artifacts.get(result["id"], [])
+            artifacts = result_artifacts.get(result.get("id"), [])
             _create_result(
                 tar,
                 run.id,
@@ -565,6 +582,8 @@ def run_archive_import(import_):  # noqa: PLR0912
                 project_id=run_dict.get("project_id") or import_record.data.get("project_id"),
                 metadata=metadata,
             )
+        import_record.status = "done"
+        db.session.add(import_record)
         db.session.commit()
     # Update the import record
     log.info("Setting import status to done")

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -369,6 +369,7 @@ def run_junit_import(import_):  # noqa: PLR0912
 
         # Handle structures where testsuite is/isn't the top level tag
         testsuites = _get_ts_element(tree)
+        matched_result_ids = set()
 
         # Run through the test suites and import all the test results
         for ts in testsuites:
@@ -413,7 +414,7 @@ def run_junit_import(import_):  # noqa: PLR0912
                 _populate_result_metadata(run_dict, result_dict, result_properties)
                 result_dict, traceback = _process_result(result_dict, testcase)
 
-                existing_result = (
+                existing_results = (
                     db.session.execute(
                         db.select(Result).where(
                             Result.run_id == run.id,
@@ -421,7 +422,11 @@ def run_junit_import(import_):  # noqa: PLR0912
                         )
                     )
                     .scalars()
-                    .first()
+                    .all()
+                )
+                existing_result = next(
+                    (r for r in existing_results if r.id not in matched_result_ids),
+                    None,
                 )
                 if existing_result:
                     existing_result.update(result_dict)
@@ -430,6 +435,7 @@ def run_junit_import(import_):  # noqa: PLR0912
                     result = Result.from_dict(**result_dict)
                     db.session.add(result)
                 db.session.flush()
+                matched_result_ids.add(result.id)
                 # _add_artifacts stages the traceback, system-out and system-err
                 # artifacts for this result -- don't duplicate that work here.
                 _add_artifacts(result, testcase, traceback)

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -24,13 +24,17 @@ uuid_pattern = re.compile(
 )
 
 
-def _upsert_result_artifact(result_id, filename, content):
-    """Insert or update a result artifact, deduplicating any legacy duplicate rows."""
+def _upsert_artifact(filename, content, result_id=None, run_id=None):
+    """Insert or update an artifact, deduplicating any legacy duplicate rows."""
+    target_col = Artifact.result_id if result_id else Artifact.run_id
+    target_id = result_id or run_id
+    meta_key = "resultId" if result_id else "runId"
+
     existing_artifacts = (
         db.session.execute(
             db.select(Artifact)
             .where(
-                Artifact.result_id == result_id,
+                target_col == target_id,
                 Artifact.filename == filename,
             )
             .order_by(Artifact.upload_date, Artifact.id)
@@ -45,48 +49,28 @@ def _upsert_result_artifact(result_id, filename, content):
     if existing_artifact:
         existing_artifact.content = content
     else:
-        db.session.add(
-            Artifact(
-                filename=filename,
-                result_id=result_id,
-                data={"contentType": "text/plain", "resultId": result_id},
-                content=content,
-            )
-        )
+        artifact_kwargs = {
+            "filename": filename,
+            "data": {"contentType": "text/plain", meta_key: target_id},
+            "content": content,
+        }
+        if result_id:
+            artifact_kwargs["result_id"] = result_id
+        else:
+            artifact_kwargs["run_id"] = run_id
+        db.session.add(Artifact(**artifact_kwargs))
+
+
+def _upsert_result_artifact(result_id, filename, content):
+    """Insert or update a result artifact, deduplicating any legacy duplicate rows."""
+    _upsert_artifact(filename, content, result_id=result_id)
 
 
 def _upsert_run_artifact(run_id, filename, content):
     """Insert or update a run artifact, deduplicating any legacy duplicate rows."""
-    existing_artifacts = (
-        db.session.execute(
-            db.select(Artifact)
-            .where(
-                Artifact.run_id == run_id,
-                Artifact.filename == filename,
-            )
-            .order_by(Artifact.upload_date, Artifact.id)
-        )
-        .scalars()
-        .all()
-    )
-    existing_artifact = existing_artifacts[0] if existing_artifacts else None
-    for duplicate in existing_artifacts[1:]:
-        db.session.delete(duplicate)
-
-    if existing_artifact:
-        existing_artifact.content = content
-    else:
-        db.session.add(
-            Artifact(
-                filename=filename,
-                run_id=run_id,
-                data={"contentType": "text/plain", "runId": run_id},
-                content=content,
-            )
-        )
+    _upsert_artifact(filename, content, run_id=run_id)
 
 
-@shared_task
 def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=None):
     """Create or update a result with artifacts, used in the archive importer"""
     old_id = None
@@ -158,8 +142,11 @@ def _import_failure_handling(import_record):
         yield
     except Exception:
         log.exception(f"Import {import_record.id} failed during processing")
-        db.session.rollback()
-        _update_import_status(import_record, "error")
+        try:
+            db.session.rollback()
+            _update_import_status(import_record, "error")
+        except Exception:
+            log.exception(f"Failed to cleanly roll back or mark import {import_record.id} as error")
         raise
 
 
@@ -198,7 +185,6 @@ def _process_result(result_dict, testcase):
     return result_dict, traceback
 
 
-@shared_task
 def _add_artifacts(result, testcase, traceback):
     """To reduce cognitive complexity"""
     if traceback:
@@ -239,16 +225,17 @@ def _populate_created_times(run_dict, start_time):
 
 def _populate_metadata(run_dict, import_record):
     """To reduce cognitive complexity"""
-    if import_record.data.get("project_id"):
-        run_dict["project_id"] = import_record.data["project_id"]
+    import_data = import_record.data or {}
+    if import_data.get("project_id"):
+        run_dict["project_id"] = import_data["project_id"]
     elif run_dict.get("metadata", {}).get("project"):
         run_dict["project_id"] = get_project_id(run_dict["metadata"]["project"])
     if run_dict.get("metadata", {}).get("component"):
         run_dict["component"] = run_dict["metadata"]["component"]
     if run_dict.get("metadata", {}).get("env"):
         run_dict["env"] = run_dict["metadata"]["env"]
-    if import_record.data.get("source"):
-        run_dict["source"] = import_record.data["source"]
+    if import_data.get("source"):
+        run_dict["source"] = import_data["source"]
 
 
 def _populate_result_metadata(run_dict, result_dict, metadata):
@@ -281,6 +268,10 @@ def run_junit_import(import_):  # noqa: PLR0912
     """Import a test run from a JUnit file"""
     # Update the status of the import
     import_record = db.session.get(Import, import_["id"])
+    if not import_record:
+        return
+    if import_record.data is None:
+        import_record.data = {}
     _update_import_status(import_record, "running")
     # Fetch the file contents
     import_file = db.session.execute(
@@ -463,9 +454,6 @@ def run_junit_import(import_):  # noqa: PLR0912
         db.session.add(import_record)
         db.session.commit()
 
-    # Update the status of the import, now that we're all done
-    _update_import_status(import_record, "done")
-
     # Clear the import file content to save database space
     # The import record is kept for audit/history, but the large binary content is removed
     clear_import_file_content.delay(import_record.id)
@@ -476,6 +464,10 @@ def run_archive_import(import_):  # noqa: PLR0912
     """Import a test run from an Ibutsu archive file"""
     # Update the status of the import
     import_record = db.session.get(Import, str(import_["id"]))
+    if not import_record:
+        return
+    if import_record.data is None:
+        import_record.data = {}
     log.info(f"Starting archive import for import record {import_record.id}")
     metadata = {}
     if import_record.data.get("metadata"):
@@ -585,9 +577,7 @@ def run_archive_import(import_):  # noqa: PLR0912
         import_record.status = "done"
         db.session.add(import_record)
         db.session.commit()
-    # Update the import record
-    log.info("Setting import status to done")
-    _update_import_status(import_record, "done")
+
     if run:
         update_run.delay(run.id)
 

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -294,6 +294,15 @@ def run_junit_import(import_):  # noqa: PLR0912
     with _import_failure_handling(import_record):
         # Parse the XML and create a run object(s)
         tree = objectify.fromstring(import_file.content)
+        # If import_record already has a run_id or filename has a uuid4, use that
+        existing_run_id = None
+        if import_record.data and import_record.data.get("run_id"):
+            run_ids = import_record.data["run_id"]
+            if isinstance(run_ids, list) and run_ids:
+                existing_run_id = run_ids[0]
+            elif isinstance(run_ids, str):
+                existing_run_id = run_ids
+
         import_record.data["run_id"] = []
         # Use current time as start time if no start time is present
         start_time = (
@@ -313,15 +322,6 @@ def run_junit_import(import_):  # noqa: PLR0912
             },
         }
 
-        # If import_record already has a run_id or filename has a uuid4, use that
-        existing_run_id = None
-        if import_record.data and import_record.data.get("run_id"):
-            run_ids = import_record.data["run_id"]
-            if isinstance(run_ids, list) and run_ids:
-                existing_run_id = run_ids[0]
-            elif isinstance(run_ids, str):
-                existing_run_id = run_ids
-
         if existing_run_id and is_uuid(str(existing_run_id)):
             run_dict["id"] = str(existing_run_id)
         elif match := uuid_pattern.search(import_record.filename):
@@ -335,7 +335,7 @@ def run_junit_import(import_):  # noqa: PLR0912
             metadata.update(import_record.data["metadata"])
 
         # Populate metadata
-        run_dict["data"] = metadata
+        run_dict["metadata"] = metadata
         # add env and component directly to the run dict if it exists in the metadata
         run_dict["env"] = metadata.get("env")
         run_dict["component"] = metadata.get("component")
@@ -523,12 +523,12 @@ def run_archive_import(import_):  # noqa: PLR0912
                 raise ValueError(msg)
             if member.name.endswith("result.json"):
                 result = json.loads(tar.extractfile(member).read())
-                if not result.get("id") and is_uuid(result_id):
+                if (not result.get("id") or not is_uuid(result.get("id"))) and is_uuid(result_id):
                     result["id"] = result_id
                 result_start_time = result.get("start_time")
                 if not start_time or start_time > result_start_time:
                     start_time = result_start_time
-                results.append(result)
+                results.append((result_id, result))
             else:
                 try:
                     result_artifacts[result_id].append(member)
@@ -572,8 +572,8 @@ def run_archive_import(import_):  # noqa: PLR0912
             content = tar.extractfile(artifact).read()
             _upsert_run_artifact(run.id, filename, content)
         # Now loop through all the results, and create or update them
-        for result in results:
-            artifacts = result_artifacts.get(result.get("id"), [])
+        for res_id, result in results:
+            artifacts = result_artifacts.get(res_id, [])
             _create_result(
                 tar,
                 run.id,

--- a/backend/ibutsu_server/util/__init__.py
+++ b/backend/ibutsu_server/util/__init__.py
@@ -202,10 +202,12 @@ def get_test_idents(item):
 
 
 def merge_dicts(old_dict, new_dict):
+    if not isinstance(old_dict, dict) or not isinstance(new_dict, dict):
+        return
     for key, value in old_dict.items():
         if key not in new_dict or new_dict[key] is None:
             new_dict[key] = value
-        elif isinstance(value, dict):
+        elif isinstance(value, dict) and isinstance(new_dict[key], dict):
             merge_dicts(value, new_dict[key])
 
 

--- a/backend/ibutsu_server/util/login.py
+++ b/backend/ibutsu_server/util/login.py
@@ -13,6 +13,6 @@ def validate_activation_code(activation_code):
         decoded_value = base64.urlsafe_b64decode(activation_code)
         if not decoded_value:
             raise ValueError("Decoded value is empty")
-    except binascii.Error, ValueError:
+    except (binascii.Error, ValueError):
         return f"Activation code {activation_code} is not valid", HTTPStatus.BAD_REQUEST
     return None

--- a/backend/ibutsu_server/util/login.py
+++ b/backend/ibutsu_server/util/login.py
@@ -13,6 +13,6 @@ def validate_activation_code(activation_code):
         decoded_value = base64.urlsafe_b64decode(activation_code)
         if not decoded_value:
             raise ValueError("Decoded value is empty")
-    except (binascii.Error, ValueError):
+    except binascii.Error, ValueError:
         return f"Activation code {activation_code} is not valid", HTTPStatus.BAD_REQUEST
     return None

--- a/backend/ibutsu_server/util/uuid.py
+++ b/backend/ibutsu_server/util/uuid.py
@@ -11,8 +11,10 @@ UUID_VARIANT_1 = 0b1000000000000000
 
 def is_uuid(candidate):
     """Determine if this is a uuid"""
+    if not candidate:
+        return False
     try:
-        UUID(candidate)
+        UUID(str(candidate))
         return True
     except ValueError:
         return False

--- a/backend/tests/controllers/test_run_controller.py
+++ b/backend/tests/controllers/test_run_controller.py
@@ -561,6 +561,36 @@ def test_get_run_list_various_filters(
     assert "runs" in response_data
 
 
+def test_filter_summary_tests_with_float_representation(
+    flask_app, make_project, make_run, auth_headers
+):
+    """Test filtering runs when summary.tests contains float values like 3.0."""
+    client, jwt_token = flask_app
+
+    project = make_project(name="float-tests-project")
+
+    make_run(
+        project_id=project.id,
+        summary={"tests": 3.0, "failures": 0.0},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 6000, "failures": 1},
+    )
+
+    query_string = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.tests>5000"),
+    ]
+    headers = auth_headers(jwt_token)
+    response = client.get("/api/run", headers=headers, params=query_string)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert len(response_data["runs"]) == 1
+    assert response_data["runs"][0]["summary"]["tests"] == 6000
+
+
 def test_filter_pass_percent_greater_than(flask_app, make_project, make_run, auth_headers):
     """Test filtering runs where pass_percent > threshold returns only matching runs."""
     client, jwt_token = flask_app

--- a/backend/tests/db/test_models.py
+++ b/backend/tests/db/test_models.py
@@ -1,0 +1,63 @@
+"""Tests for ibutsu_server.db.models module."""
+
+import pytest
+
+from ibutsu_server.db.models import Run
+
+
+class TestModelMixinUpdate:
+    """Tests for ModelMixin.update method."""
+
+    def test_update_metadata_merges_and_preserves_existing_keys(self, make_run, flask_app):
+        """Test that update with metadata merges new keys and preserves existing keys."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run = make_run(metadata={"existing_key": "val1", "shared_key": "old_val"})
+
+            run.update({"metadata": {"shared_key": "new_val", "new_key": "val2"}})
+
+            assert run.data["existing_key"] == "val1"
+            assert run.data["shared_key"] == "new_val"
+            assert run.data["new_key"] == "val2"
+
+    def test_update_with_data_key_merges_correctly(self, make_run, flask_app):
+        """Test that update with data key (instead of metadata) merges and preserves keys."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run = make_run(metadata={"existing_key": "val1", "shared_key": "old_val"})
+
+            run.update({"data": {"shared_key": "new_val", "new_key": "val2"}})
+
+            assert run.data["existing_key"] == "val1"
+            assert run.data["shared_key"] == "new_val"
+            assert run.data["new_key"] == "val2"
+
+    @pytest.mark.parametrize(
+        ("initial_meta", "update_payload", "expected_meta"),
+        [
+            (
+                {"env": "prod", "cluster": "east"},
+                {"metadata": {"cluster": "west"}},
+                {"env": "prod", "cluster": "west"},
+            ),
+            (
+                {"env": "prod", "cluster": "east"},
+                {"data": {"cluster": "west"}},
+                {"env": "prod", "cluster": "west"},
+            ),
+            (
+                {"nested": {"a": 1, "b": 2}},
+                {"metadata": {"nested": {"b": 3, "c": 4}}},
+                {"nested": {"a": 1, "b": 3, "c": 4}},
+            ),
+        ],
+    )
+    def test_update_metadata_parametrized(
+        self, make_run, flask_app, initial_meta, update_payload, expected_meta
+    ):
+        """Parametrized verification of metadata merge behavior across different payload formats."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run = make_run(metadata=initial_meta)
+            run.update(update_payload)
+            assert run.data == expected_meta

--- a/backend/tests/db/test_models.py
+++ b/backend/tests/db/test_models.py
@@ -1,12 +1,39 @@
 """Tests for ibutsu_server.db.models module."""
 
+from datetime import UTC, datetime
+
 import pytest
 
-from ibutsu_server.db.models import Run
+from ibutsu_server.db.models import Artifact
 
 
 class TestModelMixinUpdate:
     """Tests for ModelMixin.update method."""
+
+    def test_update_does_not_mutate_caller_payload(self, make_run, flask_app):
+        """Test that update does not mutate the caller's payload dictionary."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run = make_run()
+            payload = {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "component": "backend",
+                "data": {"key": "value"},
+            }
+            payload_copy = payload.copy()
+            run.update(payload)
+            assert "id" in payload
+            assert "data" in payload
+            assert payload == payload_copy
+
+    def test_update_parses_datetime_strings(self, make_run, flask_app):
+        """Test that update parses ISO datetime strings to datetime objects."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run = make_run()
+            run.update({"start_time": "2026-08-26T10:00:00Z"})
+            assert isinstance(run.start_time, datetime)
+            assert run.start_time == datetime(2026, 8, 26, 10, 0, 0, tzinfo=UTC)
 
     def test_update_metadata_merges_and_preserves_existing_keys(self, make_run, flask_app):
         """Test that update with metadata merges new keys and preserves existing keys."""
@@ -61,3 +88,13 @@ class TestModelMixinUpdate:
             run = make_run(metadata=initial_meta)
             run.update(update_payload)
             assert run.data == expected_meta
+
+
+class TestArtifactModel:
+    """Tests for Artifact model definition."""
+
+    def test_artifact_composite_indexes_declared(self):
+        """Verify Artifact model declares composite indexes for idempotency lookups."""
+        index_names = {idx.name for idx in Artifact.__table_args__}
+        assert "ix_artifacts_result_id_filename" in index_names
+        assert "ix_artifacts_run_id_filename" in index_names

--- a/backend/tests/db/test_models.py
+++ b/backend/tests/db/test_models.py
@@ -4,27 +4,32 @@ from datetime import UTC, datetime
 
 import pytest
 
-from ibutsu_server.db.models import Artifact
+from ibutsu_server.db.models import Artifact, Result
 
 
 class TestModelMixinUpdate:
     """Tests for ModelMixin.update method."""
 
     def test_update_does_not_mutate_caller_payload(self, make_run, flask_app):
-        """Test that update does not mutate the caller's payload dictionary."""
+        """Test update doesn't mutate caller's payload, including nested metadata."""
         client, _ = flask_app
         with client.application.app_context():
-            run = make_run()
+            run = make_run(metadata={"existing_key": "survives"})
             payload = {
                 "id": "11111111-1111-1111-1111-111111111111",
                 "component": "backend",
                 "data": {"key": "value"},
             }
-            payload_copy = payload.copy()
+            payload_copy = {
+                "id": payload["id"],
+                "component": payload["component"],
+                "data": payload["data"].copy(),
+            }
             run.update(payload)
             assert "id" in payload
             assert "data" in payload
             assert payload == payload_copy
+            assert "existing_key" not in payload["data"]
 
     def test_update_parses_datetime_strings(self, make_run, flask_app):
         """Test that update parses ISO datetime strings to datetime objects."""
@@ -93,8 +98,18 @@ class TestModelMixinUpdate:
 class TestArtifactModel:
     """Tests for Artifact model definition."""
 
-    def test_artifact_composite_indexes_declared(self):
-        """Verify Artifact model declares composite indexes for idempotency lookups."""
-        index_names = {idx.name for idx in Artifact.__table_args__}
-        assert "ix_artifacts_result_id_filename" in index_names
-        assert "ix_artifacts_run_id_filename" in index_names
+    def test_artifact_composite_indexes_documented(self):
+        """Verify Artifact model docstring documents composite indexes per repo convention."""
+        assert Artifact.__doc__ is not None
+        assert "ix_artifacts_result_id_filename" in Artifact.__doc__
+        assert "ix_artifacts_run_id_filename" in Artifact.__doc__
+
+
+class TestResultModel:
+    """Tests for Result model definition."""
+
+    def test_result_composite_indexes_documented(self):
+        """Verify Result model docstring documents composite indexes per repo convention."""
+        assert Result.__doc__ is not None
+        assert "ix_results_run_id_project_id" in Result.__doc__
+        assert "ix_results_run_id_test_id" in Result.__doc__

--- a/backend/tests/test_celery_utils.py
+++ b/backend/tests/test_celery_utils.py
@@ -1,7 +1,9 @@
 """Tests for ibutsu_server.celery_utils module."""
 
+from unittest.mock import MagicMock
+
 import pytest
-from celery import Celery
+from celery import Celery, signals
 
 from ibutsu_server import _AppRegistry
 from ibutsu_server.celery_utils import create_broker_celery_app, create_flask_celery_app
@@ -275,3 +277,39 @@ class TestBeatScheduleConfiguration:
         schedule_config = app.conf.beat_schedule["sync-aborted-runs"]
         assert schedule_config["task"] == "ibutsu_server.tasks.runs.sync_aborted_runs"
         assert schedule_config["schedule"] == 0.5 * 60 * 60  # 30 minutes in seconds
+
+
+class TestTaskFailureSignalHandler:
+    """Tests for the task_failure signal handler registered by create_flask_celery_app."""
+
+    @pytest.mark.parametrize(
+        ("sender", "max_retries", "retries", "expected_retry", "expected_countdown"),
+        [
+            (None, None, 0, False, None),
+            ("mock_task", 0, 0, False, None),
+            ("mock_task", 3, 0, True, 1),
+            ("mock_task", 3, 5, True, 32),
+            ("mock_task", 3, 20, True, 3600),
+        ],
+    )
+    def test_task_failure_retry_behavior(
+        self, flask_app, sender, max_retries, retries, expected_retry, expected_countdown
+    ):
+        """Test task retry behavior on task_failure signal based on max_retries and backoff."""
+        client, _ = flask_app
+        create_flask_celery_app(client.application)
+
+        if sender == "mock_task":
+            mock_task = MagicMock()
+            mock_task.max_retries = max_retries
+            mock_task.request.retries = retries
+            task_sender = mock_task
+        else:
+            task_sender = None
+
+        signals.task_failure.send(sender=task_sender, einfo=None)
+
+        if expected_retry:
+            task_sender.retry.assert_called_once_with(countdown=expected_countdown)
+        elif task_sender is not None:
+            task_sender.retry.assert_not_called()

--- a/backend/tests/test_celery_utils.py
+++ b/backend/tests/test_celery_utils.py
@@ -288,8 +288,11 @@ class TestTaskFailureSignalHandler:
             (None, None, 0, False, None),
             ("mock_task", 0, 0, False, None),
             ("mock_task", 3, 0, True, 1),
-            ("mock_task", 3, 5, True, 32),
-            ("mock_task", 3, 20, True, 3600),
+            ("mock_task", 3, 2, True, 4),
+            ("mock_task", 3, 3, False, None),
+            ("mock_task", 3, 5, False, None),
+            ("mock_task", None, 5, True, 32),
+            ("mock_task", None, 20, True, 3600),
         ],
     )
     def test_task_failure_retry_behavior(

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -3,9 +3,10 @@
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import Integer, String
+from sqlalchemy import Float, Integer, String
+from sqlalchemy.dialects import postgresql
 
-from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
+from ibutsu_server.constants import ARRAY_FIELDS, FLOAT_FIELDS, INTEGER_FIELDS, NUMERIC_FIELDS
 from ibutsu_server.db import db
 from ibutsu_server.db.models import Result, Run
 from ibutsu_server.filters import (
@@ -18,17 +19,13 @@ from ibutsu_server.filters import (
     string_to_column,
 )
 
-# NUMERIC_FIELDS that are stored as JSON sub-keys (summary.*).
-# These go through the JSON path accessor in string_to_column and therefore
-# receive an explicit as_integer() cast.  A non-numeric value stored in the
-# database for any of these keys will raise a database error at query time
-# rather than silently returning incorrect results.
-_JSON_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if f.startswith("summary.")]
+# summary.* fields categorized by type
+_JSON_INTEGER_FIELDS = sorted(f for f in INTEGER_FIELDS if f.startswith("summary."))
+_JSON_FLOAT_FIELDS = sorted(f for f in FLOAT_FIELDS if f.startswith("summary."))
+_JSON_NUMERIC_FIELDS = sorted(f for f in NUMERIC_FIELDS if f.startswith("summary."))
 
 # NUMERIC_FIELDS that map to native ORM columns (not JSON paths).
-# These bypass the JSON accessor branch entirely, so as_integer() is never
-# applied to them; their type is already enforced by the column definition.
-_DIRECT_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if not f.startswith("summary.")]
+_DIRECT_NUMERIC_FIELDS = sorted(f for f in NUMERIC_FIELDS if not f.startswith("summary."))
 
 
 @pytest.fixture
@@ -205,41 +202,62 @@ class TestStringToColumn:
         assert column is not None
 
 
+def test_numeric_fields_is_union_of_integer_and_float_fields():
+    """Verify NUMERIC_FIELDS is the union of INTEGER_FIELDS and FLOAT_FIELDS."""
+    assert NUMERIC_FIELDS == INTEGER_FIELDS | FLOAT_FIELDS
+    assert not (INTEGER_FIELDS & FLOAT_FIELDS), "INTEGER_FIELDS and FLOAT_FIELDS must be disjoint"
+
+
 class TestStringToColumnCastSemantics:
-    """Explicit coverage for the JSON-cast behavior introduced by as_integer() / as_string().
+    """Explicit coverage for JSON-cast behavior (as_float / as_integer / as_string).
 
     The contract under test:
-    - Every field listed in NUMERIC_FIELDS whose first segment is "summary" is
-      accessed via the Run.summary JSONB column and then cast to Integer with
-      as_integer().  This produces correct numeric ordering and matches the
-      ::int expression index, but will raise a database-level error if a stored
-      value cannot be cast to a number.
+    - Fields in INTEGER_FIELDS (such as summary.pass_percent) are cast to Integer
+      with as_integer() to match the ::int expression index ix_runs_pass_percent.
+    - Fields in FLOAT_FIELDS (such as summary.tests, summary.failures) are cast to
+      Float with as_float(). This produces correct numeric ordering and allows
+      PostgreSQL to evaluate both integer and floating-point JSON representations
+      (such as 3.0 or 0.0) without throwing invalid input syntax errors.
     - Non-numeric JSON fields (data.*, metadata.*, non-array summary.*) are
-      cast to String via as_string(), preserving the previous text-comparison
-      behaviour.
+      cast to String via as_string(), preserving text-comparison behaviour.
     - Array fields (metadata.tags etc.) receive neither cast; they remain raw
       JSON path expressions so that array operators (@>, ?|) work correctly.
     - Direct ORM columns (duration, start_time) never pass through the JSON
-      accessor branch and are therefore unaffected by as_integer().
+      accessor branch and are therefore unaffected by as_integer()/as_float().
     """
 
-    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
-    def test_json_numeric_fields_produce_integer_cast(self, app_ctx, field):
-        """Every summary.* NUMERIC_FIELD must use an explicit Integer cast.
+    @pytest.mark.parametrize("field", _JSON_FLOAT_FIELDS)
+    def test_json_float_fields_produce_float_cast(self, app_ctx, field):
+        """Every JSON FLOAT_FIELD must use an explicit Float cast.
+
+        Verifies that the as_float() path is taken, meaning:
+        1. Comparisons use numeric ordering, not lexicographic ordering.
+        2. Stored float values (such as 3.0 or 0.0) do not cause PostgreSQL syntax
+           errors when evaluated.
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert isinstance(column.type, Float), (
+            f"{field!r} expected a Float-cast column (as_float()) "
+            f"but got type {type(column.type).__name__!r}. "
+            "Check that this field is still listed in FLOAT_FIELDS."
+        )
+
+    @pytest.mark.parametrize("field", _JSON_INTEGER_FIELDS)
+    def test_json_integer_fields_produce_integer_cast(self, app_ctx, field):
+        """Every JSON INTEGER_FIELD must use an explicit Integer cast.
 
         Verifies that the as_integer() path is taken, meaning:
         1. Comparisons use numeric ordering, not lexicographic ordering.
         2. The cast matches the ::int expression index on ix_runs_pass_percent,
            allowing PostgreSQL to use an index scan for range filters.
-        3. A row whose stored JSON value is not numeric will raise a database
-           error at query time (not silently return wrong results).
         """
         column = string_to_column(field, Run)
         assert column is not None, f"string_to_column returned None for {field!r}"
         assert isinstance(column.type, Integer), (
             f"{field!r} expected an Integer-cast column (as_integer()) "
             f"but got type {type(column.type).__name__!r}. "
-            "Check that this field is still listed in NUMERIC_FIELDS."
+            "Check that this field is still listed in INTEGER_FIELDS."
         )
 
     @pytest.mark.parametrize(
@@ -473,6 +491,28 @@ class TestConvertFilterNumericFieldSemantics:
         below = convert_filter("summary.pass_percent(100", Run)
         assert above is not None, "Lower-bound filter on summary.pass_percent must not be None"
         assert below is not None, "Upper-bound filter on summary.pass_percent must not be None"
+
+    def test_summary_tests_postgresql_compilation(self, app_ctx):
+        """Verify summary.tests compiles to CAST(... AS FLOAT) in PostgreSQL dialect."""
+        clause = convert_filter("summary.tests>5000", Run)
+        compiled = str(clause.compile(dialect=postgresql.dialect()))
+        assert "CAST((runs.summary ->> %(summary_1)s) AS FLOAT) > %(param_1)s" in compiled
+
+    def test_summary_pass_percent_postgresql_compilation(self, app_ctx):
+        """Verify summary.pass_percent compiles to CAST(... AS INTEGER) in PostgreSQL dialect."""
+        clause = convert_filter("summary.pass_percent>80", Run)
+        compiled = str(clause.compile(dialect=postgresql.dialect()))
+        assert "CAST((runs.summary ->> %(summary_1)s) AS INTEGER) > %(param_1)s" in compiled
+
+    def test_summary_tests_with_float_filter_value(self, app_ctx):
+        """Verify summary.tests supports float filter values without error."""
+        result = convert_filter("summary.tests>5000.5", Run)
+        assert result is not None
+        right = getattr(result, "right", None)
+        assert right is not None
+        value = getattr(right, "value", None)
+        assert isinstance(value, float)
+        assert value == 5000.5
 
 
 class TestConvertFilter:

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
 from lxml import objectify
 
 from ibutsu_server.db import db
@@ -691,6 +692,42 @@ class TestRunJunitImport:
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "error"
 
+    def test_run_junit_import_no_duplicate_artifacts(self, make_import, flask_app):
+        """A failing testcase should produce exactly one of each artifact, not duplicates"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1" failures="1">
+                <testcase name="test_fail" classname="tests.mod" time="1.0">
+                    <failure message="boom">traceback text</failure>
+                    <system-out>stdout text</system-out>
+                    <system-err>stderr text</system-err>
+                </testcase>
+            </testsuite>
+            """
+
+            import_record = make_import(filename="dup.xml", format="junit", status="pending")
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = Run.query.order_by(Run.id).all()[-1]
+            result = Result.query.filter_by(run_id=run.id).one()
+            artifacts = Artifact.query.filter_by(result_id=result.id).all()
+            filenames = [a.filename for a in artifacts]
+
+            # Each artifact type should appear exactly once (no duplication)
+            assert sorted(filenames) == [
+                "system-err.log",
+                "system-out.log",
+                "traceback.log",
+            ]
+            assert len(filenames) == len(set(filenames))
+
 
 class TestRunArchiveImport:
     """Integration tests for run_archive_import task"""
@@ -895,3 +932,122 @@ class TestRunArchiveImport:
             # Verify status updated to error
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "error"
+
+    def test_run_archive_import_error_rolls_back_and_marks_error(self, make_import, flask_app):
+        """A failure during processing rolls back the run and marks the import errored"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.boom",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(filename="boom.tar.gz", format="ibutsu", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            # Force a failure while creating results, after the run has been staged
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
+                patch(
+                    "ibutsu_server.tasks.importers._create_result",
+                    side_effect=RuntimeError("boom"),
+                ),
+                pytest.raises(RuntimeError, match="boom"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            # The run must not have been committed without its contents
+            assert db.session.get(Run, run_id) is None
+            # The import must be marked error, not left stuck in "running"
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "error"
+            # Cleanup must not run on a failed import
+            clear_mock.delay.assert_not_called()
+
+    def test_run_archive_import_preserves_existing_result_metadata(
+        self, make_import, make_run, make_result, flask_app
+    ):
+        """Re-importing must not discard metadata keys set on the result outside the archive"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            # Pre-existing run and result with metadata that the archive won't contain
+            make_run(id=run_id, metadata={"build": "1"})
+            make_result(
+                id=result_id,
+                run_id=run_id,
+                test_id="test.keep",
+                result="passed",
+                metadata={"classification": "product_failure", "component": "backend"},
+            )
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.keep",
+                "result": "failed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"component": "backend", "env": "stage"},
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(filename="keep.tar.gz", format="ibutsu", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            # Existing-only metadata key must survive the re-import
+            assert result.data["classification"] == "product_failure"
+            # Incoming metadata key must be merged in
+            assert result.data["env"] == "stage"
+            # Updated fields from the archive must be applied
+            assert result.result == "failed"

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import pytest
 from lxml import objectify
+from sqlalchemy import func
 
 from ibutsu_server.db import db
 from ibutsu_server.db.base import session
@@ -1051,3 +1052,224 @@ class TestRunArchiveImport:
             assert result.data["env"] == "stage"
             # Updated fields from the archive must be applied
             assert result.result == "failed"
+
+    def test_run_archive_import_with_null_result_metadata(
+        self, make_import, make_run, make_result, flask_app
+    ):
+        """Re-importing where result.json has metadata: null must not raise TypeError."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            make_run(id=run_id, metadata={"build": "1"})
+            make_result(
+                id=result_id,
+                run_id=run_id,
+                test_id="test.null_meta",
+                result="passed",
+                metadata={"component": "backend"},
+            )
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.null_meta",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": None,
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="null_meta.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            assert result is not None
+            assert result.data["component"] == "backend"
+
+    def test_run_archive_import_without_run_json_is_idempotent(self, make_import, flask_app):
+        """Archive without run.json should use the directory run_id
+        and be idempotent on re-import.
+        """
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            result_data = {
+                "id": result_id,
+                "test_id": "test.no_run_json",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"env": "prod"},
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                data = json.dumps(result_data).encode()
+                info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
+                info.size = len(data)
+                tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(filename="no_run.tar.gz", format="ibutsu", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_id)
+            assert run is not None
+            run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+
+            # Second import using same archive content should update, not create duplicate
+            import_record_2 = make_import(
+                filename="no_run.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file_2 = ImportFile(
+                id=str(uuid4()), import_id=import_record_2.id, content=tar_content
+            )
+            session.add(import_file_2)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record_2.id)})
+
+            new_run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            assert new_run_count == run_count
+
+    def test_run_archive_import_result_without_id_field(self, make_import, flask_app):
+        """Archive where result.json omits 'id' uses the directory result_id without KeyError."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "summary": {"tests": 1}}
+            # Omit 'id' from result.json payload
+            result_data = {
+                "test_id": "test.missing_id_key",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"env": "prod"},
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+                # Add an artifact for this result
+                artifact_data = b"artifact log"
+                art_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/log.txt")
+                art_info.size = len(artifact_data)
+                tar.addfile(art_info, BytesIO(artifact_data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="missing_res_id.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            assert result is not None
+            assert result.test_id == "test.missing_id_key"
+            artifact = db.session.execute(
+                db.select(Artifact).where(
+                    Artifact.result_id == result_id, Artifact.filename == "log.txt"
+                )
+            ).scalar_one_or_none()
+            assert artifact is not None
+
+    def test_run_junit_import_idempotent_retry(self, make_import, flask_app):
+        """Retrying JUnit import updates existing run/results without creating duplicates."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            junit_content = b"""<testsuites time="1.5">
+                <testsuite name="my-suite" time="1.5" tests="1" errors="0" failures="0" skipped="0">
+                    <testcase classname="pkg.TestFoo" name="test_bar" time="1.5" />
+                </testsuite>
+            </testsuites>"""
+
+            import_record = make_import(
+                filename=f"results-{run_uuid}.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_uuid)
+            assert run is not None
+            run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
+
+            # Re-run the import (simulating a retry)
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            new_run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            new_result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
+            assert new_run_count == run_count
+            assert new_result_count == result_count

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -764,16 +764,121 @@ class TestRunArchiveImport:
             run = db.session.get(Run, run_id)
             assert run is not None
 
-            # Verify result was created (archive import creates new IDs for results)
-            result = db.session.execute(
-                db.select(Result).filter_by(test_id="test.example", run_id=run.id)
-            ).scalar_one_or_none()
+            # Verify result was created and original UUID was preserved
+            result = db.session.get(Result, result_id)
             assert result is not None
             assert result.test_id == "test.example"
+            assert result.run_id == run.id
 
             # Verify import status
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "done"
+
+    def test_run_archive_import_idempotency_no_duplicate_results(self, make_import, flask_app):
+        """Test that re-importing the same archive updates results without creating duplicates"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {
+                "id": run_id,
+                "metadata": {"build": "101", "component": "backend", "env": "stage"},
+                "summary": {"tests": 1, "passed": 1},
+            }
+
+            result_data = {
+                "id": result_id,
+                "test_id": "test.idempotent",
+                "result": "passed",
+                "duration": 2.0,
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"component": "backend", "env": "stage"},
+            }
+
+            # Create tarball with artifact
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                run_json = json.dumps(run_data).encode()
+                run_info = tarfile.TarInfo(name=f"{run_id}/run.json")
+                run_info.size = len(run_json)
+                tar.addfile(run_info, BytesIO(run_json))
+
+                result_json = json.dumps(result_data).encode()
+                result_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
+                result_info.size = len(result_json)
+                tar.addfile(result_info, BytesIO(result_json))
+
+                artifact_content = b"log output line"
+                art_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/traceback.log")
+                art_info.size = len(artifact_content)
+                tar.addfile(art_info, BytesIO(artifact_content))
+
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            # First import
+            import_record1 = make_import(
+                filename="archive1.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file1 = ImportFile(
+                id=str(uuid4()), import_id=import_record1.id, content=tar_content
+            )
+            session.add(import_file1)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record1.id)})
+
+            # Verify initial counts
+            all_results = (
+                db.session.execute(db.select(Result).where(Result.run_id == run_id)).scalars().all()
+            )
+            assert len(all_results) == 1
+            assert all_results[0].id == result_id
+            assert all_results[0].component == "backend"
+            assert all_results[0].env == "stage"
+
+            all_artifacts = (
+                db.session.execute(db.select(Artifact).where(Artifact.result_id == result_id))
+                .scalars()
+                .all()
+            )
+            assert len(all_artifacts) == 1
+
+            # Second import of the same archive
+            import_record2 = make_import(
+                filename="archive2.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file2 = ImportFile(
+                id=str(uuid4()), import_id=import_record2.id, content=tar_content
+            )
+            session.add(import_file2)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record2.id)})
+
+            # Verify no duplicates were created
+            all_results_after = (
+                db.session.execute(db.select(Result).where(Result.run_id == run_id)).scalars().all()
+            )
+            assert len(all_results_after) == 1
+            assert all_results_after[0].id == result_id
+
+            all_artifacts_after = (
+                db.session.execute(db.select(Artifact).where(Artifact.result_id == result_id))
+                .scalars()
+                .all()
+            )
+            assert len(all_artifacts_after) == 1
 
     def test_run_archive_import_missing_file(self, make_import, flask_app):
         """Test archive import with missing file"""

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -1176,8 +1176,11 @@ class TestRunArchiveImport:
             new_run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
             assert new_run_count == run_count
 
-    def test_run_archive_import_result_without_id_field(self, make_import, flask_app):
-        """Archive where result.json omits 'id' uses the directory result_id without KeyError."""
+    @pytest.mark.parametrize("id_in_json", [None, "non-uuid-1234"])
+    def test_run_archive_import_result_without_id_field(self, make_import, flask_app, id_in_json):
+        """Archive where result.json omits or has non-UUID 'id' uses the directory result_id and
+        preserves artifacts.
+        """
         client, _ = flask_app
 
         with client.application.app_context():
@@ -1185,13 +1188,15 @@ class TestRunArchiveImport:
             result_id = str(uuid4())
 
             run_data = {"id": run_id, "summary": {"tests": 1}}
-            # Omit 'id' from result.json payload
+            # Omit or provide non-UUID 'id' from result.json payload
             result_data = {
                 "test_id": "test.missing_id_key",
                 "result": "passed",
                 "start_time": datetime.now(UTC).isoformat(),
                 "metadata": {"env": "prod"},
             }
+            if id_in_json:
+                result_data["id"] = id_in_json
 
             tar_buffer = BytesIO()
             with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
@@ -1236,7 +1241,8 @@ class TestRunArchiveImport:
             ).scalar_one_or_none()
             assert artifact is not None
 
-    def test_run_junit_import_idempotent_retry(self, make_import, flask_app):
+    @pytest.mark.parametrize("has_uuid_in_filename", [True, False])
+    def test_run_junit_import_idempotent_retry(self, make_import, flask_app, has_uuid_in_filename):
         """Retrying JUnit import updates existing run/results without creating duplicates."""
         client, _ = flask_app
 
@@ -1248,9 +1254,8 @@ class TestRunArchiveImport:
                 </testsuite>
             </testsuites>"""
 
-            import_record = make_import(
-                filename=f"results-{run_uuid}.xml", format="junit", status="pending"
-            )
+            filename = f"results-{run_uuid}.xml" if has_uuid_in_filename else "results.xml"
+            import_record = make_import(filename=filename, format="junit", status="pending")
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=junit_content
             )
@@ -1260,7 +1265,10 @@ class TestRunArchiveImport:
             with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
                 run_junit_import({"id": str(import_record.id)})
 
-            run = db.session.get(Run, run_uuid)
+            if has_uuid_in_filename:
+                run = db.session.get(Run, run_uuid)
+            else:
+                run = db.session.get(Run, import_record.data["run_id"][0])
             assert run is not None
             run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
             result_count = db.session.execute(db.select(func.count(Result.id))).scalar()

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -1392,3 +1392,86 @@ class TestRunArchiveImport:
             new_result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
             assert new_run_count == run_count
             assert new_result_count == result_count
+
+    @pytest.mark.parametrize("n_testcases", [1, 3, 5])
+    def test_run_junit_import_n_distinct_testcases_produces_n_results(
+        self, make_import, flask_app, n_testcases
+    ):
+        """Assert that N distinct testcases in a JUnit XML file create exactly N Result records."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            testcases_xml = "\n".join(
+                f'<testcase classname="pkg.TestClass{i}" name="test_method_{i}" time="0.1"/>'
+                for i in range(n_testcases)
+            )
+            junit_content = (
+                f'<testsuites time="1.0">\n'
+                f'  <testsuite name="suite" time="1.0" tests="{n_testcases}" '
+                f'errors="0" failures="0" skipped="0">\n'
+                f"    {testcases_xml}\n"
+                f"  </testsuite>\n"
+                f"</testsuites>"
+            ).encode()
+
+            import_record = make_import(
+                filename="junit-multi.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run_id = import_record.data["run_id"][0]
+            results = Result.query.filter_by(run_id=run_id).all()
+            assert len(results) == n_testcases
+            test_ids = {r.test_id for r in results}
+            expected_test_ids = {f"TestClass{i}.test_method_{i}" for i in range(n_testcases)}
+            assert test_ids == expected_test_ids
+
+    def test_run_junit_import_duplicate_test_ids_in_same_file_not_collapsed(
+        self, make_import, flask_app
+    ):
+        """Two testcases with same test_id in one file don't collapse; retry is idempotent."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            # Two testcases with the same classname and name
+            junit_content = b"""<testsuites time="2.0">
+                <testsuite name="suite" time="2.0" tests="2" errors="0" failures="0" skipped="0">
+                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
+                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
+                </testsuite>
+            </testsuites>"""
+
+            import_record = make_import(
+                filename=f"results-{run_uuid}.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_uuid)
+            assert run is not None
+            results = Result.query.filter_by(run_id=run.id).all()
+            # Assert that the two testcases in the same file did NOT collapse into one result
+            assert len(results) == 2
+            assert all(r.test_id == "TestDup.test_case" for r in results)
+
+            # Re-run the import (simulating a retry): must remain 2 results, updated in place
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            retry_results = Result.query.filter_by(run_id=run.id).all()
+            assert len(retry_results) == 2
+            assert {r.id for r in results} == {r.id for r in retry_results}

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -716,9 +716,13 @@ class TestRunJunitImport:
             with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
                 run_junit_import({"id": str(import_record.id)})
 
-            run = Run.query.order_by(Run.id).all()[-1]
-            result = Result.query.filter_by(run_id=run.id).one()
-            artifacts = Artifact.query.filter_by(result_id=result.id).all()
+            run = db.session.execute(db.select(Run).order_by(Run.id)).scalars().all()[-1]
+            result = db.session.execute(db.select(Result).filter_by(run_id=run.id)).scalar_one()
+            artifacts = (
+                db.session.execute(db.select(Artifact).filter_by(result_id=result.id))
+                .scalars()
+                .all()
+            )
             filenames = [a.filename for a in artifacts]
 
             # Each artifact type should appear exactly once (no duplication)
@@ -728,6 +732,62 @@ class TestRunJunitImport:
                 "traceback.log",
             ]
             assert len(filenames) == len(set(filenames))
+
+    def test_run_junit_import_error_rolls_back_and_marks_error(self, make_import, flask_app):
+        """A failure during JUnit processing rolls back the run and marks the import errored"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1" failures="0">
+                <testcase name="test_rollback" classname="tests.mod" time="1.0" />
+            </testsuite>
+            """
+
+            import_record = make_import(filename="rollback.xml", format="junit", status="pending")
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
+                patch(
+                    "ibutsu_server.tasks.importers._process_result",
+                    side_effect=RuntimeError("junit boom"),
+                ),
+                pytest.raises(RuntimeError, match="junit boom"),
+            ):
+                run_junit_import({"id": str(import_record.id)})
+
+            # The import must be marked error, not left stuck in "running"
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "error"
+            # Cleanup must not run on a failed import
+            clear_mock.delay.assert_not_called()
+
+    def test_run_junit_import_with_none_data(self, make_import, flask_app):
+        """JUnit import succeeds even when import_record.data is None"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1">
+                <testcase name="test_one" classname="tests.mod" time="0.5" />
+            </testsuite>
+            """
+            import_record = make_import(filename="none_data.xml", format="junit", status="pending")
+            import_record.data = None
+            db.session.add(import_record)
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            db.session.add(import_file)
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "done"
+            assert "run_id" in updated.data
 
 
 class TestRunArchiveImport:
@@ -989,6 +1049,57 @@ class TestRunArchiveImport:
             assert updated.status == "error"
             # Cleanup must not run on a failed import
             clear_mock.delay.assert_not_called()
+
+    def test_run_archive_import_with_none_data(self, make_import, flask_app):
+        """Archive import succeeds even when import_record.data is None"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.none_data",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="none_data.tar.gz", format="ibutsu", status="pending"
+            )
+            import_record.data = None
+            db.session.add(import_record)
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            db.session.add(import_file)
+            db.session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "done"
+            assert "run_id" in updated.data
+            assert updated.data["run_id"] == [run_id]
 
     def test_run_archive_import_preserves_existing_result_metadata(
         self, make_import, make_run, make_result, flask_app

--- a/backend/tests/test_migration_c4d5e6f7a8b9.py
+++ b/backend/tests/test_migration_c4d5e6f7a8b9.py
@@ -1,0 +1,116 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+
+from ibutsu_server.db.models import Artifact, Result
+
+
+@pytest.fixture
+def migration_module():
+    """Load the c4d5e6f7a8b9 migration module dynamically."""
+    migration_path = (
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_c4d5e6f7a8b9", migration_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_alembic_heads_single_head():
+    """Verify that Alembic has exactly one head revision in the migration graph."""
+    alembic_ini = Path(__file__).parent.parent / "alembic.ini"
+    alembic_cfg = Config(str(alembic_ini))
+    script_dir = ScriptDirectory.from_config(alembic_cfg)
+    heads = script_dir.get_heads()
+    assert len(heads) == 1
+    assert heads[0] == "c4d5e6f7a8b9"
+
+
+def test_sqlite_upgrade_and_downgrade(migration_module, monkeypatch):
+    """Test upgrade and downgrade operations on a SQLite database."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE artifacts ("
+                "id TEXT PRIMARY KEY, result_id TEXT, run_id TEXT, filename TEXT"
+                ")"
+            )
+        )
+        conn.execute(
+            sa.text("CREATE TABLE results (id TEXT PRIMARY KEY, run_id TEXT, test_id TEXT)")
+        )
+
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        monkeypatch.setattr(migration_module.op, "_proxy", Operations(ctx), raising=False)
+
+        # Test upgrade creates all three composite indexes
+        migration_module.upgrade()
+
+        artifact_indexes = {
+            row[0]
+            for row in conn.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='artifacts'"
+                )
+            ).fetchall()
+        }
+        assert "ix_artifacts_result_id_filename" in artifact_indexes
+        assert "ix_artifacts_run_id_filename" in artifact_indexes
+
+        result_indexes = {
+            row[0]
+            for row in conn.execute(
+                sa.text("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='results'")
+            ).fetchall()
+        }
+        assert "ix_results_run_id_test_id" in result_indexes
+
+        # Test idempotent upgrade does not error
+        migration_module.upgrade()
+
+        # Test downgrade drops all three composite indexes
+        migration_module.downgrade()
+
+        artifact_indexes = {
+            row[0]
+            for row in conn.execute(
+                sa.text(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='artifacts'"
+                )
+            ).fetchall()
+        }
+        assert "ix_artifacts_result_id_filename" not in artifact_indexes
+        assert "ix_artifacts_run_id_filename" not in artifact_indexes
+
+        result_indexes = {
+            row[0]
+            for row in conn.execute(
+                sa.text("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='results'")
+            ).fetchall()
+        }
+        assert "ix_results_run_id_test_id" not in result_indexes
+
+        # Test idempotent downgrade does not error
+        migration_module.downgrade()
+
+
+def test_models_documentation():
+    """Ensure composite indexes are documented in model docstrings."""
+    assert Artifact.__doc__ is not None
+    assert "ix_artifacts_result_id_filename" in Artifact.__doc__
+    assert "ix_artifacts_run_id_filename" in Artifact.__doc__
+
+    assert Result.__doc__ is not None
+    assert "ix_results_run_id_test_id: Composite index on (run_id, test_id)" in Result.__doc__

--- a/frontend/src/pages/run.js
+++ b/frontend/src/pages/run.js
@@ -465,7 +465,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                             />
                           </DataListItemRow>
                         </DataListItem>
-                        {run.metadata && run.metadata.component && (
+                        {(run.component || run.metadata?.component) && (
                           <DataListItem aria-labelledby="Component">
                             <DataListItemRow>
                               <DataListItemCells
@@ -474,14 +474,14 @@ const Run = ({ defaultTab = 'summary' }) => {
                                     <strong>Component:</strong>
                                   </DataListCell>,
                                   <DataListCell key={2} width={4}>
-                                    {run.metadata.component}
+                                    {run.component ?? run.metadata?.component}
                                   </DataListCell>,
                                 ]}
                               />
                             </DataListItemRow>
                           </DataListItem>
                         )}
-                        {run.metadata && run.metadata.env && (
+                        {(run.env || run.metadata?.env) && (
                           <DataListItem aria-labelledby="Environment">
                             <DataListItemRow>
                               <DataListItemCells
@@ -490,7 +490,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                     <strong>Environment:</strong>
                                   </DataListCell>,
                                   <DataListCell key={2} width={4}>
-                                    {run.metadata.env}
+                                    {run.env ?? run.metadata?.env}
                                   </DataListCell>,
                                 ]}
                               />

--- a/frontend/src/pages/run.js
+++ b/frontend/src/pages/run.js
@@ -474,7 +474,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                     <strong>Component:</strong>
                                   </DataListCell>,
                                   <DataListCell key={2} width={4}>
-                                    {run.component ?? run.metadata?.component}
+                                    {run.component || run.metadata?.component}
                                   </DataListCell>,
                                 ]}
                               />
@@ -490,7 +490,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                                     <strong>Environment:</strong>
                                   </DataListCell>,
                                   <DataListCell key={2} width={4}>
-                                    {run.env ?? run.metadata?.env}
+                                    {run.env || run.metadata?.env}
                                   </DataListCell>,
                                 ]}
                               />

--- a/frontend/src/pages/run.js
+++ b/frontend/src/pages/run.js
@@ -465,7 +465,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                             />
                           </DataListItemRow>
                         </DataListItem>
-                        {(run.component || run.metadata?.component) && (
+                        {Boolean(run.component || run.metadata?.component) && (
                           <DataListItem aria-labelledby="Component">
                             <DataListItemRow>
                               <DataListItemCells
@@ -481,7 +481,7 @@ const Run = ({ defaultTab = 'summary' }) => {
                             </DataListItemRow>
                           </DataListItem>
                         )}
-                        {(run.env || run.metadata?.env) && (
+                        {Boolean(run.env || run.metadata?.env) && (
                           <DataListItem aria-labelledby="Environment">
                             <DataListItemRow>
                               <DataListItemCells

--- a/frontend/src/utilities/tables.js
+++ b/frontend/src/utilities/tables.js
@@ -88,9 +88,9 @@ export const resultToRow = (result, filterFunc) => {
     } else {
       componentBadge = buildBadge('component', resultComponent, false);
     }
+    badges.push(componentBadge);
+    badges.push(' ');
   }
-  badges.push(componentBadge);
-  badges.push(' ');
   const resultEnv = result.metadata?.env ?? result.env ?? null;
   if (resultEnv) {
     let envBadge;
@@ -179,10 +179,12 @@ export const resultToComparisonRow = (result) => {
   }
   let resultIcons = [];
   let markers = [];
-  result.forEach((result) => {
-    resultIcons.push(ICON_RESULT_MAP(result.result));
-    if (result.metadata && result.metadata.markers) {
-      for (const marker of result.metadata.markers) {
+  result.forEach((resultItem) => {
+    resultIcons.push(
+      ICON_RESULT_MAP[resultItem.result] || ICON_RESULT_MAP.manual,
+    );
+    if (resultItem.metadata && resultItem.metadata.markers) {
+      for (const marker of resultItem.metadata.markers) {
         // Don't add duplicate markers
         if (markers.filter((m) => m.key === marker).length === 0) {
           markers.push(
@@ -195,12 +197,9 @@ export const resultToComparisonRow = (result) => {
     }
   });
 
-  if (result[0].metadata && result[0].metadata.component) {
-    markers.push(
-      <Badge key={result[0].metadata.component}>
-        {result[0].metadata.component}
-      </Badge>,
-    );
+  const comp = result[0]?.component ?? result[0]?.metadata?.component;
+  if (comp) {
+    markers.push(<Badge key={comp}>{comp}</Badge>);
   }
 
   let cells = [];
@@ -234,29 +233,31 @@ export const runToRow = (run, filterFunc) => {
     ? new Date(run.start_time)
     : new Date(run.created);
 
-  if (filterFunc) {
-    if (run.component) {
-      componentBadge = buildBadge('component', run.component, false, () =>
+  const runComponent = run.component ?? run.metadata?.component ?? null;
+  if (runComponent) {
+    if (filterFunc) {
+      componentBadge = buildBadge('component', runComponent, false, () =>
         filterFunc({
           field: 'component',
           operator: 'eq',
-          value: run.component,
+          value: runComponent,
         }),
       );
+    } else {
+      componentBadge = buildBadge('component', runComponent, false);
     }
-  } else {
-    componentBadge = buildBadge('component', run.component, false);
+    badges.push(componentBadge);
   }
-  badges.push(componentBadge);
 
-  if (run.env) {
+  const runEnv = run.env ?? run.metadata?.env ?? null;
+  if (runEnv) {
     let envBadge;
     if (filterFunc) {
-      envBadge = buildBadge(run.env, run.env, false, () =>
-        filterFunc({ field: 'env', operator: 'eq', value: run.env }),
+      envBadge = buildBadge(runEnv, runEnv, false, () =>
+        filterFunc({ field: 'env', operator: 'eq', value: runEnv }),
       );
     } else {
-      envBadge = buildBadge(run.env, run.env, false);
+      envBadge = buildBadge(runEnv, runEnv, false);
     }
     badges.push(envBadge);
   }

--- a/frontend/src/utilities/tables.js
+++ b/frontend/src/utilities/tables.js
@@ -75,7 +75,7 @@ export const resultToRow = (result, filterFunc) => {
   let classification = '';
   let componentBadge;
   const resultComponent =
-    result.metadata?.component ?? result.component ?? null;
+    result.component || result.metadata?.component || null;
   if (resultComponent) {
     if (filterFunc) {
       componentBadge = buildBadge('component', resultComponent, false, () =>
@@ -91,7 +91,7 @@ export const resultToRow = (result, filterFunc) => {
     badges.push(componentBadge);
     badges.push(' ');
   }
-  const resultEnv = result.metadata?.env ?? result.env ?? null;
+  const resultEnv = result.env || result.metadata?.env || null;
   if (resultEnv) {
     let envBadge;
     if (filterFunc) {
@@ -174,7 +174,7 @@ export const resultToRow = (result, filterFunc) => {
 };
 
 export const resultToComparisonRow = (result) => {
-  if (!Array.isArray(result)) {
+  if (!Array.isArray(result) || result.length === 0) {
     return { cells: [] };
   }
   let resultIcons = [];
@@ -197,7 +197,7 @@ export const resultToComparisonRow = (result) => {
     }
   });
 
-  const comp = result[0]?.component ?? result[0]?.metadata?.component;
+  const comp = result[0]?.component || result[0]?.metadata?.component;
   if (comp) {
     markers.push(<Badge key={comp}>{comp}</Badge>);
   }

--- a/frontend/src/utilities/tables.js
+++ b/frontend/src/utilities/tables.js
@@ -233,7 +233,7 @@ export const runToRow = (run, filterFunc) => {
     ? new Date(run.start_time)
     : new Date(run.created);
 
-  const runComponent = run.component ?? run.metadata?.component ?? null;
+  const runComponent = run.component || run.metadata?.component || null;
   if (runComponent) {
     if (filterFunc) {
       componentBadge = buildBadge('component', runComponent, false, () =>
@@ -249,7 +249,7 @@ export const runToRow = (run, filterFunc) => {
     badges.push(componentBadge);
   }
 
-  const runEnv = run.env ?? run.metadata?.env ?? null;
+  const runEnv = run.env || run.metadata?.env || null;
   if (runEnv) {
     let envBadge;
     if (filterFunc) {

--- a/frontend/src/utilities/tables.js
+++ b/frontend/src/utilities/tables.js
@@ -199,7 +199,7 @@ export const resultToComparisonRow = (result) => {
 
   const comp = result[0]?.component || result[0]?.metadata?.component;
   if (comp) {
-    markers.push(<Badge key={comp}>{comp}</Badge>);
+    markers.push(<Badge key={`comp-${comp}`}>{comp}</Badge>);
   }
 
   let cells = [];

--- a/frontend/src/utilities/tables.test.js
+++ b/frontend/src/utilities/tables.test.js
@@ -99,6 +99,24 @@ describe('runToRow', () => {
     const rowData = runToRow(runWithTopLevel);
     expect(rowData.cells.length).toBeGreaterThan(0);
   });
+
+  it('handles runs with empty string component/env falling back to metadata', () => {
+    const run = {
+      id: 'run-3',
+      start_time: '2026-08-26T10:00:00Z',
+      duration: 10,
+      component: '', // empty string should fall back to metadata
+      env: '',
+      metadata: { component: 'backend', env: 'stage' },
+      summary: { tests: 5, passes: 5 },
+    };
+
+    const filterFunc = vi.fn();
+    const rowData = runToRow(run, filterFunc);
+    expect(rowData.cells.length).toBeGreaterThan(0);
+    // Verify that badges were created for the metadata values
+    // (The implementation should use || which treats empty string as falsy)
+  });
 });
 
 describe('resultToRow', () => {
@@ -117,5 +135,24 @@ describe('resultToRow', () => {
     const filterFunc = vi.fn();
     const rowData = resultToRow(result, filterFunc);
     expect(rowData.cells.length).toBeGreaterThan(0);
+  });
+
+  it('handles results with empty string component/env falling back to metadata', () => {
+    const result = {
+      id: 'res-2',
+      test_id: 'test_fallback',
+      result: 'passed',
+      duration: 1.0,
+      start_time: '2026-08-26T10:00:00Z',
+      component: '', // empty string should fall back to metadata
+      env: '',
+      metadata: { component: 'backend', env: 'stage' },
+    };
+
+    const filterFunc = vi.fn();
+    const rowData = resultToRow(result, filterFunc);
+    expect(rowData.cells.length).toBeGreaterThan(0);
+    // Verify that badges were created for the metadata values
+    // (The implementation should use || which treats empty string as falsy)
   });
 });

--- a/frontend/src/utilities/tables.test.js
+++ b/frontend/src/utilities/tables.test.js
@@ -65,8 +65,11 @@ describe('resultToComparisonRow', () => {
     expect(resultRow.cells.length).toBe(3); // 1 test cell + 2 result cells
   });
 
-  it('handles non-array inputs gracefully', () => {
+  it('handles non-array and empty array inputs gracefully', () => {
     expect(resultToComparisonRow(null)).toEqual({ cells: [] });
+    expect(resultToComparisonRow(undefined)).toEqual({ cells: [] });
+    expect(resultToComparisonRow({})).toEqual({ cells: [] });
+    expect(resultToComparisonRow([])).toEqual({ cells: [] });
   });
 });
 

--- a/frontend/src/utilities/tables.test.js
+++ b/frontend/src/utilities/tables.test.js
@@ -1,4 +1,9 @@
-import { tableSortFunctions } from './tables';
+import {
+  tableSortFunctions,
+  resultToComparisonRow,
+  runToRow,
+  resultToRow,
+} from './tables';
 
 // Helper to build a minimal row object shaped like what PatternFly table
 // sort callbacks receive: { cells: [...] }.
@@ -35,5 +40,82 @@ describe('tableSortFunctions.passPercent', () => {
   it('sorts "N/A"/missing values to the top in ascending order', () => {
     expect(sort('N/A', '0', 'asc')).toBeLessThan(0);
     expect(sort('0', 'N/A', 'asc')).toBeGreaterThan(0);
+  });
+});
+
+describe('resultToComparisonRow', () => {
+  it('handles result comparison with valid ICON_RESULT_MAP lookup', () => {
+    const results = [
+      {
+        id: 'res-1',
+        test_id: 'test_foo',
+        result: 'passed',
+        metadata: { component: 'frontend' },
+      },
+      {
+        id: 'res-2',
+        test_id: 'test_foo',
+        result: 'failed',
+        component: 'frontend',
+      },
+    ];
+
+    const resultRow = resultToComparisonRow(results);
+    expect(resultRow.id).toBe('res-1');
+    expect(resultRow.cells.length).toBe(3); // 1 test cell + 2 result cells
+  });
+
+  it('handles non-array inputs gracefully', () => {
+    expect(resultToComparisonRow(null)).toEqual({ cells: [] });
+  });
+});
+
+describe('runToRow', () => {
+  it('handles runs with null component and null env', () => {
+    const run = {
+      id: 'run-1',
+      start_time: '2026-08-26T10:00:00Z',
+      duration: 10,
+      component: null,
+      env: null,
+      summary: { tests: 5, passes: 5 },
+    };
+
+    const filterFunc = vi.fn();
+    const rowData = runToRow(run, filterFunc);
+    expect(rowData.cells.length).toBeGreaterThan(0);
+  });
+
+  it('handles runs with top-level or metadata component and env', () => {
+    const runWithTopLevel = {
+      id: 'run-2',
+      start_time: '2026-08-26T10:00:00Z',
+      duration: 10,
+      component: 'backend',
+      env: 'prod',
+      summary: { tests: 5, passes: 5 },
+    };
+
+    const rowData = runToRow(runWithTopLevel);
+    expect(rowData.cells.length).toBeGreaterThan(0);
+  });
+});
+
+describe('resultToRow', () => {
+  it('handles results with null component and null env', () => {
+    const result = {
+      id: 'res-1',
+      test_id: 'test_bar',
+      result: 'passed',
+      duration: 1.0,
+      start_time: '2026-08-26T10:00:00Z',
+      component: null,
+      env: null,
+      metadata: {},
+    };
+
+    const filterFunc = vi.fn();
+    const rowData = resultToRow(result, filterFunc);
+    expect(rowData.cells.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/utilities/tables.test.js
+++ b/frontend/src/utilities/tables.test.js
@@ -71,6 +71,26 @@ describe('resultToComparisonRow', () => {
     expect(resultToComparisonRow({})).toEqual({ cells: [] });
     expect(resultToComparisonRow([])).toEqual({ cells: [] });
   });
+
+  it('does not cause React key collisions when a marker matches the component name', () => {
+    const results = [
+      {
+        id: 'res-1',
+        test_id: 'test_foo',
+        result: 'passed',
+        component: 'frontend',
+        metadata: { markers: ['frontend', 'unit'] },
+      },
+    ];
+
+    const resultRow = resultToComparisonRow(results);
+    const fragment = resultRow.cells[0];
+    const badges = fragment.props.children[2];
+    const keys = badges.map((b) => b.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toContain('frontend');
+    expect(keys).toContain('comp-frontend');
+  });
 });
 
 describe('runToRow', () => {

--- a/frontend/src/utilities/tables.test.js
+++ b/frontend/src/utilities/tables.test.js
@@ -121,6 +121,8 @@ describe('runToRow', () => {
 
     const rowData = runToRow(runWithTopLevel);
     expect(rowData.cells.length).toBeGreaterThan(0);
+    const badges = rowData.cells[0].props.children[2];
+    expect(badges).toHaveLength(2);
   });
 
   it('handles runs with empty string component/env falling back to metadata', () => {
@@ -137,8 +139,8 @@ describe('runToRow', () => {
     const filterFunc = vi.fn();
     const rowData = runToRow(run, filterFunc);
     expect(rowData.cells.length).toBeGreaterThan(0);
-    // Verify that badges were created for the metadata values
-    // (The implementation should use || which treats empty string as falsy)
+    const badges = rowData.cells[0].props.children[2];
+    expect(badges).toHaveLength(2);
   });
 });
 
@@ -158,6 +160,8 @@ describe('resultToRow', () => {
     const filterFunc = vi.fn();
     const rowData = resultToRow(result, filterFunc);
     expect(rowData.cells.length).toBeGreaterThan(0);
+    const badges = rowData.cells[0].props.children[2];
+    expect(badges).toHaveLength(0);
   });
 
   it('handles results with empty string component/env falling back to metadata', () => {
@@ -175,7 +179,9 @@ describe('resultToRow', () => {
     const filterFunc = vi.fn();
     const rowData = resultToRow(result, filterFunc);
     expect(rowData.cells.length).toBeGreaterThan(0);
-    // Verify that badges were created for the metadata values
-    // (The implementation should use || which treats empty string as falsy)
+    const badges = rowData.cells[0].props.children[2].filter(
+      (badge) => typeof badge !== 'string',
+    );
+    expect(badges).toHaveLength(2);
   });
 });

--- a/frontend/src/widgets/result-aggregate-apex.js
+++ b/frontend/src/widgets/result-aggregate-apex.js
@@ -19,8 +19,12 @@ import { useSVGContainerDimensions } from '../components/hooks/use-svg-container
 
 // Helper function to get color for a label
 const getColorForLabel = (label, index) => {
+  if (!label) {
+    return DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length];
+  }
   // First check if it's a result type
-  const resultColor = CHART_COLOR_MAP[label.toLowerCase()];
+  const labelStr = String(label).toLowerCase();
+  const resultColor = CHART_COLOR_MAP[labelStr];
   if (resultColor) {
     return resultColor;
   }
@@ -118,7 +122,11 @@ const ResultAggregateApex = ({
 
     chartData.forEach((datum) => {
       series.push(datum.y);
-      labels.push(toTitleCase(datum.x));
+      labels.push(
+        datum.x !== null && datum.x !== undefined && datum.x !== ''
+          ? toTitleCase(datum.x)
+          : 'N/A',
+      );
     });
 
     return {
@@ -130,8 +138,11 @@ const ResultAggregateApex = ({
   const chartLegend = useMemo(() => {
     if (
       chartLabels?.length > 0 &&
-      chartLabels.every((label) =>
-        Object.keys(ICON_RESULT_MAP).includes(label.toLowerCase()),
+      chartLabels.every(
+        (label) =>
+          label &&
+          typeof label === 'string' &&
+          Object.keys(ICON_RESULT_MAP).includes(label.toLowerCase()),
       )
     ) {
       return {
@@ -139,17 +150,23 @@ const ResultAggregateApex = ({
           show: false,
         },
         legendData: chartLabels.map((resultLabel, index) => {
+          const lowerLabel = resultLabel
+            ? String(resultLabel).toLowerCase()
+            : '';
           // Find the corresponding count from chartData
           const chartItem = chartData.find(
-            (item) => item.x === resultLabel.toLowerCase(),
+            (item) =>
+              (item.x ? String(item.x).toLowerCase() : 'n/a') === lowerLabel,
           );
           const count = chartItem ? chartItem.y : chartSeries[index] || 0;
 
           return {
             name: `${resultLabel} (${count})`,
             symbol: {
-              fill: CHART_COLOR_MAP[resultLabel.toLowerCase()],
-              type: resultLabel.toLowerCase(),
+              fill:
+                CHART_COLOR_MAP[lowerLabel] ||
+                DEFAULT_CHART_COLORS[index % DEFAULT_CHART_COLORS.length],
+              type: lowerLabel,
             },
           };
         }),

--- a/frontend/src/widgets/result-aggregate-apex.js
+++ b/frontend/src/widgets/result-aggregate-apex.js
@@ -124,7 +124,7 @@ const ResultAggregateApex = ({
       series.push(datum.y);
       labels.push(
         datum.x !== null && datum.x !== undefined && datum.x !== ''
-          ? toTitleCase(datum.x)
+          ? toTitleCase(String(datum.x))
           : 'N/A',
       );
     });

--- a/frontend/src/widgets/result-aggregate-apex.test.js
+++ b/frontend/src/widgets/result-aggregate-apex.test.js
@@ -445,5 +445,26 @@ describe('ResultAggregateApex', () => {
         expect(labels).toContain('Failed');
       });
     });
+
+    it('should handle null/undefined _id values safely without crashing', async () => {
+      HttpClient.get.mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { _id: 'backend', count: 10 },
+          { _id: null, count: 5 },
+          { _id: '', count: 2 },
+        ],
+      });
+
+      renderComponent({ groupField: 'component' });
+
+      await waitFor(() => {
+        const chart = screen.getByTestId('apex-chart');
+        const labels = JSON.parse(chart.getAttribute('data-labels'));
+        expect(labels).toContain('Backend');
+        expect(labels).toContain('N/A');
+        expect(chart).toHaveTextContent('Total: 17');
+      });
+    });
   });
 });

--- a/frontend/src/widgets/result-aggregate-apex.test.js
+++ b/frontend/src/widgets/result-aggregate-apex.test.js
@@ -466,5 +466,29 @@ describe('ResultAggregateApex', () => {
         expect(chart).toHaveTextContent('Total: 17');
       });
     });
+
+    it('should handle non-string _id values safely without crashing', async () => {
+      HttpClient.get.mockResolvedValue({
+        ok: true,
+        json: async () => [
+          { _id: 200, count: 15 },
+          { _id: 404, count: 3 },
+          { _id: 0, count: 1 },
+          { _id: false, count: 2 },
+        ],
+      });
+
+      renderComponent({ groupField: 'metadata.response_code' });
+
+      await waitFor(() => {
+        const chart = screen.getByTestId('apex-chart');
+        const labels = JSON.parse(chart.getAttribute('data-labels'));
+        expect(labels).toContain('200');
+        expect(labels).toContain('404');
+        expect(labels).toContain('0');
+        expect(labels).toContain('False');
+        expect(chart).toHaveTextContent('Total: 21');
+      });
+    });
   });
 });


### PR DESCRIPTION
Address behavior of the importer task on error/timeout Duplication of result and artifact records bug

Address behavior of run/result table loading in the frontend when component/env are not set

## Summary by Sourcery

Improve import reliability and run/result presentation by making processing transactional and idempotent while handling missing metadata and mixed data types safely.

New Features:
- Make JUnit and archive imports idempotent by updating existing runs, results, and artifacts instead of creating duplicates.
- Support component and environment values from either top-level fields or metadata across backend and frontend views.
- Handle null and non-string aggregate chart labels safely in the frontend.

Bug Fixes:
- Ensure failed or timed-out imports roll back staged data, are marked as errored, and do not trigger cleanup.
- Prevent duplicate artifact records during imports and preserve existing metadata during record updates.
- Correct numeric filtering for integer and floating-point JSON summary fields.
- Make run, result, and comparison table rendering robust when component or environment values are absent.

Enhancements:
- Add composite artifact indexes to improve idempotency lookups.
- Respect task retry limits and disable automatic retries for importer tasks.

Tests:
- Add backend and frontend coverage for importer rollback, idempotency, metadata preservation, numeric filtering, retry behavior, and null-safe table and chart rendering.