### PR TITLE
Keep worker commands for hostname

### DIFF
--- a/backend/docker/Dockerfile.worker
+++ b/backend/docker/Dockerfile.worker
@@ -25,10 +25,15 @@ USER 1001
 #   CELERY_POOL: Pool type (prefork/gevent/threads) - default: gevent
 #   CELERY_AUTOSCALE: Autoscale settings (e.g., "10,2") - overrides CELERY_CONCURRENCY
 #   CELERY_CONCURRENCY: Fixed concurrency - default: 4
+#   CELERY_LOGLEVEL: Log level - default: info
 #
 # Examples:
 #   gevent with autoscaling: CELERY_POOL=gevent CELERY_AUTOSCALE=20,2
 #   prefork with fixed concurrency: CELERY_POOL=prefork CELERY_CONCURRENCY=4
 #   threads with autoscaling: CELERY_POOL=threads CELERY_AUTOSCALE=10,2
 #
-CMD ["celery", "--app", "ibutsu_server:worker_app", "worker"]
+# Critical flags:
+#   --events: Required for Flower monitoring (sends task events to broker)
+#   --hostname: Static worker name for consistent identification across restarts
+#               %n expands to node name, preventing worker name conflicts
+CMD ["celery", "--app", "ibutsu_server:worker_app", "worker", "--events", "--hostname", "ibutsu-worker@%n"]


### PR DESCRIPTION
without the %n the worker doesn't register correctly with scheduler or flower after pod restart

## Summary by Sourcery

Bug Fixes:
- Preserve worker hostname identity across pod restarts so workers continue registering correctly with the scheduler and Flower.