### PR TITLE
filters: clearly separate integer and float fields for json cast

### DIFF
--- a/backend/ibutsu_server/constants.py
+++ b/backend/ibutsu_server/constants.py
@@ -32,18 +32,36 @@ OAUTH_CONFIG = {
 }
 ALLOWED_TRUE_BOOLEANS = ["y", "t", "1"]
 ARRAY_FIELDS = ["metadata.tags", "metadata.markers", "metadata.annotations"]
-NUMERIC_FIELDS = [
-    "duration",
-    "start_time",
-    "summary.failures",
-    "summary.errors",
-    "summary.pass_percent",
-    "summary.passes",
-    "summary.skips",
-    "summary.tests",
-    "summary.xfailures",
-    "summary.xpasses",
-]
+# Direct ORM columns that are numeric or timestamps (these bypass the JSON path accessor)
+DIRECT_NUMERIC_FIELDS = frozenset(
+    {
+        "duration",
+        "start_time",
+    }
+)
+# JSON fields cast to Integer (as_integer()) to match ::int expression indexes
+INTEGER_FIELDS = frozenset(
+    {
+        "summary.pass_percent",
+    }
+)
+# JSON fields cast to Float (as_float()), including summary count fields to allow both
+# integer and floating-point JSON representations (such as 3.0 or 0.0) without syntax errors
+FLOAT_FIELDS = frozenset(
+    {
+        "summary.collected",
+        "summary.errors",
+        "summary.failures",
+        "summary.not_run",
+        "summary.passes",
+        "summary.skips",
+        "summary.tests",
+        "summary.xfailures",
+        "summary.xpasses",
+    }
+)
+# Union of all numeric fields used for filter value conversion and comparison handling
+NUMERIC_FIELDS = INTEGER_FIELDS | FLOAT_FIELDS | DIRECT_NUMERIC_FIELDS
 MAX_PAGE_SIZE = 500  # max page size API can return, page_sizes over this are sent to a worker
 HEATMAP_MAX_BUILDS = 40  # max for number of builds that are possible to display in heatmap
 BARCHART_MAX_BUILDS = 150  # max for number of builds possible to display in bar chart

--- a/backend/ibutsu_server/filters.py
+++ b/backend/ibutsu_server/filters.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from sqlalchemy import Text, cast
 from sqlalchemy.dialects.postgresql import array
 
-from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
+from ibutsu_server.constants import ARRAY_FIELDS, FLOAT_FIELDS, INTEGER_FIELDS, NUMERIC_FIELDS
 from ibutsu_server.db.types import PortableUUID
 
 # gte/lte each have two operator spellings, and both are actively used (not
@@ -83,6 +83,19 @@ def _array_compare(oper, column, value):
 
 
 def string_to_column(field, model):
+    """Convert a field string to a SQLAlchemy column object.
+
+    Handles JSON sub-keys (data.*, metadata.*, summary.*) with explicit typing:
+    - INTEGER_FIELDS (e.g. summary.pass_percent) are cast to Integer with
+      as_integer() to match integer expression indexes (e.g. ix_runs_pass_percent).
+    - FLOAT_FIELDS (e.g. summary count fields like summary.tests, summary.failures)
+      are cast to Float with as_float(), allowing both integer and float JSON
+      representations (such as 3.0 or 0.0) without query-time cast errors.
+    - Other non-array JSON fields are cast to String with as_string().
+    - ARRAY_FIELDS remain raw JSON path expressions for array containment operators.
+    - Direct ORM columns (e.g. duration, start_time in DIRECT_NUMERIC_FIELDS)
+      are accessed directly via model attributes.
+    """
     field_parts = field.split(".")
 
     # For subqueries, access columns directly via .c
@@ -96,8 +109,15 @@ def string_to_column(field, model):
                 continue
             column = column[part]
 
-        if field in NUMERIC_FIELDS:
+        # Cast JSON fields based on type category:
+        # - INTEGER_FIELDS: cast to Integer with as_integer() to match expression indexes
+        # - FLOAT_FIELDS: cast to Float with as_float() to support numeric ordering and handle
+        #   both integer and float representations (e.g. 3.0 or 0.0)
+        # - Non-array scalar fields: cast to String with as_string() for text comparison
+        if field in INTEGER_FIELDS:
             column = column.as_integer()
