### PR TITLE
Composite DB indexes for artifacts and results idempotency

### DIFF
--- a/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
+++ b/backend/alembic/versions/c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py
@@ -1,0 +1,137 @@
+"""add_composite_indexes_artifacts_idempotency
+
+Add composite indexes backing importer idempotency lookups:
+- on artifacts: (result_id, filename) and (run_id, filename) for archive imports
+- on results: (run_id, test_id) for JUnit importer per-testcase lookups
+
+Revision ID: c4d5e6f7a8b9
+Revises: efdaeff6dc95
+Create Date: 2026-08-27 00:00:00.000000
+
+"""
+
+import contextlib
+import logging
+
+import sqlalchemy as sa
+
+from alembic import context, op
+
+# revision identifiers, used by Alembic.
+revision = "c4d5e6f7a8b9"
+down_revision = "efdaeff6dc95"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.versions.c4d5e6f7a8b9")
+
+INDEXES = [
+    ("ix_artifacts_result_id_filename", "artifacts", ["result_id", "filename"]),
+    ("ix_artifacts_run_id_filename", "artifacts", ["run_id", "filename"]),
+    ("ix_results_run_id_test_id", "results", ["run_id", "test_id"]),
+]
+
+_INVALID_INDEX_SQL = sa.text(
+    """
+    SELECT i.indisvalid
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = :index_name
+      AND n.nspname = current_schema()
+    """
+)
+
+
+def _is_postgresql() -> bool:
+    """Check if the current database dialect is PostgreSQL."""
+    bind = op.get_bind()
+    if bind:
+        return bind.dialect.name == "postgresql"
+    return op.get_context().dialect.name == "postgresql"
+
+
+def _is_offline() -> bool:
+    """Check if Alembic is running in offline mode."""
+    with contextlib.suppress(NameError, AttributeError):
+        return context.is_offline_mode()
+    return getattr(op.get_context(), "as_sql", False)
+
+
+def _cleanup_invalid_index(index_name: str, table_name: str) -> None:
+    """Drop index if left in an INVALID state by an interrupted concurrent run."""
+    if _is_offline():
+        return
+    conn = op.get_bind()
+    if conn is None:
+        return
+    row = conn.execute(_INVALID_INDEX_SQL, {"index_name": index_name}).fetchone()
+    if row and not row[0]:
+        logger.warning("Found invalid index %s; dropping before recreating", index_name)
+        op.drop_index(
+            index_name,
+            table_name=table_name,
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def upgrade() -> None:
+    """Create composite indexes on artifacts and results for import idempotency lookups."""
+    logger.info("Starting migration %s", revision)
+
+    if _is_postgresql():
+        with op.get_context().autocommit_block():
+            for index_name, table_name, columns in INDEXES:
+                _cleanup_invalid_index(index_name, table_name)
+                logger.info(
+                    "Creating index %s on %s CONCURRENTLY (PostgreSQL)",
+                    index_name,
+                    table_name,
+                )
+                op.create_index(
+                    index_name,
+                    table_name,
+                    columns,
+                    unique=False,
+                    postgresql_concurrently=True,
+                    if_not_exists=True,
+                )
+    else:
+        for index_name, table_name, columns in INDEXES:
+            logger.info("Creating index %s on %s (non-PostgreSQL)", index_name, table_name)
+            op.create_index(
+                index_name,
+                table_name,
+                columns,
+                unique=False,
+                if_not_exists=True,
+            )
+
+
+def downgrade() -> None:
+    """Drop composite indexes on artifacts and results."""
+    logger.info("Starting downgrade %s", revision)
+
+    if _is_postgresql():
+        with op.get_context().autocommit_block():
+            for index_name, table_name, _ in reversed(INDEXES):
+                logger.info(
+                    "Dropping index %s from %s CONCURRENTLY (PostgreSQL)",
+                    index_name,
+                    table_name,
+                )
+                op.drop_index(
+                    index_name,
+                    table_name=table_name,
+                    postgresql_concurrently=True,
+                    if_exists=True,
+                )
+    else:
+        for index_name, table_name, _ in reversed(INDEXES):
+            logger.info("Dropping index %s from %s (non-PostgreSQL)", index_name, table_name)
+            op.drop_index(
+                index_name,
+                table_name=table_name,
+                if_exists=True,
+            )

--- a/backend/ibutsu_server/db/models.py
+++ b/backend/ibutsu_server/db/models.py
@@ -102,6 +102,14 @@ class FileMixin(ModelMixin):
 
 
 class Artifact(Model, FileMixin):
+    """
+    Artifact model representing files associated with runs or results.
+
+    Composite indexes managed via Alembic migrations (c4d5e6f7a8b9):
+    - ix_artifacts_result_id_filename: Composite index on (result_id, filename)
+    - ix_artifacts_run_id_filename: Composite index on (run_id, filename)
+    """
+
     __tablename__ = "artifacts"
     result_id = Column(PortableUUID(), ForeignKey("results.id"), index=True)
     run_id = Column(PortableUUID(), ForeignKey("runs.id"), index=True)
@@ -219,6 +227,7 @@ class Result(Model, ModelMixin):
     - ix_results_tags: GIN index on data->'tags'
     Cross-dialect:
     - ix_results_run_id_project_id: Composite index on (run_id, project_id)
+    - ix_results_run_id_test_id: Composite index on (run_id, test_id)
     """
 
     __tablename__ = "results"

--- a/backend/tests/test_migration_c4d5e6f7a8b9.py
+++ b/backend/tests/test_migration_c4d5e6f7a8b9.py
@@ -1,0 +1,187 @@
+import importlib.util
+import io
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from alembic.script import ScriptDirectory
+
+from ibutsu_server.db.models import Artifact, Result
+
+
+@pytest.fixture
+def migration_module():
+    """Load the c4d5e6f7a8b9 migration module dynamically."""
+    migration_path = (
+        Path(__file__).parent.parent
+        / "alembic"
+        / "versions"
+        / "c4d5e6f7a8b9_add_composite_indexes_artifacts_idempotency.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_c4d5e6f7a8b9", migration_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_alembic_heads_single_head():
+    """Verify that Alembic has exactly one head revision in the migration graph."""
+    alembic_ini = Path(__file__).parent.parent / "alembic.ini"
+    alembic_cfg = Config(str(alembic_ini))
+    alembic_cfg.set_main_option("script_location", str(alembic_ini.parent / "alembic"))
+    script_dir = ScriptDirectory.from_config(alembic_cfg)
+    heads = script_dir.get_heads()
+    assert len(heads) == 1
+    assert heads[0] == "c4d5e6f7a8b9"
+
+
+def test_sqlite_upgrade_and_downgrade(migration_module, monkeypatch):
+    """Test upgrade and downgrade operations on a SQLite database with column verification."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE artifacts ("
+                "id TEXT PRIMARY KEY, result_id TEXT, run_id TEXT, filename TEXT"
+                ")"
+            )
+        )
+        conn.execute(
+            sa.text("CREATE TABLE results (id TEXT PRIMARY KEY, run_id TEXT, test_id TEXT)")
+        )
+
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        monkeypatch.setattr(migration_module.op, "_proxy", Operations(ctx), raising=False)
+
+        # Test upgrade creates all three composite indexes
+        migration_module.upgrade()
+
+        inspector = sa.inspect(conn)
+        artifact_indexes = {
+            idx["name"]: idx["column_names"] for idx in inspector.get_indexes("artifacts")
+        }
+        result_indexes = {
+            idx["name"]: idx["column_names"] for idx in inspector.get_indexes("results")
+        }
+
+        # Assert index existence AND column composition/order
+        assert artifact_indexes.get("ix_artifacts_result_id_filename") == [
+            "result_id",
+            "filename",
+        ]
+        assert artifact_indexes.get("ix_artifacts_run_id_filename") == ["run_id", "filename"]
+        assert result_indexes.get("ix_results_run_id_test_id") == ["run_id", "test_id"]
+
+        # Test idempotent upgrade does not error
+        migration_module.upgrade()
+
+        # Test downgrade drops all three composite indexes
+        migration_module.downgrade()
+
+        inspector_post_down = sa.inspect(conn)
+        artifact_down_indexes = {
+            idx["name"] for idx in inspector_post_down.get_indexes("artifacts")
+        }
+        result_down_indexes = {idx["name"] for idx in inspector_post_down.get_indexes("results")}
+
+        assert "ix_artifacts_result_id_filename" not in artifact_down_indexes
+        assert "ix_artifacts_run_id_filename" not in artifact_down_indexes
+        assert "ix_results_run_id_test_id" not in result_down_indexes
+
+        # Test idempotent downgrade does not error
+        migration_module.downgrade()
+
+
+@pytest.mark.parametrize("bind_returns_none", [False, True])
+def test_postgresql_offline_upgrade_and_downgrade(migration_module, monkeypatch, bind_returns_none):
+    """Test SQL generation in offline mode for PostgreSQL dialect."""
+    buf = io.StringIO()
+    ctx = MigrationContext.configure(
+        url="postgresql://user:pass@localhost/db",
+        opts={"as_sql": True, "output_buffer": buf},
+    )
+    monkeypatch.setattr(migration_module.op, "_proxy", Operations(ctx), raising=False)
+    if bind_returns_none:
+        monkeypatch.setattr(migration_module.op, "get_bind", lambda: None)
+
+    migration_module.upgrade()
+    upgrade_sql = buf.getvalue()
+    assert (
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_artifacts_result_id_filename"
+        " ON artifacts (result_id, filename)" in upgrade_sql
+    )
+    assert (
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_artifacts_run_id_filename"
+        " ON artifacts (run_id, filename)" in upgrade_sql
+    )
+    assert (
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_results_run_id_test_id"
+        " ON results (run_id, test_id)" in upgrade_sql
+    )
+
+    buf.seek(0)
+    buf.truncate(0)
+
+    migration_module.downgrade()
+    downgrade_sql = buf.getvalue()
+    assert "DROP INDEX CONCURRENTLY IF EXISTS ix_results_run_id_test_id" in downgrade_sql
+    assert "DROP INDEX CONCURRENTLY IF EXISTS ix_artifacts_run_id_filename" in downgrade_sql
+    assert "DROP INDEX CONCURRENTLY IF EXISTS ix_artifacts_result_id_filename" in downgrade_sql
+
+
+@pytest.mark.parametrize(
+    ("row_result", "should_drop"),
+    [
+        ((False,), True),
+        ((True,), False),
+        (None, False),
+    ],
+)
+def test_cleanup_invalid_index(migration_module, monkeypatch, row_result, should_drop):
+    """Test that invalid indexes are dropped and valid/missing indexes are untouched."""
+    mock_bind = MagicMock()
+    mock_bind.execute.return_value.fetchone.return_value = row_result
+    mock_drop = MagicMock()
+
+    monkeypatch.setattr(migration_module.op, "get_bind", MagicMock(return_value=mock_bind))
+    monkeypatch.setattr(migration_module.op, "drop_index", mock_drop)
+    monkeypatch.setattr(migration_module, "_is_offline", lambda: False)
+
+    migration_module._cleanup_invalid_index("ix_artifacts_result_id_filename", "artifacts")
+
+    assert mock_drop.called == should_drop
+    if should_drop:
+        mock_drop.assert_called_once_with(
+            "ix_artifacts_result_id_filename",
+            table_name="artifacts",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def test_cleanup_invalid_index_offline(migration_module, monkeypatch):
+    """Test that invalid index cleanup is skipped in offline mode."""
+    mock_bind = MagicMock()
+    mock_drop = MagicMock()
+    monkeypatch.setattr(migration_module.op, "get_bind", MagicMock(return_value=mock_bind))
+    monkeypatch.setattr(migration_module.op, "drop_index", mock_drop)
+    monkeypatch.setattr(migration_module, "_is_offline", lambda: True)
+
+    migration_module._cleanup_invalid_index("ix_artifacts_result_id_filename", "artifacts")
+    assert not mock_bind.execute.called
+    assert not mock_drop.called
+
+
+def test_models_documentation():
+    """Ensure composite indexes are documented in model docstrings."""
+    assert Artifact.__doc__ is not None
+    assert "ix_artifacts_result_id_filename" in Artifact.__doc__
+    assert "ix_artifacts_run_id_filename" in Artifact.__doc__
+
+    assert Result.__doc__ is not None
+    assert "ix_results_run_id_test_id: Composite index on (run_id, test_id)" in Result.__doc__


### PR DESCRIPTION
## Summary by Sourcery

Improve importer idempotency performance by adding resilient composite indexes for artifact and result lookups.

Enhancements:
- Add composite indexes supporting efficient artifact and result idempotency lookups during imports.
- Create and remove indexes safely across PostgreSQL and other database dialects, including recovery from invalid PostgreSQL indexes.

Tests:
- Add migration coverage for index creation, idempotent upgrades and downgrades, PostgreSQL SQL generation, and invalid-index cleanup.