+        elif field in FLOAT_FIELDS:
+            column = column.as_float()
         elif field not in ARRAY_FIELDS:
             column = column.as_string()
     else:

--- a/backend/tests/controllers/test_run_controller.py
+++ b/backend/tests/controllers/test_run_controller.py
@@ -561,6 +561,61 @@ def test_get_run_list_various_filters(
     assert "runs" in response_data
 
 
+def test_filter_summary_tests_with_float_representation(
+    flask_app, make_project, make_run, auth_headers
+):
+    """Test filtering runs when summary.tests contains float values like 3.0."""
+    client, jwt_token = flask_app
+
+    project = make_project(name="float-tests-project")
+
+    make_run(
+        project_id=project.id,
+        summary={"tests": 3.0, "failures": 0.0},
+    )
+    make_run(
+        project_id=project.id,
+        summary={"tests": 6000, "failures": 1},
+    )
+
+    # 1. Verify filtering out the float row returns only the integer row
+    query_string = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.tests>5000"),
+    ]
+    headers = auth_headers(jwt_token)
+    response = client.get("/api/run", headers=headers, params=query_string)
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert len(response_data["runs"]) == 1
+    assert response_data["runs"][0]["summary"]["tests"] == 6000
+
+    # 2. Verify filtering for the float-represented run matches and returns it
+    query_string_match = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.tests<=5000"),
+    ]
+    response_match = client.get("/api/run", headers=headers, params=query_string_match)
+    assert response_match.status_code == 200
+
+    match_data = response_match.json()
+    assert len(match_data["runs"]) == 1
+    assert match_data["runs"][0]["summary"]["tests"] == 3.0
+
+    # 3. Verify equality filter on float-represented summary field
+    query_string_eq = [
+        ("filter", f"project_id={project.id}"),
+        ("filter", "summary.failures=0"),
+    ]
+    response_eq = client.get("/api/run", headers=headers, params=query_string_eq)
+    assert response_eq.status_code == 200
+
+    eq_data = response_eq.json()
+    assert len(eq_data["runs"]) == 1
+    assert eq_data["runs"][0]["summary"]["failures"] == 0.0
+
+
 def test_filter_pass_percent_greater_than(flask_app, make_project, make_run, auth_headers):
     """Test filtering runs where pass_percent > threshold returns only matching runs."""
     client, jwt_token = flask_app

--- a/backend/tests/test_filters.py
+++ b/backend/tests/test_filters.py
@@ -3,9 +3,16 @@
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import Integer, String
+from sqlalchemy import Float, Integer, String
+from sqlalchemy.dialects import postgresql
 
-from ibutsu_server.constants import ARRAY_FIELDS, NUMERIC_FIELDS
+from ibutsu_server.constants import (
+    ARRAY_FIELDS,
+    DIRECT_NUMERIC_FIELDS,
+    FLOAT_FIELDS,
+    INTEGER_FIELDS,
+    NUMERIC_FIELDS,
+)
 from ibutsu_server.db import db
 from ibutsu_server.db.models import Result, Run
 from ibutsu_server.filters import (
@@ -18,17 +25,15 @@ from ibutsu_server.filters import (
     string_to_column,
 )
 
-# NUMERIC_FIELDS that are stored as JSON sub-keys (summary.*).
-# These go through the JSON path accessor in string_to_column and therefore
-# receive an explicit as_integer() cast.  A non-numeric value stored in the
-# database for any of these keys will raise a database error at query time
-# rather than silently returning incorrect results.
-_JSON_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if f.startswith("summary.")]
-
-# NUMERIC_FIELDS that map to native ORM columns (not JSON paths).
-# These bypass the JSON accessor branch entirely, so as_integer() is never
-# applied to them; their type is already enforced by the column definition.
-_DIRECT_NUMERIC_FIELDS = [f for f in NUMERIC_FIELDS if not f.startswith("summary.")]
+# Fields categorized by type:
+# - _JSON_INTEGER_FIELDS receive an as_integer() cast to match expression indexes
+# - _JSON_FLOAT_FIELDS receive an as_float() cast to support integer/float representations
+# - _DIRECT_NUMERIC_FIELDS map to native ORM columns (bypass JSON accessor)
+# - _JSON_NUMERIC_FIELDS is the union of JSON integer and float categories
+_JSON_INTEGER_FIELDS = sorted(INTEGER_FIELDS)
+_JSON_FLOAT_FIELDS = sorted(FLOAT_FIELDS)
+_DIRECT_NUMERIC_FIELDS = sorted(DIRECT_NUMERIC_FIELDS)
+_JSON_NUMERIC_FIELDS = sorted(INTEGER_FIELDS | FLOAT_FIELDS)
 
 
 @pytest.fixture
@@ -205,41 +210,68 @@ class TestStringToColumn:
         assert column is not None
 
 
+def test_numeric_fields_is_union_of_categories():
+    """Verify NUMERIC_FIELDS is the union of field category sets."""
+    assert NUMERIC_FIELDS == INTEGER_FIELDS | FLOAT_FIELDS | DIRECT_NUMERIC_FIELDS
+    assert not (INTEGER_FIELDS & FLOAT_FIELDS), "INTEGER_FIELDS and FLOAT_FIELDS must be disjoint"
+    assert not (INTEGER_FIELDS & DIRECT_NUMERIC_FIELDS), (
+        "INTEGER_FIELDS and DIRECT_NUMERIC_FIELDS must be disjoint"
+    )
+    assert not (FLOAT_FIELDS & DIRECT_NUMERIC_FIELDS), (
+        "FLOAT_FIELDS and DIRECT_NUMERIC_FIELDS must be disjoint"
+    )
+
+
 class TestStringToColumnCastSemantics:
-    """Explicit coverage for the JSON-cast behavior introduced by as_integer() / as_string().
+    """Explicit coverage for JSON-cast behavior (as_float / as_integer / as_string).
 
     The contract under test:
-    - Every field listed in NUMERIC_FIELDS whose first segment is "summary" is
-      accessed via the Run.summary JSONB column and then cast to Integer with
-      as_integer().  This produces correct numeric ordering and matches the
-      ::int expression index, but will raise a database-level error if a stored
-      value cannot be cast to a number.
+    - Fields in INTEGER_FIELDS (such as summary.pass_percent) are cast to Integer
+      with as_integer() to match the ::int expression index ix_runs_pass_percent.
+    - Fields in FLOAT_FIELDS (such as summary.tests, summary.failures) are cast to
+      Float with as_float(). This produces correct numeric ordering and allows
+      PostgreSQL to evaluate both integer and floating-point JSON representations
+      (such as 3.0 or 0.0) without throwing invalid input syntax errors.
     - Non-numeric JSON fields (data.*, metadata.*, non-array summary.*) are
-      cast to String via as_string(), preserving the previous text-comparison
-      behaviour.
+      cast to String via as_string(), preserving text-comparison behaviour.
     - Array fields (metadata.tags etc.) receive neither cast; they remain raw
       JSON path expressions so that array operators (@>, ?|) work correctly.
     - Direct ORM columns (duration, start_time) never pass through the JSON
-      accessor branch and are therefore unaffected by as_integer().
+      accessor branch and are therefore unaffected by as_integer()/as_float().
     """
 
-    @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
-    def test_json_numeric_fields_produce_integer_cast(self, app_ctx, field):
-        """Every summary.* NUMERIC_FIELD must use an explicit Integer cast.
+    @pytest.mark.parametrize("field", _JSON_FLOAT_FIELDS)
+    def test_json_float_fields_produce_float_cast(self, app_ctx, field):
+        """Every JSON FLOAT_FIELD must use an explicit Float cast.
+
+        Verifies that the as_float() path is taken, meaning:
+        1. Comparisons use numeric ordering, not lexicographic ordering.
+        2. Stored float values (such as 3.0 or 0.0) do not cause PostgreSQL syntax
+           errors when evaluated.
+        """
+        column = string_to_column(field, Run)
+        assert column is not None, f"string_to_column returned None for {field!r}"
+        assert isinstance(column.type, Float), (
+            f"{field!r} expected a Float-cast column (as_float()) "
+            f"but got type {type(column.type).__name__!r}. "
+            "Check that this field is still listed in FLOAT_FIELDS."
+        )
+
+    @pytest.mark.parametrize("field", _JSON_INTEGER_FIELDS)
+    def test_json_integer_fields_produce_integer_cast(self, app_ctx, field):
+        """Every JSON INTEGER_FIELD must use an explicit Integer cast.
 
         Verifies that the as_integer() path is taken, meaning:
         1. Comparisons use numeric ordering, not lexicographic ordering.
         2. The cast matches the ::int expression index on ix_runs_pass_percent,
            allowing PostgreSQL to use an index scan for range filters.
-        3. A row whose stored JSON value is not numeric will raise a database
-           error at query time (not silently return wrong results).
         """
         column = string_to_column(field, Run)
         assert column is not None, f"string_to_column returned None for {field!r}"
         assert isinstance(column.type, Integer), (
             f"{field!r} expected an Integer-cast column (as_integer()) "
             f"but got type {type(column.type).__name__!r}. "
-            "Check that this field is still listed in NUMERIC_FIELDS."
+            "Check that this field is still listed in INTEGER_FIELDS."
         )
 
     @pytest.mark.parametrize(
@@ -252,7 +284,7 @@ class TestStringToColumnCastSemantics:
         ],
     )
     def test_non_numeric_json_fields_produce_string_cast(self, app_ctx, field, model):
-        """Non-numeric JSON fields must use a String cast, not a Float cast.
+        """Non-numeric JSON fields must use a String cast, not an Integer or Float cast.
 
         This guards against accidentally adding a field to NUMERIC_FIELDS and
         breaking text-comparison filters on fields that hold string values.
@@ -266,10 +298,13 @@ class TestStringToColumnCastSemantics:
         assert not isinstance(column.type, Integer), (
             f"{field!r} must not be Integer-cast; it holds string values."
         )
+        assert not isinstance(column.type, Float), (
+            f"{field!r} must not be Float-cast; it holds string values."
+        )
 
     @pytest.mark.parametrize("field", ARRAY_FIELDS)
     def test_array_fields_are_not_scalar_cast(self, app_ctx, field):
-        """Array fields must not receive a Float or String cast.
+        """Array fields must not receive an Integer, Float, or String cast.
 
         Array comparisons use the @> and ?| JSON operators; casting to a scalar
         type first would make these operators unusable.
@@ -279,6 +314,7 @@ class TestStringToColumnCastSemantics:
         assert not isinstance(column.type, Integer), (
             f"Array field {field!r} must not be Integer-cast."
         )
+        assert not isinstance(column.type, Float), f"Array field {field!r} must not be Float-cast."
         assert not isinstance(column.type, String), (
             f"Array field {field!r} must not be String-cast."
         )
@@ -298,7 +334,7 @@ class TestStringToColumnCastSemantics:
             "If this field was moved to a JSON column, update this test."
         )
         # These are native ORM columns, not JSON path expressions, so they will
-        # NOT be Integer instances from as_integer() — their type comes from the
+        # NOT receive as_integer() or as_float() casts — their type comes from the
         # SQLAlchemy column definition (Float for duration, DateTime for start_time).
         # We only assert the column resolves without error.
 
@@ -323,13 +359,19 @@ class TestStringToColumnCastSemantics:
 class TestConvertFilterNumericFieldSemantics:
     """Tests for the numeric comparison semantics of convert_filter on JSON fields.
 
-    The as_integer() cast on NUMERIC_FIELDS means:
-    - Comparison operators (>, <, >=, <=) behave with numeric ordering.
-    - The cast matches the ::int expression indexes, allowing PostgreSQL to use
-      index scans for range filters rather than sequential scans.
-    - The filter value is also converted to int/float by _to_int_or_float.
+    The separate as_integer() and as_float() casts on NUMERIC_FIELDS mean:
+    - Fields in INTEGER_FIELDS (e.g. summary.pass_percent) receive an as_integer()
+      cast to match ::int expression indexes (like ix_runs_pass_percent), allowing
+      PostgreSQL to use index scans for range filters rather than sequential scans.
+    - Fields in FLOAT_FIELDS (e.g. summary count fields like summary.tests,
+      summary.failures) receive an as_float() cast, providing numeric ordering
+      while supporting both integer and floating-point JSON representations (such
+      as 3.0 or 0.0) without invalid input syntax errors.
+    - Comparison operators (>, <, >=, <=) behave with numeric ordering across both
+      categories.
+    - The filter value is converted to int or float by _to_int_or_float.
     - Rows with non-numeric JSON values for these keys will produce a database
-      error at query time.
+      error at query time when the database evaluates the cast.
     """
 
     @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
@@ -394,7 +436,7 @@ class TestConvertFilterNumericFieldSemantics:
 
     @pytest.mark.parametrize("field", _JSON_NUMERIC_FIELDS)
     def test_numeric_json_field_not_equal_filter(self, app_ctx, field):
-        """Numeric JSON fields must support not-equal comparisons and cast values to int."""
+        """Numeric JSON fields must support not-equal comparisons with numeric values."""
         result = convert_filter(f"{field}!0", Run)
         assert result is not None, f"convert_filter returned None for '!' filter on {field!r}"
 
@@ -455,11 +497,12 @@ class TestConvertFilterNumericFieldSemantics:
     def test_non_numeric_string_value_on_numeric_field_is_kept_as_str(self, app_ctx):
         """A non-numeric string value for a NUMERIC_FIELD stays as a string.
 
-        This exercises the _to_int_or_float fallback.  The database will still
-        apply the as_integer() cast to the column side; the right-hand string
-        value will be passed through as-is and may cause a type-mismatch error
-        at query execution time.  The purpose here is to verify no exception is
-        raised at filter *construction* time.
+        This exercises the _to_int_or_float fallback. The database will still
+        apply the as_float() or as_integer() cast to the column side (e.g.
+        as_float() for summary.failures); the right-hand string value will be
+        passed through as-is and may cause a type-mismatch error at query
+        execution time. The purpose here is to verify no exception is raised
+        at filter *construction* time.
         """
         result = convert_filter("summary.failures=not_a_number", Run)
         assert result is not None, (
@@ -473,6 +516,28 @@ class TestConvertFilterNumericFieldSemantics:
         below = convert_filter("summary.pass_percent(100", Run)
         assert above is not None, "Lower-bound filter on summary.pass_percent must not be None"
         assert below is not None, "Upper-bound filter on summary.pass_percent must not be None"
+
+    def test_summary_tests_postgresql_compilation(self, app_ctx):
+        """Verify summary.tests compiles to CAST(... AS FLOAT) in PostgreSQL dialect."""
+        clause = convert_filter("summary.tests>5000", Run)
+        compiled = str(clause.compile(dialect=postgresql.dialect()))
+        assert "CAST((runs.summary ->> %(summary_1)s) AS FLOAT) > %(param_1)s" in compiled
+
+    def test_summary_pass_percent_postgresql_compilation(self, app_ctx):
+        """Verify summary.pass_percent compiles to CAST(... AS INTEGER) in PostgreSQL dialect."""
+        clause = convert_filter("summary.pass_percent>80", Run)
+        compiled = str(clause.compile(dialect=postgresql.dialect()))
+        assert "CAST((runs.summary ->> %(summary_1)s) AS INTEGER) > %(param_1)s" in compiled
+
+    def test_summary_tests_with_float_filter_value(self, app_ctx):
+        """Verify summary.tests supports float filter values without error."""
+        result = convert_filter("summary.tests>5000.5", Run)
+        assert result is not None
+        right = getattr(result, "right", None)
+        assert right is not None
+        value = getattr(right, "value", None)
+        assert isinstance(value, float)
+        assert value == 5000.5
 
 
 class TestConvertFilter:


### PR DESCRIPTION
## Summary by Sourcery

Support robust numeric filtering by applying type-appropriate casts to integer and floating-point JSON fields.

Bug Fixes:
- Handle filtering of JSON numeric fields stored as floating-point representations without query-time cast errors.

Enhancements:
- Separate JSON filter fields into integer and float categories while preserving integer casts for indexed percentage fields and numeric ordering for summary counts.

Tests:
- Add coverage for numeric field categorization, generated SQL casts, float-valued JSON filters, and API filtering behavior.