### PR TITLE
Backend importer idempotency

### DIFF
--- a/backend/ibutsu_server/celery_utils.py
+++ b/backend/ibutsu_server/celery_utils.py
@@ -256,7 +256,7 @@ def retry_task_on_exception(*_args, **kwargs):
         return
     request = getattr(task, "request", None)
     retries = getattr(request, "retries", 0) if request else 0
-    if max_retries is not None and retries >= max_retries:
+    if max_retries is not None and max_retries >= 0 and retries >= max_retries:
         return
     # Incremental backoff, starts at a minute and maxes out at 1 hour.
     backoff = min(2**retries, 3600)

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -27,6 +27,9 @@ uuid_pattern = re.compile(
 
 def _upsert_artifact(filename, content, result_id=None, run_id=None):
     """Insert or update an artifact, deduplicating any legacy duplicate rows."""
+    if not (result_id or run_id):
+        msg = "Either result_id or run_id must be provided to _upsert_artifact"
+        raise ValueError(msg)
     target_col = Artifact.result_id if result_id else Artifact.run_id
     target_id = result_id or run_id
     meta_key = "resultId" if result_id else "runId"
@@ -74,7 +77,6 @@ def _upsert_run_artifact(run_id, filename, content):
 
 def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=None):
     """Create or update a result with artifacts, used in the archive importer"""
-    old_id = None
     result_id = result.get("id")
     result_record = db.session.get(Result, result_id) if is_uuid(result_id) else None
 
@@ -103,7 +105,7 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
         result_record.update(result)
     else:
         if not is_uuid(result_id) and "id" in result:
-            old_id = result.pop("id")
+            result.pop("id")
         result_record = Result.from_dict(**result)
         db.session.add(result_record)
 
@@ -113,11 +115,8 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
         filename = artifact.name.split("/")[-1]
         content = tar.extractfile(artifact).read()
         _upsert_result_artifact(result_record.id, filename, content)
-    db.session.flush()
-    return old_id
 
 
-@shared_task
 def _update_import_status(import_record, status):
     """Update the status of the import"""
     # Make sure we have the latest data
@@ -200,9 +199,6 @@ def _add_artifacts(result, testcase, traceback):
     if testcase.find("system-err") is not None:
         system_err = bytes(str(testcase["system-err"]), "utf8")
         _upsert_result_artifact(result.id, "system-err.log", system_err)
-    # Flush rather than commit so these artifacts remain part of the importing
-    # task's transaction and roll back with the run/result if a later step fails.
-    db.session.flush()
 
 
 def _get_properties(xml_element: objectify.Element) -> dict:
@@ -242,6 +238,8 @@ def _populate_metadata(run_dict, import_record):
         run_dict["env"] = run_metadata["env"]
     if import_data.get("source"):
         run_dict["source"] = import_data["source"]
+    elif run_metadata.get("source"):
+        run_dict["source"] = run_metadata["source"]
 
 
 def _populate_result_metadata(run_dict, result_dict, metadata):
@@ -249,8 +247,10 @@ def _populate_result_metadata(run_dict, result_dict, metadata):
     # Extend the result metadata with import metadata, and add env and component
     if metadata:
         result_dict["metadata"].update(metadata)
-        result_dict["env"] = run_dict.get("env")
-        result_dict["component"] = run_dict.get("component")
+        if run_dict.get("env"):
+            result_dict["env"] = run_dict["env"]
+        if run_dict.get("component"):
+            result_dict["component"] = run_dict["component"]
         if metadata.get("project_id"):
             result_dict["project_id"] = metadata["project_id"]
         if metadata.get("source"):
@@ -269,15 +269,90 @@ def _get_test_name_path(testcase):
     return test_name, backup_fspath
 
 
+def _upsert_junit_result(
+    ts,
+    testcase,
+    run_dict,
+    ts_properties,
+    import_record,
+    existing_candidates,
+    matched_result_ids,
+):
+    """Upsert a single JUnit testcase result and its associated artifacts."""
+    test_name, backup_fspath = _get_test_name_path(testcase)
+    fspath = ts.get("file")
+    result_dict = {
+        "test_id": test_name,
+        "start_time": run_dict["start_time"],
+        "duration": float(testcase.get("time") or 0),
+        "run_id": run_dict["id"],
+        "metadata": {
+            "run": run_dict["id"],
+            "fspath": fspath or testcase.get("file") or backup_fspath,
+            "line": testcase.get("line"),
+        },
+        "params": {},
+        "source": ts.get("name"),
+    }
+
+    if import_record.data and import_record.data.get("project_id"):
+        result_dict["project_id"] = import_record.data["project_id"]
+    if import_record.data and import_record.data.get("source"):
+        result_dict["source"] = import_record.data["source"]
+
+    result_properties = {**ts_properties, **_get_properties(testcase)}
+
+    _populate_result_metadata(run_dict, result_dict, result_properties)
+    result_dict, traceback = _process_result(result_dict, testcase)
+
+    existing_result = next(
+        (r for r in existing_candidates if r.id not in matched_result_ids),
+        None,
+    )
+    if existing_result:
+        existing_result.update(result_dict)
+        result = existing_result
+    else:
+        result = Result.from_dict(**result_dict)
+        db.session.add(result)
+    db.session.flush()
+    matched_result_ids.add(result.id)
+    _add_artifacts(result, testcase, traceback)
+    return result
+
+
+def _extract_run_id(import_record):
+    """Extract an existing run ID from import record data or filename."""
+    if import_record.data and import_record.data.get("run_id"):
+        run_ids = import_record.data["run_id"]
+        if isinstance(run_ids, list) and run_ids:
+            return str(run_ids[0])
+        if isinstance(run_ids, str):
+            return run_ids
+    if import_record.filename and (match := uuid_pattern.search(import_record.filename)):
+        return match.group(1)
+    return None
+
+
+def _update_run_summary(run, run_data):
+    """Update run duration and summary counts if empty."""
+    if not run.duration:
+        run.duration = run_data["duration"]
+    for key in ("errors", "failures", "skips", "xfailures", "xpasses", "tests"):
+        if not run.summary.get(key):
+            run.summary[key] = run_data[key]
+
+
 @shared_task(max_retries=0)
-def run_junit_import(import_):  # noqa: PLR0912
+def run_junit_import(import_):
     """Import a test run from a JUnit file"""
-    # Update the status of the import
-    import_record = db.session.get(Import, import_["id"])
+    import_record = db.session.get(Import, str(import_["id"]))
     if not import_record:
         return
     if import_record.data is None:
         import_record.data = {}
+    log.info(f"Starting JUnit import for import record {import_record.id}")
+    log.info("Setting import status to running")
     _update_import_status(import_record, "running")
     # Fetch the file contents
     import_file = db.session.execute(
@@ -291,20 +366,9 @@ def run_junit_import(import_):  # noqa: PLR0912
     with _import_failure_handling(import_record):
         # Parse the XML and create a run object(s)
         tree = objectify.fromstring(import_file.content)
-        # If import_record already has a run_id or filename has a uuid4, use that
-        existing_run_id = None
-        if import_record.data and import_record.data.get("run_id"):
-            run_ids = import_record.data["run_id"]
-            if isinstance(run_ids, list) and run_ids:
-                existing_run_id = run_ids[0]
-            elif isinstance(run_ids, str):
-                existing_run_id = run_ids
-
+        existing_run_id = _extract_run_id(import_record)
         import_record.data["run_id"] = []
-        # Use current time as start time if no start time is present
-        start_time = (
-            parser.parse(tree.get("timestamp")) if tree.get("timestamp") else datetime.now(UTC)
-        )
+        start_time = _parse_timestamp(tree)
         run_dict = {
             "created": datetime.now(UTC),
             "start_time": start_time,
@@ -321,8 +385,6 @@ def run_junit_import(import_):  # noqa: PLR0912
 
         if existing_run_id and is_uuid(str(existing_run_id)):
             run_dict["id"] = str(existing_run_id)
-        elif import_record.filename and (match := uuid_pattern.search(import_record.filename)):
-            run_dict["id"] = match.group(1)
 
         # Get metadata from the XML file
         metadata = _get_properties(tree)
@@ -333,20 +395,7 @@ def run_junit_import(import_):  # noqa: PLR0912
 
         # Populate metadata
         run_dict["metadata"] = metadata
-        # add env and component directly to the run dict if it exists in the metadata
-        run_dict["env"] = metadata.get("env")
-        run_dict["component"] = metadata.get("component")
-        run_dict["source"] = metadata.get("source")
-
-        # Set the project if it exists
-        if metadata.get("project"):
-            run_dict["project_id"] = get_project_id(metadata["project"])
-
-        # If there are any properties set by the importer, overwrite with those
-        if import_record.data.get("project_id"):
-            run_dict["project_id"] = import_record.data["project_id"]
-        if import_record.data.get("source"):
-            run_dict["source"] = import_record.data["source"]
+        _populate_metadata(run_dict, import_record)
 
         # Insert or update the run, and then update the import with the run id. Flush (not
         # commit) so the run gets an ID while staying in the same transaction as
@@ -398,72 +447,22 @@ def run_junit_import(import_):  # noqa: PLR0912
             run_data["xfailures"] += int(ts.get("xfailures", 0))
             run_data["xpasses"] += int(ts.get("xpasses", 0))
             run_data["tests"] += int(ts.get("tests", 0))
-            fspath = ts.get("file")
-            run_properties = _get_properties(ts)
+            ts_properties = {**metadata, **_get_properties(ts)}
 
             for testcase in ts.iterchildren(tag="testcase"):
-                test_name, backup_fspath = _get_test_name_path(testcase)
-                result_dict = {
-                    "test_id": test_name,
-                    "start_time": run_dict["start_time"],
-                    "duration": float(testcase.get("time") or 0),
-                    "run_id": run.id,
-                    "metadata": {
-                        "run": run.id,
-                        "fspath": fspath or testcase.get("file") or backup_fspath,
-                        "line": testcase.get("line"),
-                    },
-                    "params": {},
-                    "source": ts.get("name"),
-                }
-
-                # If there are any properties set by the importer, overwrite with those
-                if import_record.data.get("project_id"):
-                    result_dict["project_id"] = import_record.data["project_id"]
-                if import_record.data.get("source"):
-                    result_dict["source"] = import_record.data["source"]
-
-                # If the JUnit XML has a properties object, add those properties in
-                result_properties = {}
-                result_properties.update(metadata)
-                result_properties.update(run_properties)
-                result_properties.update(_get_properties(testcase))
-
-                _populate_result_metadata(run_dict, result_dict, result_properties)
-                result_dict, traceback = _process_result(result_dict, testcase)
-
+                test_name, _ = _get_test_name_path(testcase)
                 existing_candidates = existing_results_by_test_id.get(test_name, [])
-                existing_result = next(
-                    (r for r in existing_candidates if r.id not in matched_result_ids),
-                    None,
+                _upsert_junit_result(
+                    ts,
+                    testcase,
+                    run_dict,
+                    ts_properties,
+                    import_record,
+                    existing_candidates,
+                    matched_result_ids,
                 )
-                if existing_result:
-                    existing_result.update(result_dict)
-                    result = existing_result
-                else:
-                    result = Result.from_dict(**result_dict)
-                    db.session.add(result)
-                db.session.flush()
-                matched_result_ids.add(result.id)
-                # _add_artifacts stages the traceback, system-out and system-err
-                # artifacts for this result -- don't duplicate that work here.
-                _add_artifacts(result, testcase, traceback)
 
-        # Check if we need to update the run
-        if not run.duration:
-            run.duration = run_data["duration"]
-        if not run.summary["errors"]:
-            run.summary["errors"] = run_data["errors"]
-        if not run.summary["failures"]:
-            run.summary["failures"] = run_data["failures"]
-        if not run.summary["skips"]:
-            run.summary["skips"] = run_data["skips"]
-        if not run.summary["xfailures"]:
-            run.summary["xfailures"] = run_data["xfailures"]
-        if not run.summary["xpasses"]:
-            run.summary["xpasses"] = run_data["xpasses"]
-        if not run.summary["tests"]:
-            run.summary["tests"] = run_data["tests"]
+        _update_run_summary(run, run_data)
         db.session.add(run)
         import_record.status = "done"
         db.session.add(import_record)
@@ -524,7 +523,7 @@ def run_archive_import(import_):  # noqa: PLR0912
                 else:
                     run_artifacts.append(member)
                 continue
-            result_id, _file_name = rest.split("/")
+            result_id, _file_name = rest.split("/", 1)
             if not is_uuid(result_id):
                 msg = f"Invalid result ID {result_id} in archive import"
                 raise ValueError(msg)

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -1,6 +1,7 @@
 import json
 import re
 import tarfile
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import UTC, datetime
 from io import BytesIO
@@ -88,8 +89,12 @@ def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=Non
     result["metadata"] = result_metadata
 
     # Support both top-level and metadata for component and env
-    result["env"] = result.get("env") or result_metadata.get("env")
-    result["component"] = result.get("component") or result_metadata.get("component")
+    env = result.get("env") or result_metadata.get("env")
+    if env:
+        result["env"] = env
+    component = result.get("component") or result_metadata.get("component")
+    if component:
+        result["component"] = component
     result["run_id"] = run_id
     if project_id:
         result["project_id"] = project_id
@@ -226,14 +231,15 @@ def _populate_created_times(run_dict, start_time):
 def _populate_metadata(run_dict, import_record):
     """To reduce cognitive complexity"""
     import_data = import_record.data or {}
+    run_metadata = run_dict.get("metadata") or {}
     if import_data.get("project_id"):
         run_dict["project_id"] = import_data["project_id"]
-    elif run_dict.get("metadata", {}).get("project"):
-        run_dict["project_id"] = get_project_id(run_dict["metadata"]["project"])
-    if run_dict.get("metadata", {}).get("component"):
-        run_dict["component"] = run_dict["metadata"]["component"]
-    if run_dict.get("metadata", {}).get("env"):
-        run_dict["env"] = run_dict["metadata"]["env"]
+    elif run_metadata.get("project"):
+        run_dict["project_id"] = get_project_id(run_metadata["project"])
+    if run_metadata.get("component"):
+        run_dict["component"] = run_metadata["component"]
+    if run_metadata.get("env"):
+        run_dict["env"] = run_metadata["env"]
     if import_data.get("source"):
         run_dict["source"] = import_data["source"]
 
@@ -315,7 +321,7 @@ def run_junit_import(import_):  # noqa: PLR0912
 
         if existing_run_id and is_uuid(str(existing_run_id)):
             run_dict["id"] = str(existing_run_id)
-        elif match := uuid_pattern.search(import_record.filename):
+        elif import_record.filename and (match := uuid_pattern.search(import_record.filename)):
             run_dict["id"] = match.group(1)
 
         # Get metadata from the XML file
@@ -346,6 +352,7 @@ def run_junit_import(import_):  # noqa: PLR0912
         # commit) so the run gets an ID while staying in the same transaction as
         # its results/artifacts -- a later failure then rolls the run back too.
         run = db.session.get(Run, run_dict["id"]) if is_uuid(run_dict.get("id")) else None
+        is_existing_run = run is not None
         if run:
             run.update(run_dict)
         else:
@@ -370,6 +377,17 @@ def run_junit_import(import_):  # noqa: PLR0912
         # Handle structures where testsuite is/isn't the top level tag
         testsuites = _get_ts_element(tree)
         matched_result_ids = set()
+        existing_results_by_test_id = defaultdict(list)
+        if is_existing_run:
+            existing_results = (
+                db.session.execute(
+                    db.select(Result).where(Result.run_id == run.id).order_by(Result.id)
+                )
+                .scalars()
+                .all()
+            )
+            for r in existing_results:
+                existing_results_by_test_id[r.test_id].append(r)
 
         # Run through the test suites and import all the test results
         for ts in testsuites:
@@ -414,18 +432,9 @@ def run_junit_import(import_):  # noqa: PLR0912
                 _populate_result_metadata(run_dict, result_dict, result_properties)
                 result_dict, traceback = _process_result(result_dict, testcase)
 
-                existing_results = (
-                    db.session.execute(
-                        db.select(Result).where(
-                            Result.run_id == run.id,
-                            Result.test_id == test_name,
-                        )
-                    )
-                    .scalars()
-                    .all()
-                )
+                existing_candidates = existing_results_by_test_id.get(test_name, [])
                 existing_result = next(
-                    (r for r in existing_results if r.id not in matched_result_ids),
+                    (r for r in existing_candidates if r.id not in matched_result_ids),
                     None,
                 )
                 if existing_result:
@@ -547,7 +556,7 @@ def run_archive_import(import_):  # noqa: PLR0912
         if not run_dict.get("id") and is_uuid(run_id):
             run_dict["id"] = run_id
         # patch things up a bit, if necessary
-        run_dict["metadata"] = run_dict.get("metadata", {})
+        run_dict["metadata"] = run_dict.get("metadata") or {}
         run_dict["metadata"].update(metadata)
         _populate_metadata(run_dict, import_record)
         _populate_created_times(run_dict, start_time)

--- a/backend/ibutsu_server/tasks/importers.py
+++ b/backend/ibutsu_server/tasks/importers.py
@@ -1,6 +1,7 @@
 import json
 import re
 import tarfile
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from io import BytesIO
 
@@ -23,44 +24,91 @@ uuid_pattern = re.compile(
 )
 
 
-@shared_task
+def _upsert_artifact(filename, content, result_id=None, run_id=None):
+    """Insert or update an artifact, deduplicating any legacy duplicate rows."""
+    target_col = Artifact.result_id if result_id else Artifact.run_id
+    target_id = result_id or run_id
+    meta_key = "resultId" if result_id else "runId"
+
+    existing_artifacts = (
+        db.session.execute(
+            db.select(Artifact)
+            .where(
+                target_col == target_id,
+                Artifact.filename == filename,
+            )
+            .order_by(Artifact.upload_date, Artifact.id)
+        )
+        .scalars()
+        .all()
+    )
+    existing_artifact = existing_artifacts[0] if existing_artifacts else None
+    for duplicate in existing_artifacts[1:]:
+        db.session.delete(duplicate)
+
+    if existing_artifact:
+        existing_artifact.content = content
+    else:
+        artifact_kwargs = {
+            "filename": filename,
+            "data": {"contentType": "text/plain", meta_key: target_id},
+            "content": content,
+        }
+        if result_id:
+            artifact_kwargs["result_id"] = result_id
+        else:
+            artifact_kwargs["run_id"] = run_id
+        db.session.add(Artifact(**artifact_kwargs))
+
+
+def _upsert_result_artifact(result_id, filename, content):
+    """Insert or update a result artifact, deduplicating any legacy duplicate rows."""
+    _upsert_artifact(filename, content, result_id=result_id)
+
+
+def _upsert_run_artifact(run_id, filename, content):
+    """Insert or update a run artifact, deduplicating any legacy duplicate rows."""
+    _upsert_artifact(filename, content, run_id=run_id)
+
+
 def _create_result(tar, run_id, result, artifacts, project_id=None, metadata=None):
-    """Create a result with artifacts, used in the archive importer"""
+    """Create or update a result with artifacts, used in the archive importer"""
     old_id = None
     result_id = result.get("id")
     result_record = db.session.get(Result, result_id) if is_uuid(result_id) else None
+
+    # Merge metadata - normalize to dict to handle null metadata gracefully
+    result_metadata = result.get("metadata") or {}
+    if metadata:
+        result_metadata.update(metadata)
+    # promote user_properties to the level of metadata
+    if "user_properties" in result_metadata:
+        user_properties = result_metadata.pop("user_properties")
+        result_metadata.update(user_properties)
+    result["metadata"] = result_metadata
+
+    # Support both top-level and metadata for component and env
+    result["env"] = result.get("env") or result_metadata.get("env")
+    result["component"] = result.get("component") or result_metadata.get("component")
+    result["run_id"] = run_id
+    if project_id:
+        result["project_id"] = project_id
+
     if result_record:
-        result_record.run_id = run_id
+        result_record.update(result)
     else:
-        old_id = result["id"]
-        if "id" in result:
-            result.pop("id")
-        result["run_id"] = run_id
-        if project_id:
-            result["project_id"] = project_id
-        if metadata:
-            result["metadata"] = result.get("metadata", {})
-            result["metadata"].update(metadata)
-        # promote user_properties to the level of metadata
-        if "user_properties" in result.get("metadata", {}):
-            user_properties = result["metadata"].pop("user_properties")
-            result["metadata"].update(user_properties)
-        result["env"] = result.get("metadata", {}).get("env")
-        result["component"] = result.get("metadata", {}).get("component")
+        if not is_uuid(result_id) and "id" in result:
+            old_id = result.pop("id")
         result_record = Result.from_dict(**result)
-    db.session.add(result_record)
-    db.session.commit()
-    result = result_record.to_dict()
+        db.session.add(result_record)
+
+    db.session.flush()
+
     for artifact in artifacts:
-        db.session.add(
-            Artifact(
-                filename=artifact.name.split("/")[-1],
-                result_id=result["id"],
-                data={"contentType": "text/plain", "resultId": result["id"]},
-                content=tar.extractfile(artifact).read(),
-            )
-        )
-    db.session.commit()
+        filename = artifact.name.split("/")[-1]
+        content = tar.extractfile(artifact).read()
+        _upsert_result_artifact(result_record.id, filename, content)
+    db.session.flush()
     return old_id
 
 
@@ -76,6 +124,30 @@ def _update_import_status(import_record, status):
         db.session.commit()
     else:
         log.error(f"Could not find import with ID {import_record.id} to update status to {status}")
+
+
+@contextmanager
+def _import_failure_handling(import_record):
+    """Roll back and mark an import as errored if processing raises.
+
+    The importers build up the run and all of its results/artifacts inside a
+    single transaction, committing only once everything has been staged. If any
+    step fails part-way through -- an unexpected exception, a malformed archive,
+    or a Celery soft time limit -- roll the whole transaction back so we never
+    leave a run committed without its results/artifacts, and flip the import
+    status to ``error`` so it isn't left stuck in ``running``. The original
+    exception is re-raised so Celery still records the task as failed.
+    """
+    try:
+        yield
+    except Exception:
+        log.exception(f"Import {import_record.id} failed during processing")
+        try:
+            db.session.rollback()
+            _update_import_status(import_record, "error")
+        except Exception:
+            log.exception(f"Failed to cleanly roll back or mark import {import_record.id} as error")
+        raise
 
 
 def _get_ts_element(tree):
@@ -113,39 +185,19 @@ def _process_result(result_dict, testcase):
     return result_dict, traceback
 
 
-@shared_task
 def _add_artifacts(result, testcase, traceback):
     """To reduce cognitive complexity"""
     if traceback:
-        db.session.add(
-            Artifact(
-                filename="traceback.log",
-                result_id=result.id,
-                data={"contentType": "text/plain", "resultId": result.id},
-                content=traceback,
-            )
-        )
+        _upsert_result_artifact(result.id, "traceback.log", traceback)
     if testcase.find("system-out") is not None:
         system_out = bytes(str(testcase["system-out"]), "utf8")
-        db.session.add(
-            Artifact(
-                filename="system-out.log",
-                result_id=result.id,
-                data={"contentType": "text/plain", "resultId": result.id},
-                content=system_out,
-            )
-        )
+        _upsert_result_artifact(result.id, "system-out.log", system_out)
     if testcase.find("system-err") is not None:
         system_err = bytes(str(testcase["system-err"]), "utf8")
-        db.session.add(
-            Artifact(
-                filename="system-err.log",
-                result_id=result.id,
-                data={"contentType": "text/plain", "resultId": result.id},
-                content=system_err,
-            )
-        )
-    db.session.commit()
+        _upsert_result_artifact(result.id, "system-err.log", system_err)
+    # Flush rather than commit so these artifacts remain part of the importing
+    # task's transaction and roll back with the run/result if a later step fails.
+    db.session.flush()
 
 
 def _get_properties(xml_element: objectify.Element) -> dict:
@@ -173,16 +225,17 @@ def _populate_created_times(run_dict, start_time):
 
 def _populate_metadata(run_dict, import_record):
     """To reduce cognitive complexity"""
-    if import_record.data.get("project_id"):
-        run_dict["project_id"] = import_record.data["project_id"]
+    import_data = import_record.data or {}
+    if import_data.get("project_id"):
+        run_dict["project_id"] = import_data["project_id"]
     elif run_dict.get("metadata", {}).get("project"):
         run_dict["project_id"] = get_project_id(run_dict["metadata"]["project"])
     if run_dict.get("metadata", {}).get("component"):
         run_dict["component"] = run_dict["metadata"]["component"]
     if run_dict.get("metadata", {}).get("env"):
         run_dict["env"] = run_dict["metadata"]["env"]
-    if import_record.data.get("source"):
-        run_dict["source"] = import_record.data["source"]
+    if import_data.get("source"):
+        run_dict["source"] = import_data["source"]
 
 
 def _populate_result_metadata(run_dict, result_dict, metadata):
@@ -210,11 +263,15 @@ def _get_test_name_path(testcase):
     return test_name, backup_fspath
 
 
-@shared_task
+@shared_task(max_retries=0)
 def run_junit_import(import_):  # noqa: PLR0912
     """Import a test run from a JUnit file"""
     # Update the status of the import
     import_record = db.session.get(Import, import_["id"])
+    if not import_record:
+        return
+    if import_record.data is None:
+        import_record.data = {}
     _update_import_status(import_record, "running")
     # Fetch the file contents
     import_file = db.session.execute(
@@ -223,185 +280,200 @@ def run_junit_import(import_):  # noqa: PLR0912
     if not import_file:
         _update_import_status(import_record, "error")
         return
-    # Parse the XML and create a run object(s)
-    tree = objectify.fromstring(import_file.content)
-    import_record.data["run_id"] = []
-    # Use current time as start time if no start time is present
-    start_time = parser.parse(tree.get("timestamp")) if tree.get("timestamp") else datetime.now(UTC)
-    run_dict = {
-        "created": datetime.now(UTC),
-        "start_time": start_time,
-        "duration": float(tree.get("time", 0.0)),
-        "summary": {
-            "errors": int(tree.get("errors", 0)),
-            "failures": int(tree.get("failures", 0)),
-            "skips": int(tree.get("skipped", 0)),
-            "xfailures": int(tree.get("xfailures", 0)),
-            "xpasses": int(tree.get("xpasses", 0)),
-            "tests": int(tree.get("tests", 0)),
-        },
-    }
+    # Process the JUnit file within a single transaction so a failure part-way
+    # through rolls back cleanly and marks the import as errored.
+    with _import_failure_handling(import_record):
+        # Parse the XML and create a run object(s)
+        tree = objectify.fromstring(import_file.content)
+        # If import_record already has a run_id or filename has a uuid4, use that
+        existing_run_id = None
+        if import_record.data and import_record.data.get("run_id"):
+            run_ids = import_record.data["run_id"]
+            if isinstance(run_ids, list) and run_ids:
+                existing_run_id = run_ids[0]
+            elif isinstance(run_ids, str):
+                existing_run_id = run_ids
 
-    # If the filename contains a uuid4, let's use that for the run ID
-    if match := uuid_pattern.search(import_record.filename):
-        run_dict["id"] = match.group(1)
+        import_record.data["run_id"] = []
+        # Use current time as start time if no start time is present
+        start_time = (
+            parser.parse(tree.get("timestamp")) if tree.get("timestamp") else datetime.now(UTC)
+        )
+        run_dict = {
+            "created": datetime.now(UTC),
+            "start_time": start_time,
+            "duration": float(tree.get("time", 0.0)),
+            "summary": {
+                "errors": int(tree.get("errors", 0)),
+                "failures": int(tree.get("failures", 0)),
+                "skips": int(tree.get("skipped", 0)),
+                "xfailures": int(tree.get("xfailures", 0)),
+                "xpasses": int(tree.get("xpasses", 0)),
+                "tests": int(tree.get("tests", 0)),
+            },
+        }
 
-    # Get metadata from the XML file
-    metadata = _get_properties(tree)
+        if existing_run_id and is_uuid(str(existing_run_id)):
+            run_dict["id"] = str(existing_run_id)
+        elif match := uuid_pattern.search(import_record.filename):
+            run_dict["id"] = match.group(1)
 
-    # Update metadata from import data
-    if import_record.data.get("metadata"):
-        metadata.update(import_record.data["metadata"])
+        # Get metadata from the XML file
+        metadata = _get_properties(tree)
 
-    # Populate metadata
-    run_dict["data"] = metadata
-    # add env and component directly to the run dict if it exists in the metadata
-    run_dict["env"] = metadata.get("env")
-    run_dict["component"] = metadata.get("component")
-    run_dict["source"] = metadata.get("source")
+        # Update metadata from import data
+        if import_record.data.get("metadata"):
+            metadata.update(import_record.data["metadata"])
 
-    # Set the project if it exists
-    if metadata.get("project"):
-        run_dict["project_id"] = get_project_id(metadata["project"])
+        # Populate metadata
+        run_dict["metadata"] = metadata
+        # add env and component directly to the run dict if it exists in the metadata
+        run_dict["env"] = metadata.get("env")
+        run_dict["component"] = metadata.get("component")
+        run_dict["source"] = metadata.get("source")
 
-    # If there are any properties set by the importer, overwrite with those
-    if import_record.data.get("project_id"):
-        run_dict["project_id"] = import_record.data["project_id"]
-    if import_record.data.get("source"):
-        run_dict["source"] = import_record.data["source"]
+        # Set the project if it exists
+        if metadata.get("project"):
+            run_dict["project_id"] = get_project_id(metadata["project"])
 
-    # Insert the run, and then update the import with the run id
-    run = Run.from_dict(**run_dict)
-    db.session.add(run)
-    db.session.commit()
-    run_dict = run.to_dict()
-    import_record.run_id = run.id
-    import_record.data["run_id"].append(run.id)
+        # If there are any properties set by the importer, overwrite with those
+        if import_record.data.get("project_id"):
+            run_dict["project_id"] = import_record.data["project_id"]
+        if import_record.data.get("source"):
+            run_dict["source"] = import_record.data["source"]
 
-    # If the top level "testsuites" element doesn't have these, we'll need to build them manually
-    run_data = {
-        "duration": 0.0,
-        "errors": 0,
-        "failures": 0,
-        "skips": 0,
-        "xfailures": 0,
-        "xpasses": 0,
-        "tests": 0,
-    }
+        # Insert or update the run, and then update the import with the run id. Flush (not
+        # commit) so the run gets an ID while staying in the same transaction as
+        # its results/artifacts -- a later failure then rolls the run back too.
+        run = db.session.get(Run, run_dict["id"]) if is_uuid(run_dict.get("id")) else None
+        if run:
+            run.update(run_dict)
+        else:
+            run = Run.from_dict(**run_dict)
+        db.session.add(run)
+        db.session.flush()
+        run_dict = run.to_dict()
+        if run.id not in import_record.data["run_id"]:
+            import_record.data["run_id"].append(run.id)
 
-    # Handle structures where testsuite is/isn't the top level tag
-    testsuites = _get_ts_element(tree)
+        # If the top level "testsuites" element doesn't have these, build them manually
+        run_data = {
+            "duration": 0.0,
+            "errors": 0,
+            "failures": 0,
+            "skips": 0,
+            "xfailures": 0,
+            "xpasses": 0,
+            "tests": 0,
+        }
 
-    # Run through the test suites and import all the test results
-    for ts in testsuites:
-        run_data["duration"] += float(ts.get("time", 0.0))
-        run_data["errors"] += int(ts.get("errors", 0))
-        run_data["failures"] += int(ts.get("failures", 0))
-        run_data["skips"] += int(ts.get("skipped", 0))
-        run_data["xfailures"] += int(ts.get("xfailures", 0))
-        run_data["xpasses"] += int(ts.get("xpasses", 0))
-        run_data["tests"] += int(ts.get("tests", 0))
-        fspath = ts.get("file")
-        run_properties = _get_properties(ts)
+        # Handle structures where testsuite is/isn't the top level tag
+        testsuites = _get_ts_element(tree)
+        matched_result_ids = set()
 
-        for testcase in ts.iterchildren(tag="testcase"):
-            test_name, backup_fspath = _get_test_name_path(testcase)
-            result_dict = {
-                "test_id": test_name,
-                "start_time": run_dict["start_time"],
-                "duration": float(testcase.get("time") or 0),
-                "run_id": run.id,
-                "metadata": {
-                    "run": run.id,
-                    "fspath": fspath or testcase.get("file") or backup_fspath,
-                    "line": testcase.get("line"),
-                },
-                "params": {},
-                "source": ts.get("name"),
-            }
+        # Run through the test suites and import all the test results
+        for ts in testsuites:
+            run_data["duration"] += float(ts.get("time", 0.0))
+            run_data["errors"] += int(ts.get("errors", 0))
+            run_data["failures"] += int(ts.get("failures", 0))
+            run_data["skips"] += int(ts.get("skipped", 0))
+            run_data["xfailures"] += int(ts.get("xfailures", 0))
+            run_data["xpasses"] += int(ts.get("xpasses", 0))
+            run_data["tests"] += int(ts.get("tests", 0))
+            fspath = ts.get("file")
+            run_properties = _get_properties(ts)
 
-            # If there are any properties set by the importer, overwrite with those
-            if import_record.data.get("project_id"):
-                result_dict["project_id"] = import_record.data["project_id"]
-            if import_record.data.get("source"):
-                result_dict["source"] = import_record.data["source"]
+            for testcase in ts.iterchildren(tag="testcase"):
+                test_name, backup_fspath = _get_test_name_path(testcase)
+                result_dict = {
+                    "test_id": test_name,
+                    "start_time": run_dict["start_time"],
+                    "duration": float(testcase.get("time") or 0),
+                    "run_id": run.id,
+                    "metadata": {
+                        "run": run.id,
+                        "fspath": fspath or testcase.get("file") or backup_fspath,
+                        "line": testcase.get("line"),
+                    },
+                    "params": {},
+                    "source": ts.get("name"),
+                }
 
-            # If the JUnit XML has a properties object, add those properties in
-            result_properties = {}
-            result_properties.update(metadata)
-            result_properties.update(run_properties)
-            result_properties.update(_get_properties(testcase))
+                # If there are any properties set by the importer, overwrite with those
+                if import_record.data.get("project_id"):
+                    result_dict["project_id"] = import_record.data["project_id"]
+                if import_record.data.get("source"):
+                    result_dict["source"] = import_record.data["source"]
 
-            _populate_result_metadata(run_dict, result_dict, result_properties)
-            result_dict, traceback = _process_result(result_dict, testcase)
+                # If the JUnit XML has a properties object, add those properties in
+                result_properties = {}
+                result_properties.update(metadata)
+                result_properties.update(run_properties)
+                result_properties.update(_get_properties(testcase))
 
-            result = Result.from_dict(**result_dict)
-            db.session.add(result)
-            db.session.commit()
-            _add_artifacts(result, testcase, traceback)
+                _populate_result_metadata(run_dict, result_dict, result_properties)
+                result_dict, traceback = _process_result(result_dict, testcase)
 
-            if traceback:
-                db.session.add(
-                    Artifact(
-                        filename="traceback.log",
-                        result_id=result.id,
-                        data={"contentType": "text/plain", "resultId": result.id},
-                        content=traceback,
+                existing_results = (
+                    db.session.execute(
+                        db.select(Result).where(
+                            Result.run_id == run.id,
+                            Result.test_id == test_name,
+                        )
                     )
+                    .scalars()
+                    .all()
                 )
-            if testcase.find("system-out") is not None:
-                system_out = bytes(str(testcase["system-out"]), "utf8")
-                db.session.add(
-                    Artifact(
-                        filename="system-out.log",
-                        result_id=result.id,
-                        data={"contentType": "text/plain", "resultId": result.id},
-                        content=system_out,
-                    )
+                existing_result = next(
+                    (r for r in existing_results if r.id not in matched_result_ids),
+                    None,
                 )
-            if testcase.find("system-err") is not None:
-                system_err = bytes(str(testcase["system-err"]), "utf8")
-                db.session.add(
-                    Artifact(
-                        filename="system-err.log",
-                        result_id=result.id,
-                        data={"contentType": "text/plain", "resultId": result.id},
-                        content=system_err,
-                    )
-                )
-            db.session.commit()
+                if existing_result:
+                    existing_result.update(result_dict)
+                    result = existing_result
+                else:
+                    result = Result.from_dict(**result_dict)
+                    db.session.add(result)
+                db.session.flush()
+                matched_result_ids.add(result.id)
+                # _add_artifacts stages the traceback, system-out and system-err
+                # artifacts for this result -- don't duplicate that work here.
+                _add_artifacts(result, testcase, traceback)
 
-    # Check if we need to update the run
-    if not run.duration:
-        run.duration = run_data["duration"]
-    if not run.summary["errors"]:
-        run.summary["errors"] = run_data["errors"]
-    if not run.summary["failures"]:
-        run.summary["failures"] = run_data["failures"]
-    if not run.summary["skips"]:
-        run.summary["skips"] = run_data["skips"]
-    if not run.summary["xfailures"]:
-        run.summary["xfailures"] = run_data["xfailures"]
-    if not run.summary["xpasses"]:
-        run.summary["xpasses"] = run_data["xpasses"]
-    if not run.summary["tests"]:
-        run.summary["tests"] = run_data["tests"]
-    db.session.add(run)
-    db.session.commit()
-
-    # Update the status of the import, now that we're all done
-    _update_import_status(import_record, "done")
+        # Check if we need to update the run
+        if not run.duration:
+            run.duration = run_data["duration"]
+        if not run.summary["errors"]:
+            run.summary["errors"] = run_data["errors"]
+        if not run.summary["failures"]:
+            run.summary["failures"] = run_data["failures"]
+        if not run.summary["skips"]:
+            run.summary["skips"] = run_data["skips"]
+        if not run.summary["xfailures"]:
+            run.summary["xfailures"] = run_data["xfailures"]
+        if not run.summary["xpasses"]:
+            run.summary["xpasses"] = run_data["xpasses"]
+        if not run.summary["tests"]:
+            run.summary["tests"] = run_data["tests"]
+        db.session.add(run)
+        import_record.status = "done"
+        db.session.add(import_record)
+        db.session.commit()
 
     # Clear the import file content to save database space
     # The import record is kept for audit/history, but the large binary content is removed
     clear_import_file_content.delay(import_record.id)
 
 
-@shared_task
+@shared_task(max_retries=0)
 def run_archive_import(import_):  # noqa: PLR0912
     """Import a test run from an Ibutsu archive file"""
     # Update the status of the import
     import_record = db.session.get(Import, str(import_["id"]))
+    if not import_record:
+        return
+    if import_record.data is None:
+        import_record.data = {}
     log.info(f"Starting archive import for import record {import_record.id}")
     metadata = {}
     if import_record.data.get("metadata"):
@@ -424,7 +496,10 @@ def run_archive_import(import_):  # noqa: PLR0912
     result_artifacts = {}
     start_time = None
     file_object = BytesIO(import_file.content)
-    with tarfile.open(fileobj=file_object) as tar:
+    # Process the archive within a single transaction so a failure part-way
+    # through rolls back cleanly and marks the import as errored -- the run is
+    # never committed without its results/artifacts.
+    with _import_failure_handling(import_record), tarfile.open(fileobj=file_object) as tar:
         for member in tar.getmembers():
             # We don't care about directories, skip them
             if member.isdir():
@@ -446,16 +521,19 @@ def run_archive_import(import_):  # noqa: PLR0912
                 raise ValueError(msg)
             if member.name.endswith("result.json"):
                 result = json.loads(tar.extractfile(member).read())
+                if (not result.get("id") or not is_uuid(result.get("id"))) and is_uuid(result_id):
+                    result["id"] = result_id
                 result_start_time = result.get("start_time")
                 if not start_time or start_time > result_start_time:
                     start_time = result_start_time
-                results.append(result)
+                results.append((result_id, result))
             else:
                 try:
                     result_artifacts[result_id].append(member)
                 except KeyError:
                     result_artifacts[result_id] = [member]
         run_dict = run or {
+            "id": run_id,
             "duration": 0,
             "summary": {
                 "errors": 0,
@@ -466,6 +544,8 @@ def run_archive_import(import_):  # noqa: PLR0912
                 "tests": 0,
             },
         }
+        if not run_dict.get("id") and is_uuid(run_id):
+            run_dict["id"] = run_id
         # patch things up a bit, if necessary
         run_dict["metadata"] = run_dict.get("metadata", {})
         run_dict["metadata"].update(metadata)
@@ -480,22 +560,18 @@ def run_archive_import(import_):  # noqa: PLR0912
         else:
             run = Run.from_dict(**run_dict)
         db.session.add(run)
-        db.session.commit()
-        import_record.run_id = run.id
+        # Flush (not commit) so the run receives an ID while staying in the same
+        # transaction as its results/artifacts -- committed together at the end.
+        db.session.flush()
         import_record.data["run_id"] = [run.id]
         # Loop through any artifacts associated with the run and upload them
         for artifact in run_artifacts:
-            db.session.add(
-                Artifact(
-                    filename=artifact.name.split("/")[-1],
-                    run_id=run.id,
-                    data={"contentType": "text/plain", "runId": run.id},
-                    content=tar.extractfile(artifact).read(),
-                )
-            )
+            filename = artifact.name.split("/")[-1]
+            content = tar.extractfile(artifact).read()
+            _upsert_run_artifact(run.id, filename, content)
         # Now loop through all the results, and create or update them
-        for result in results:
-            artifacts = result_artifacts.get(result["id"], [])
+        for res_id, result in results:
+            artifacts = result_artifacts.get(res_id, [])
             _create_result(
                 tar,
                 run.id,
@@ -504,9 +580,10 @@ def run_archive_import(import_):  # noqa: PLR0912
                 project_id=run_dict.get("project_id") or import_record.data.get("project_id"),
                 metadata=metadata,
             )
-    # Update the import record
-    log.info("Setting import status to done")
-    _update_import_status(import_record, "done")
+        import_record.status = "done"
+        db.session.add(import_record)
+        db.session.commit()
+
     if run:
         update_run.delay(run.id)
 

--- a/backend/tests/test_celery_utils.py
+++ b/backend/tests/test_celery_utils.py
@@ -293,6 +293,9 @@ class TestTaskFailureSignalHandler:
             ("mock_task", 3, 5, False, None),
             ("mock_task", None, 5, True, 32),
             ("mock_task", None, 20, True, 3600),
+            ("mock_task", -1, 0, True, 1),
+            ("mock_task", -1, 5, True, 32),
+            ("mock_task", -1, 20, True, 3600),
         ],
     )
     def test_task_failure_retry_behavior(

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -7,7 +7,9 @@ from io import BytesIO
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
 from lxml import objectify
+from sqlalchemy import func
 
 from ibutsu_server.db import db
 from ibutsu_server.db.base import session
@@ -691,6 +693,102 @@ class TestRunJunitImport:
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "error"
 
+    def test_run_junit_import_no_duplicate_artifacts(self, make_import, flask_app):
+        """A failing testcase should produce exactly one of each artifact, not duplicates"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1" failures="1">
+                <testcase name="test_fail" classname="tests.mod" time="1.0">
+                    <failure message="boom">traceback text</failure>
+                    <system-out>stdout text</system-out>
+                    <system-err>stderr text</system-err>
+                </testcase>
+            </testsuite>
+            """
+
+            import_record = make_import(filename="dup.xml", format="junit", status="pending")
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = db.session.execute(db.select(Run).order_by(Run.id)).scalars().all()[-1]
+            result = db.session.execute(db.select(Result).filter_by(run_id=run.id)).scalar_one()
+            artifacts = (
+                db.session.execute(db.select(Artifact).filter_by(result_id=result.id))
+                .scalars()
+                .all()
+            )
+            filenames = [a.filename for a in artifacts]
+
+            # Each artifact type should appear exactly once (no duplication)
+            assert sorted(filenames) == [
+                "system-err.log",
+                "system-out.log",
+                "traceback.log",
+            ]
+            assert len(filenames) == len(set(filenames))
+
+    def test_run_junit_import_error_rolls_back_and_marks_error(self, make_import, flask_app):
+        """A failure during JUnit processing rolls back the run and marks the import errored"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1" failures="0">
+                <testcase name="test_rollback" classname="tests.mod" time="1.0" />
+            </testsuite>
+            """
+
+            import_record = make_import(filename="rollback.xml", format="junit", status="pending")
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
+                patch(
+                    "ibutsu_server.tasks.importers._process_result",
+                    side_effect=RuntimeError("junit boom"),
+                ),
+                pytest.raises(RuntimeError, match="junit boom"),
+            ):
+                run_junit_import({"id": str(import_record.id)})
+
+            # The import must be marked error, not left stuck in "running"
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "error"
+            # Cleanup must not run on a failed import
+            clear_mock.delay.assert_not_called()
+
+    def test_run_junit_import_with_none_data(self, make_import, flask_app):
+        """JUnit import succeeds even when import_record.data is None"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1">
+                <testcase name="test_one" classname="tests.mod" time="0.5" />
+            </testsuite>
+            """
+            import_record = make_import(filename="none_data.xml", format="junit", status="pending")
+            import_record.data = None
+            db.session.add(import_record)
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            db.session.add(import_file)
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "done"
+            assert "run_id" in updated.data
+
 
 class TestRunArchiveImport:
     """Integration tests for run_archive_import task"""
@@ -764,16 +862,121 @@ class TestRunArchiveImport:
             run = db.session.get(Run, run_id)
             assert run is not None
 
-            # Verify result was created (archive import creates new IDs for results)
-            result = db.session.execute(
-                db.select(Result).filter_by(test_id="test.example", run_id=run.id)
-            ).scalar_one_or_none()
+            # Verify result was created and original UUID was preserved
+            result = db.session.get(Result, result_id)
             assert result is not None
             assert result.test_id == "test.example"
+            assert result.run_id == run.id
 
             # Verify import status
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "done"
+
+    def test_run_archive_import_idempotency_no_duplicate_results(self, make_import, flask_app):
+        """Test that re-importing the same archive updates results without creating duplicates"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {
+                "id": run_id,
+                "metadata": {"build": "101", "component": "backend", "env": "stage"},
+                "summary": {"tests": 1, "passed": 1},
+            }
+
+            result_data = {
+                "id": result_id,
+                "test_id": "test.idempotent",
+                "result": "passed",
+                "duration": 2.0,
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"component": "backend", "env": "stage"},
+            }
+
+            # Create tarball with artifact
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                run_json = json.dumps(run_data).encode()
+                run_info = tarfile.TarInfo(name=f"{run_id}/run.json")
+                run_info.size = len(run_json)
+                tar.addfile(run_info, BytesIO(run_json))
+
+                result_json = json.dumps(result_data).encode()
+                result_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
+                result_info.size = len(result_json)
+                tar.addfile(result_info, BytesIO(result_json))
+
+                artifact_content = b"log output line"
+                art_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/traceback.log")
+                art_info.size = len(artifact_content)
+                tar.addfile(art_info, BytesIO(artifact_content))
+
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            # First import
+            import_record1 = make_import(
+                filename="archive1.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file1 = ImportFile(
+                id=str(uuid4()), import_id=import_record1.id, content=tar_content
+            )
+            session.add(import_file1)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record1.id)})
+
+            # Verify initial counts
+            all_results = (
+                db.session.execute(db.select(Result).where(Result.run_id == run_id)).scalars().all()
+            )
+            assert len(all_results) == 1
+            assert all_results[0].id == result_id
+            assert all_results[0].component == "backend"
+            assert all_results[0].env == "stage"
+
+            all_artifacts = (
+                db.session.execute(db.select(Artifact).where(Artifact.result_id == result_id))
+                .scalars()
+                .all()
+            )
+            assert len(all_artifacts) == 1
+
+            # Second import of the same archive
+            import_record2 = make_import(
+                filename="archive2.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file2 = ImportFile(
+                id=str(uuid4()), import_id=import_record2.id, content=tar_content
+            )
+            session.add(import_file2)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record2.id)})
+
+            # Verify no duplicates were created
+            all_results_after = (
+                db.session.execute(db.select(Result).where(Result.run_id == run_id)).scalars().all()
+            )
+            assert len(all_results_after) == 1
+            assert all_results_after[0].id == result_id
+
+            all_artifacts_after = (
+                db.session.execute(db.select(Artifact).where(Artifact.result_id == result_id))
+                .scalars()
+                .all()
+            )
+            assert len(all_artifacts_after) == 1
 
     def test_run_archive_import_missing_file(self, make_import, flask_app):
         """Test archive import with missing file"""
@@ -790,3 +993,485 @@ class TestRunArchiveImport:
             # Verify status updated to error
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "error"
+
+    def test_run_archive_import_error_rolls_back_and_marks_error(self, make_import, flask_app):
+        """A failure during processing rolls back the run and marks the import errored"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.boom",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(filename="boom.tar.gz", format="ibutsu", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            # Force a failure while creating results, after the run has been staged
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
+                patch(
+                    "ibutsu_server.tasks.importers._create_result",
+                    side_effect=RuntimeError("boom"),
+                ),
+                pytest.raises(RuntimeError, match="boom"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            # The run must not have been committed without its contents
+            assert db.session.get(Run, run_id) is None
+            # The import must be marked error, not left stuck in "running"
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "error"
+            # Cleanup must not run on a failed import
+            clear_mock.delay.assert_not_called()
+
+    def test_run_archive_import_with_none_data(self, make_import, flask_app):
+        """Archive import succeeds even when import_record.data is None"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.none_data",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="none_data.tar.gz", format="ibutsu", status="pending"
+            )
+            import_record.data = None
+            db.session.add(import_record)
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            db.session.add(import_file)
+            db.session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "done"
+            assert "run_id" in updated.data
+            assert updated.data["run_id"] == [run_id]
+
+    def test_run_archive_import_preserves_existing_result_metadata(
+        self, make_import, make_run, make_result, flask_app
+    ):
+        """Re-importing must not discard metadata keys set on the result outside the archive"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            # Pre-existing run and result with metadata that the archive won't contain
+            make_run(id=run_id, metadata={"build": "1"})
+            make_result(
+                id=result_id,
+                run_id=run_id,
+                test_id="test.keep",
+                result="passed",
+                metadata={"classification": "product_failure", "component": "backend"},
+            )
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.keep",
+                "result": "failed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"component": "backend", "env": "stage"},
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(filename="keep.tar.gz", format="ibutsu", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            # Existing-only metadata key must survive the re-import
+            assert result.data["classification"] == "product_failure"
+            # Incoming metadata key must be merged in
+            assert result.data["env"] == "stage"
+            # Updated fields from the archive must be applied
+            assert result.result == "failed"
+
+    def test_run_archive_import_with_null_result_metadata(
+        self, make_import, make_run, make_result, flask_app
+    ):
+        """Re-importing where result.json has metadata: null must not raise TypeError."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            make_run(id=run_id, metadata={"build": "1"})
+            make_result(
+                id=result_id,
+                run_id=run_id,
+                test_id="test.null_meta",
+                result="passed",
+                metadata={"component": "backend"},
+            )
+
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.null_meta",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": None,
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="null_meta.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            assert result is not None
+            assert result.data["component"] == "backend"
+
+    def test_run_archive_import_without_run_json_is_idempotent(self, make_import, flask_app):
+        """Archive without run.json should use the directory run_id
+        and be idempotent on re-import.
+        """
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            result_data = {
+                "id": result_id,
+                "test_id": "test.no_run_json",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"env": "prod"},
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                data = json.dumps(result_data).encode()
+                info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
+                info.size = len(data)
+                tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(filename="no_run.tar.gz", format="ibutsu", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_id)
+            assert run is not None
+            run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+
+            # Second import using same archive content should update, not create duplicate
+            import_record_2 = make_import(
+                filename="no_run.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file_2 = ImportFile(
+                id=str(uuid4()), import_id=import_record_2.id, content=tar_content
+            )
+            session.add(import_file_2)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record_2.id)})
+
+            new_run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            assert new_run_count == run_count
+
+    @pytest.mark.parametrize("id_in_json", [None, "non-uuid-1234"])
+    def test_run_archive_import_result_without_id_field(self, make_import, flask_app, id_in_json):
+        """Archive where result.json omits or has non-UUID 'id' uses the directory result_id and
+        preserves artifacts.
+        """
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "summary": {"tests": 1}}
+            # Omit or provide non-UUID 'id' from result.json payload
+            result_data = {
+                "test_id": "test.missing_id_key",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"env": "prod"},
+            }
+            if id_in_json:
+                result_data["id"] = id_in_json
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+                # Add an artifact for this result
+                artifact_data = b"artifact log"
+                art_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/log.txt")
+                art_info.size = len(artifact_data)
+                tar.addfile(art_info, BytesIO(artifact_data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="missing_res_id.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            assert result is not None
+            assert result.test_id == "test.missing_id_key"
+            artifact = db.session.execute(
+                db.select(Artifact).where(
+                    Artifact.result_id == result_id, Artifact.filename == "log.txt"
+                )
+            ).scalar_one_or_none()
+            assert artifact is not None
+
+    @pytest.mark.parametrize("has_uuid_in_filename", [True, False])
+    def test_run_junit_import_idempotent_retry(self, make_import, flask_app, has_uuid_in_filename):
+        """Retrying JUnit import updates existing run/results without creating duplicates."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            junit_content = b"""<testsuites time="1.5">
+                <testsuite name="my-suite" time="1.5" tests="1" errors="0" failures="0" skipped="0">
+                    <testcase classname="pkg.TestFoo" name="test_bar" time="1.5" />
+                </testsuite>
+            </testsuites>"""
+
+            filename = f"results-{run_uuid}.xml" if has_uuid_in_filename else "results.xml"
+            import_record = make_import(filename=filename, format="junit", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            if has_uuid_in_filename:
+                run = db.session.get(Run, run_uuid)
+            else:
+                run = db.session.get(Run, import_record.data["run_id"][0])
+            assert run is not None
+            run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
+
+            # Re-run the import (simulating a retry)
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            new_run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            new_result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
+            assert new_run_count == run_count
+            assert new_result_count == result_count
+
+    @pytest.mark.parametrize("n_testcases", [1, 3, 5])
+    def test_run_junit_import_n_distinct_testcases_produces_n_results(
+        self, make_import, flask_app, n_testcases
+    ):
+        """Assert that N distinct testcases in a JUnit XML file create exactly N Result records."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            testcases_xml = "\n".join(
+                f'<testcase classname="pkg.TestClass{i}" name="test_method_{i}" time="0.1"/>'
+                for i in range(n_testcases)
+            )
+            junit_content = (
+                f'<testsuites time="1.0">\n'
+                f'  <testsuite name="suite" time="1.0" tests="{n_testcases}" '
+                f'errors="0" failures="0" skipped="0">\n'
+                f"    {testcases_xml}\n"
+                f"  </testsuite>\n"
+                f"</testsuites>"
+            ).encode()
+
+            import_record = make_import(
+                filename="junit-multi.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run_id = import_record.data["run_id"][0]
+            results = Result.query.filter_by(run_id=run_id).all()
+            assert len(results) == n_testcases
+            test_ids = {r.test_id for r in results}
+            expected_test_ids = {f"TestClass{i}.test_method_{i}" for i in range(n_testcases)}
+            assert test_ids == expected_test_ids
+
+    def test_run_junit_import_duplicate_test_ids_in_same_file_not_collapsed(
+        self, make_import, flask_app
+    ):
+        """Two testcases with same test_id in one file don't collapse; retry is idempotent."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            # Two testcases with the same classname and name
+            junit_content = b"""<testsuites time="2.0">
+                <testsuite name="suite" time="2.0" tests="2" errors="0" failures="0" skipped="0">
+                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
+                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
+                </testsuite>
+            </testsuites>"""
+
+            import_record = make_import(
+                filename=f"results-{run_uuid}.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_uuid)
+            assert run is not None
+            results = Result.query.filter_by(run_id=run.id).all()
+            # Assert that the two testcases in the same file did NOT collapse into one result
+            assert len(results) == 2
+            assert all(r.test_id == "TestDup.test_case" for r in results)
+
+            # Re-run the import (simulating a retry): must remain 2 results, updated in place
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            retry_results = Result.query.filter_by(run_id=run.id).all()
+            assert len(retry_results) == 2
+            assert {r.id for r in results} == {r.id for r in retry_results}

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -25,6 +25,8 @@ from ibutsu_server.tasks.importers import (
     _populate_result_metadata,
     _process_result,
     _update_import_status,
+    _upsert_result_artifact,
+    _upsert_run_artifact,
     run_archive_import,
     run_junit_import,
 )
@@ -571,6 +573,153 @@ class TestAddArtifacts:
             assert filenames == {"traceback.log", "system-out.log", "system-err.log"}
 
 
+class TestUpsertArtifact:
+    """Tests for _upsert_artifact, _upsert_result_artifact, and _upsert_run_artifact"""
+
+    def test_upsert_result_artifact_insert_and_update(self, make_result, flask_app):
+        """Test inserting a new result artifact and updating it in-place."""
+        client, _ = flask_app
+        with client.application.app_context():
+            result = make_result()
+            _upsert_result_artifact(result.id, "log.txt", b"initial content")
+            db.session.flush()
+
+            art = db.session.execute(
+                db.select(Artifact).where(
+                    Artifact.result_id == result.id, Artifact.filename == "log.txt"
+                )
+            ).scalar_one()
+            assert art.content == b"initial content"
+            assert art.data["resultId"] == result.id
+            assert art.data["contentType"] == "text/plain"
+
+            _upsert_result_artifact(result.id, "log.txt", b"updated content")
+            db.session.flush()
+
+            artifacts = (
+                db.session.execute(
+                    db.select(Artifact).where(
+                        Artifact.result_id == result.id, Artifact.filename == "log.txt"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(artifacts) == 1
+            assert artifacts[0].id == art.id
+            assert artifacts[0].content == b"updated content"
+
+    def test_upsert_run_artifact_insert_and_update(self, make_run, flask_app):
+        """Test inserting a new run artifact and updating it in-place."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run = make_run()
+            _upsert_run_artifact(run.id, "console.log", b"console output")
+            db.session.flush()
+
+            art = db.session.execute(
+                db.select(Artifact).where(
+                    Artifact.run_id == run.id, Artifact.filename == "console.log"
+                )
+            ).scalar_one()
+            assert art.content == b"console output"
+            assert art.data["runId"] == run.id
+
+            _upsert_run_artifact(run.id, "console.log", b"new console output")
+            db.session.flush()
+
+            artifacts = (
+                db.session.execute(
+                    db.select(Artifact).where(
+                        Artifact.run_id == run.id, Artifact.filename == "console.log"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(artifacts) == 1
+            assert artifacts[0].id == art.id
+            assert artifacts[0].content == b"new console output"
+
+    @pytest.mark.parametrize("target_type", ["result", "run"])
+    def test_upsert_artifact_deduplicates_legacy_rows(
+        self, make_run, make_result, flask_app, target_type
+    ):
+        """Test that _upsert_artifact removes multiple legacy duplicate rows."""
+        client, _ = flask_app
+        with client.application.app_context():
+            d1 = datetime(2026, 1, 1, tzinfo=UTC)
+            d2 = datetime(2026, 1, 2, tzinfo=UTC)
+            d3 = datetime(2026, 1, 3, tzinfo=UTC)
+            if target_type == "result":
+                res = make_result()
+                target_id = res.id
+                kwargs1 = {
+                    "result_id": target_id,
+                    "filename": "dup.txt",
+                    "content": b"v1",
+                    "upload_date": d1,
+                }
+                kwargs2 = {
+                    "result_id": target_id,
+                    "filename": "dup.txt",
+                    "content": b"v2",
+                    "upload_date": d2,
+                }
+                kwargs3 = {
+                    "result_id": target_id,
+                    "filename": "dup.txt",
+                    "content": b"v3",
+                    "upload_date": d3,
+                }
+                query = db.select(Artifact).where(
+                    Artifact.result_id == target_id, Artifact.filename == "dup.txt"
+                )
+            else:
+                run = make_run()
+                target_id = run.id
+                kwargs1 = {
+                    "run_id": target_id,
+                    "filename": "dup.txt",
+                    "content": b"v1",
+                    "upload_date": d1,
+                }
+                kwargs2 = {
+                    "run_id": target_id,
+                    "filename": "dup.txt",
+                    "content": b"v2",
+                    "upload_date": d2,
+                }
+                kwargs3 = {
+                    "run_id": target_id,
+                    "filename": "dup.txt",
+                    "content": b"v3",
+                    "upload_date": d3,
+                }
+                query = db.select(Artifact).where(
+                    Artifact.run_id == target_id, Artifact.filename == "dup.txt"
+                )
+
+            art1 = Artifact(**kwargs1)
+            art2 = Artifact(**kwargs2)
+            art3 = Artifact(**kwargs3)
+            db.session.add_all([art1, art2, art3])
+            db.session.commit()
+
+            assert len(db.session.execute(query).scalars().all()) == 3
+
+            if target_type == "result":
+                _upsert_result_artifact(target_id, "dup.txt", b"deduped content")
+            else:
+                _upsert_run_artifact(target_id, "dup.txt", b"deduped content")
+            db.session.commit()
+
+            remaining = db.session.execute(query).scalars().all()
+            assert len(remaining) == 1
+            assert remaining[0].id == art1.id
+            assert remaining[0].content == b"deduped content"
+
+
 class TestRunJunitImport:
     """Integration tests for run_junit_import task"""
 
@@ -744,7 +893,10 @@ class TestRunJunitImport:
             </testsuite>
             """
 
-            import_record = make_import(filename="rollback.xml", format="junit", status="pending")
+            run_uuid = str(uuid4())
+            import_record = make_import(
+                filename=f"rollback-{run_uuid}.xml", format="junit", status="pending"
+            )
             import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
             session.add(import_file)
             session.commit()
@@ -759,11 +911,42 @@ class TestRunJunitImport:
             ):
                 run_junit_import({"id": str(import_record.id)})
 
+            # The run and results must not have been committed
+            assert db.session.get(Run, run_uuid) is None
+            assert (
+                db.session.execute(db.select(Result).where(Result.run_id == run_uuid))
+                .scalars()
+                .all()
+                == []
+            )
             # The import must be marked error, not left stuck in "running"
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "error"
             # Cleanup must not run on a failed import
             clear_mock.delay.assert_not_called()
+
+    def test_run_junit_import_with_none_filename(self, make_import, flask_app):
+        """JUnit import succeeds even when import_record.filename is None"""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1">
+                <testcase name="test_one" classname="tests.mod" time="0.5" />
+            </testsuite>
+            """
+            import_record = make_import(filename=None, format="junit", status="pending")
+            db.session.add(import_record)
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            db.session.add(import_file)
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "done"
+            assert "run_id" in updated.data
 
     def test_run_junit_import_with_none_data(self, make_import, flask_app):
         """JUnit import succeeds even when import_record.data is None"""
@@ -788,6 +971,214 @@ class TestRunJunitImport:
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "done"
             assert "run_id" in updated.data
+
+    def test_run_junit_import_missing_record_returns_none(self, flask_app):
+        """JUnit import returns early when the import record is not found."""
+        client, _ = flask_app
+        with client.application.app_context():
+            assert run_junit_import({"id": str(uuid4())}) is None
+
+    def test_run_junit_import_with_string_run_id_in_data(self, make_import, flask_app):
+        """JUnit import handles string run_id in import_record.data."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            junit_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite" tests="1">
+                <testcase name="test_str_run_id" classname="tests.mod" time="0.5" />
+            </testsuite>
+            """
+            import_record = make_import(filename="str_run_id.xml", format="junit", status="pending")
+            import_record.data = {"run_id": run_uuid}
+            db.session.add(import_record)
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            db.session.add(import_file)
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_uuid)
+            assert run is not None
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "done"
+            assert updated.data["run_id"] == [run_uuid]
+
+    def test_run_junit_import_with_metadata_project_and_source(
+        self, make_import, make_project, flask_app
+    ):
+        """JUnit import correctly applies metadata, project, and source."""
+        client, _ = flask_app
+        with client.application.app_context():
+            proj = make_project(name="junit-test-project")
+            junit_xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+            <testsuite name="suite-with-props" tests="1" errors="1" failures="1"
+                       skipped="1" xfailures="1" xpasses="1">
+                <properties>
+                    <property key="project" value="{proj.name}" />
+                    <property key="env" value="staging" />
+                    <property key="component" value="api" />
+                </properties>
+                <testcase name="test_with_source" classname="tests.prop" time="0.3">
+                    <error message="err">err msg</error>
+                </testcase>
+            </testsuite>
+            """.encode()
+
+            import_record = make_import(filename="props.xml", format="junit", status="pending")
+            import_record.data = {
+                "metadata": {"extra_tag": "v1"},
+                "source": "custom_ci",
+            }
+            db.session.add(import_record)
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            db.session.add(import_file)
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run_id = import_record.data["run_id"][0]
+            run = db.session.get(Run, run_id)
+            assert run is not None
+            assert run.project_id == proj.id
+            assert run.source == "custom_ci"
+            assert run.data.get("extra_tag") == "v1"
+
+            result = db.session.execute(
+                db.select(Result).where(Result.run_id == run_id)
+            ).scalar_one()
+            assert result.source == "custom_ci"
+
+    @pytest.mark.parametrize("has_uuid_in_filename", [True, False])
+    def test_run_junit_import_idempotent_retry(self, make_import, flask_app, has_uuid_in_filename):
+        """Retrying JUnit import updates existing run/results without creating duplicates."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            junit_content = b"""<testsuites time="1.5">
+                <testsuite name="my-suite" time="1.5" tests="1" errors="0" failures="0" skipped="0">
+                    <testcase classname="pkg.TestFoo" name="test_bar" time="1.5" />
+                </testsuite>
+            </testsuites>"""
+
+            filename = f"results-{run_uuid}.xml" if has_uuid_in_filename else "results.xml"
+            import_record = make_import(filename=filename, format="junit", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            if has_uuid_in_filename:
+                run = db.session.get(Run, run_uuid)
+            else:
+                run = db.session.get(Run, import_record.data["run_id"][0])
+            assert run is not None
+            run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
+
+            # Re-run the import (simulating a retry)
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            new_run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
+            new_result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
+            assert new_run_count == run_count
+            assert new_result_count == result_count
+
+    @pytest.mark.parametrize("n_testcases", [1, 3, 5])
+    def test_run_junit_import_n_distinct_testcases_produces_n_results(
+        self, make_import, flask_app, n_testcases
+    ):
+        """Assert that N distinct testcases in a JUnit XML file create exactly N Result records."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            testcases_xml = "\n".join(
+                f'<testcase classname="pkg.TestClass{i}" name="test_method_{i}" time="0.1"/>'
+                for i in range(n_testcases)
+            )
+            junit_content = (
+                f'<testsuites time="1.0">\n'
+                f'  <testsuite name="suite" time="1.0" tests="{n_testcases}" '
+                f'errors="0" failures="0" skipped="0">\n'
+                f"    {testcases_xml}\n"
+                f"  </testsuite>\n"
+                f"</testsuites>"
+            ).encode()
+
+            import_record = make_import(
+                filename="junit-multi.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run_id = import_record.data["run_id"][0]
+            results = (
+                db.session.execute(db.select(Result).where(Result.run_id == run_id)).scalars().all()
+            )
+            assert len(results) == n_testcases
+            test_ids = {r.test_id for r in results}
+            expected_test_ids = {f"TestClass{i}.test_method_{i}" for i in range(n_testcases)}
+            assert test_ids == expected_test_ids
+
+    def test_run_junit_import_duplicate_test_ids_in_same_file_not_collapsed(
+        self, make_import, flask_app
+    ):
+        """Two testcases with same test_id in one file don't collapse; retry is idempotent."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            # Two testcases with the same classname and name
+            junit_content = b"""<testsuites time="2.0">
+                <testsuite name="suite" time="2.0" tests="2" errors="0" failures="0" skipped="0">
+                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
+                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
+                </testsuite>
+            </testsuites>"""
+
+            import_record = make_import(
+                filename=f"results-{run_uuid}.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=junit_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_uuid)
+            assert run is not None
+            results = (
+                db.session.execute(db.select(Result).where(Result.run_id == run.id)).scalars().all()
+            )
+            # Assert that the two testcases in the same file did NOT collapse into one result
+            assert len(results) == 2
+            assert all(r.test_id == "TestDup.test_case" for r in results)
+
+            # Re-run the import (simulating a retry): must remain 2 results, updated in place
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            retry_results = (
+                db.session.execute(db.select(Result).where(Result.run_id == run.id)).scalars().all()
+            )
+            assert len(retry_results) == 2
+            assert {r.id for r in results} == {r.id for r in retry_results}
 
 
 class TestRunArchiveImport:
@@ -1224,6 +1615,119 @@ class TestRunArchiveImport:
             assert result is not None
             assert result.data["component"] == "backend"
 
+    def test_run_archive_import_with_null_run_metadata(self, make_import, make_run, flask_app):
+        """Archive where run.json has metadata: null must not raise AttributeError."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "metadata": None, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.null_run_meta",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {"component": "backend"},
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="null_run_meta.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_id)
+            assert run is not None
+            assert run.data == {}
+
+    def test_run_archive_import_preserves_existing_env_and_component(
+        self, make_import, make_run, make_result, flask_app
+    ):
+        """Re-importing must not wipe out existing env and component when omitted in archive."""
+        client, _ = flask_app
+
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            # Pre-existing run and result with env and component set on the database record
+            make_run(id=run_id, metadata={"build": "1"})
+            make_result(
+                id=result_id,
+                run_id=run_id,
+                test_id="test.preserve_env_comp",
+                result="passed",
+                env="staging",
+                component="backend",
+            )
+
+            # Archive whose result.json does not specify env or component
+            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.preserve_env_comp",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {},
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
+
+            import_record = make_import(
+                filename="preserve.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            assert result is not None
+            assert result.env == "staging"
+            assert result.component == "backend"
+
     def test_run_archive_import_without_run_json_is_idempotent(self, make_import, flask_app):
         """Archive without run.json should use the directory run_id
         and be idempotent on re-import.
@@ -1352,126 +1856,280 @@ class TestRunArchiveImport:
             ).scalar_one_or_none()
             assert artifact is not None
 
-    @pytest.mark.parametrize("has_uuid_in_filename", [True, False])
-    def test_run_junit_import_idempotent_retry(self, make_import, flask_app, has_uuid_in_filename):
-        """Retrying JUnit import updates existing run/results without creating duplicates."""
+    def test_run_archive_import_missing_record_returns_none(self, flask_app):
+        """Archive import returns early when the import record is not found."""
         client, _ = flask_app
-
         with client.application.app_context():
-            run_uuid = str(uuid4())
-            junit_content = b"""<testsuites time="1.5">
-                <testsuite name="my-suite" time="1.5" tests="1" errors="0" failures="0" skipped="0">
-                    <testcase classname="pkg.TestFoo" name="test_bar" time="1.5" />
-                </testsuite>
-            </testsuites>"""
+            assert run_archive_import({"id": str(uuid4())}) is None
 
-            filename = f"results-{run_uuid}.xml" if has_uuid_in_filename else "results.xml"
-            import_record = make_import(filename=filename, format="junit", status="pending")
-            import_file = ImportFile(
-                id=str(uuid4()), import_id=import_record.id, content=junit_content
-            )
-            session.add(import_file)
-            session.commit()
-
-            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
-                run_junit_import({"id": str(import_record.id)})
-
-            if has_uuid_in_filename:
-                run = db.session.get(Run, run_uuid)
-            else:
-                run = db.session.get(Run, import_record.data["run_id"][0])
-            assert run is not None
-            run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
-            result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
-
-            # Re-run the import (simulating a retry)
-            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
-                run_junit_import({"id": str(import_record.id)})
-
-            new_run_count = db.session.execute(db.select(func.count(Run.id))).scalar()
-            new_result_count = db.session.execute(db.select(func.count(Result.id))).scalar()
-            assert new_run_count == run_count
-            assert new_result_count == result_count
-
-    @pytest.mark.parametrize("n_testcases", [1, 3, 5])
-    def test_run_junit_import_n_distinct_testcases_produces_n_results(
-        self, make_import, flask_app, n_testcases
-    ):
-        """Assert that N distinct testcases in a JUnit XML file create exactly N Result records."""
+    def test_run_archive_import_with_run_level_artifact(self, make_import, flask_app):
+        """Archive import upserts run-level artifacts without duplication."""
         client, _ = flask_app
-
         with client.application.app_context():
-            testcases_xml = "\n".join(
-                f'<testcase classname="pkg.TestClass{i}" name="test_method_{i}" time="0.1"/>'
-                for i in range(n_testcases)
-            )
-            junit_content = (
-                f'<testsuites time="1.0">\n'
-                f'  <testsuite name="suite" time="1.0" tests="{n_testcases}" '
-                f'errors="0" failures="0" skipped="0">\n'
-                f"    {testcases_xml}\n"
-                f"  </testsuite>\n"
-                f"</testsuites>"
-            ).encode()
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            run_data = {"id": run_id, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.with_run_art",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+
+                # Add a run-level artifact
+                run_art_content = b"run-level log content"
+                run_art_info = tarfile.TarInfo(name=f"{run_id}/console.log")
+                run_art_info.size = len(run_art_content)
+                tar.addfile(run_art_info, BytesIO(run_art_content))
+
+            tar_buffer.seek(0)
+            tar_content = tar_buffer.read()
 
             import_record = make_import(
-                filename="junit-multi.xml", format="junit", status="pending"
+                filename="run_art.tar.gz", format="ibutsu", status="pending"
             )
             import_file = ImportFile(
-                id=str(uuid4()), import_id=import_record.id, content=junit_content
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
             session.add(import_file)
             session.commit()
 
-            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
-                run_junit_import({"id": str(import_record.id)})
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
 
-            run_id = import_record.data["run_id"][0]
-            results = Result.query.filter_by(run_id=run_id).all()
-            assert len(results) == n_testcases
-            test_ids = {r.test_id for r in results}
-            expected_test_ids = {f"TestClass{i}.test_method_{i}" for i in range(n_testcases)}
-            assert test_ids == expected_test_ids
+            # Check that run-level artifact was stored
+            art = db.session.execute(
+                db.select(Artifact).where(
+                    Artifact.run_id == run_id, Artifact.filename == "console.log"
+                )
+            ).scalar_one_or_none()
+            assert art is not None
+            assert art.content == b"run-level log content"
+            assert art.data["runId"] == run_id
 
-    def test_run_junit_import_duplicate_test_ids_in_same_file_not_collapsed(
-        self, make_import, flask_app
-    ):
-        """Two testcases with same test_id in one file don't collapse; retry is idempotent."""
+            # Re-import should update the run artifact in-place without duplicating
+            import_record2 = make_import(
+                filename="run_art.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file2 = ImportFile(
+                id=str(uuid4()), import_id=import_record2.id, content=tar_content
+            )
+            session.add(import_file2)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record2.id)})
+
+            run_arts = (
+                db.session.execute(
+                    db.select(Artifact).where(
+                        Artifact.run_id == run_id, Artifact.filename == "console.log"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(run_arts) == 1
+            assert run_arts[0].id == art.id
+
+    def test_run_archive_import_run_json_without_id_field(self, make_import, flask_app):
+        """Archive where run.json omits the 'id' field sets run_id from directory."""
         client, _ = flask_app
-
         with client.application.app_context():
-            run_uuid = str(uuid4())
-            # Two testcases with the same classname and name
-            junit_content = b"""<testsuites time="2.0">
-                <testsuite name="suite" time="2.0" tests="2" errors="0" failures="0" skipped="0">
-                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
-                    <testcase classname="pkg.TestDup" name="test_case" time="1.0"/>
-                </testsuite>
-            </testsuites>"""
+            run_id = str(uuid4())
+            result_id = str(uuid4())
 
+            # run.json without 'id' field
+            run_data = {"summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.run_without_id",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+
+            tar_buffer.seek(0)
             import_record = make_import(
-                filename=f"results-{run_uuid}.xml", format="junit", status="pending"
+                filename="no_run_id_field.tar.gz", format="ibutsu", status="pending"
             )
             import_file = ImportFile(
-                id=str(uuid4()), import_id=import_record.id, content=junit_content
+                id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read()
             )
             session.add(import_file)
             session.commit()
 
-            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
-                run_junit_import({"id": str(import_record.id)})
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
 
-            run = db.session.get(Run, run_uuid)
+            run = db.session.get(Run, run_id)
             assert run is not None
-            results = Result.query.filter_by(run_id=run.id).all()
-            # Assert that the two testcases in the same file did NOT collapse into one result
-            assert len(results) == 2
-            assert all(r.test_id == "TestDup.test_case" for r in results)
+            assert run.id == run_id
 
-            # Re-run the import (simulating a retry): must remain 2 results, updated in place
-            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
-                run_junit_import({"id": str(import_record.id)})
+    def test_run_archive_import_with_user_properties_and_importer_metadata(
+        self, make_import, make_project, flask_app
+    ):
+        """Archive import promotes user_properties and merges importer metadata and project."""
+        client, _ = flask_app
+        with client.application.app_context():
+            proj = make_project(name="archive-user-props-project")
+            run_id = str(uuid4())
+            result_id = str(uuid4())
 
-            retry_results = Result.query.filter_by(run_id=run.id).all()
-            assert len(retry_results) == 2
-            assert {r.id for r in results} == {r.id for r in retry_results}
+            run_data = {"id": run_id, "summary": {"tests": 1}}
+            result_data = {
+                "id": result_id,
+                "test_id": "test.user_properties",
+                "result": "passed",
+                "start_time": datetime.now(UTC).isoformat(),
+                "metadata": {
+                    "user_properties": {"team": "qe", "tier": "smoke"},
+                },
+            }
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                for name, payload in [
+                    (f"{run_id}/run.json", run_data),
+                    (f"{run_id}/{result_id}/result.json", result_data),
+                ]:
+                    data = json.dumps(payload).encode()
+                    info = tarfile.TarInfo(name=name)
+                    info.size = len(data)
+                    tar.addfile(info, BytesIO(data))
+
+            tar_buffer.seek(0)
+            import_record = make_import(
+                filename="user_props.tar.gz", format="ibutsu", status="pending"
+            )
+            import_record.data = {
+                "metadata": {"imported_by": "automation"},
+                "project_id": proj.id,
+            }
+            session.add(import_record)
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read()
+            )
+            session.add(import_file)
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            result = db.session.get(Result, result_id)
+            assert result is not None
+            assert result.project_id == proj.id
+            assert result.data.get("team") == "qe"
+            assert result.data.get("tier") == "smoke"
+            assert result.data.get("imported_by") == "automation"
+            assert "user_properties" not in result.data
+
+    def test_run_archive_import_skips_directories(self, make_import, flask_app):
+        """Archive import gracefully skips directory members in the tarball."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                dir_info = tarfile.TarInfo(name=f"{run_id}/")
+                dir_info.type = tarfile.DIRTYPE
+                tar.addfile(dir_info)
+
+                sub_dir_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/")
+                sub_dir_info.type = tarfile.DIRTYPE
+                tar.addfile(sub_dir_info)
+
+                result_data = json.dumps(
+                    {"id": result_id, "test_id": "test.dir", "result": "passed"}
+                ).encode()
+                info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
+                info.size = len(result_data)
+                tar.addfile(info, BytesIO(result_data))
+
+            tar_buffer.seek(0)
+            import_record = make_import(filename="dir.tar.gz", format="ibutsu", status="pending")
+            session.add(
+                ImportFile(id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read())
+            )
+            session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            assert db.session.get(Import, import_record.id).status == "done"
+
+    @pytest.mark.parametrize(
+        ("bad_member_name", "error_match"),
+        [
+            ("not-a-uuid/run.json", "Invalid run ID not-a-uuid"),
+            (
+                "00000000-0000-4000-8000-000000000001/not-a-uuid/result.json",
+                "Invalid result ID not-a-uuid",
+            ),
+        ],
+    )
+    def test_run_archive_import_invalid_uuids_raise_value_error(
+        self, make_import, flask_app, bad_member_name, error_match
+    ):
+        """Archive import raises ValueError and marks import as error on bad UUIDs."""
+        client, _ = flask_app
+        with client.application.app_context():
+            tar_buffer = BytesIO()
+            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+                payload = b"{}"
+                info = tarfile.TarInfo(name=bad_member_name)
+                info.size = len(payload)
+                tar.addfile(info, BytesIO(payload))
+
+            tar_buffer.seek(0)
+            import_record = make_import(
+                filename="bad_uuid.tar.gz", format="ibutsu", status="pending"
+            )
+            session.add(
+                ImportFile(id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read())
+            )
+            session.commit()
+
+            with pytest.raises(ValueError, match=error_match):
+                run_archive_import({"id": str(import_record.id)})
+
+            assert db.session.get(Import, import_record.id).status == "error"

--- a/backend/tests/test_importers.py
+++ b/backend/tests/test_importers.py
@@ -8,14 +8,14 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from lxml import objectify
+from lxml import etree, objectify
 from sqlalchemy import func
 
 from ibutsu_server.db import db
-from ibutsu_server.db.base import session
 from ibutsu_server.db.models import Artifact, Import, ImportFile, Result, Run
 from ibutsu_server.tasks.importers import (
     _add_artifacts,
+    _extract_run_id,
     _get_properties,
     _get_test_name_path,
     _get_ts_element,
@@ -25,11 +25,36 @@ from ibutsu_server.tasks.importers import (
     _populate_result_metadata,
     _process_result,
     _update_import_status,
+    _update_run_summary,
+    _upsert_artifact,
     _upsert_result_artifact,
     _upsert_run_artifact,
     run_archive_import,
     run_junit_import,
 )
+
+
+def make_archive_bytes(members: dict) -> bytes:
+    """Create an in-memory tar.gz archive from a mapping of path -> content."""
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in members.items():
+            if content is None or content == "dir":
+                info = tarfile.TarInfo(name=name)
+                info.type = tarfile.DIRTYPE
+                tar.addfile(info)
+            else:
+                if isinstance(content, dict):
+                    payload = json.dumps(content).encode()
+                elif isinstance(content, str):
+                    payload = content.encode()
+                else:
+                    payload = content
+                info = tarfile.TarInfo(name=name)
+                info.size = len(payload)
+                tar.addfile(info, BytesIO(payload))
+    buf.seek(0)
+    return buf.read()
 
 
 class TestGetProperties:
@@ -576,30 +601,46 @@ class TestAddArtifacts:
 class TestUpsertArtifact:
     """Tests for _upsert_artifact, _upsert_result_artifact, and _upsert_run_artifact"""
 
-    def test_upsert_result_artifact_insert_and_update(self, make_result, flask_app):
-        """Test inserting a new result artifact and updating it in-place."""
+    @pytest.mark.parametrize("target_type", ["result", "run"])
+    def test_upsert_artifact_insert_and_update(self, make_result, make_run, flask_app, target_type):
+        """Test inserting a new artifact and updating it in-place."""
         client, _ = flask_app
         with client.application.app_context():
-            result = make_result()
-            _upsert_result_artifact(result.id, "log.txt", b"initial content")
+            if target_type == "result":
+                target = make_result()
+                target_col = Artifact.result_id
+                meta_key = "resultId"
+                filename = "log.txt"
+                initial_content = b"initial content"
+                updated_content = b"updated content"
+                _upsert_result_artifact(target.id, filename, initial_content)
+            else:
+                target = make_run()
+                target_col = Artifact.run_id
+                meta_key = "runId"
+                filename = "console.log"
+                initial_content = b"console output"
+                updated_content = b"new console output"
+                _upsert_run_artifact(target.id, filename, initial_content)
+
             db.session.flush()
 
             art = db.session.execute(
-                db.select(Artifact).where(
-                    Artifact.result_id == result.id, Artifact.filename == "log.txt"
-                )
+                db.select(Artifact).where(target_col == target.id, Artifact.filename == filename)
             ).scalar_one()
-            assert art.content == b"initial content"
-            assert art.data["resultId"] == result.id
-            assert art.data["contentType"] == "text/plain"
+            assert art.content == initial_content
+            assert art.data[meta_key] == target.id
 
-            _upsert_result_artifact(result.id, "log.txt", b"updated content")
+            if target_type == "result":
+                _upsert_result_artifact(target.id, filename, updated_content)
+            else:
+                _upsert_run_artifact(target.id, filename, updated_content)
             db.session.flush()
 
             artifacts = (
                 db.session.execute(
                     db.select(Artifact).where(
-                        Artifact.result_id == result.id, Artifact.filename == "log.txt"
+                        target_col == target.id, Artifact.filename == filename
                     )
                 )
                 .scalars()
@@ -607,39 +648,16 @@ class TestUpsertArtifact:
             )
             assert len(artifacts) == 1
             assert artifacts[0].id == art.id
-            assert artifacts[0].content == b"updated content"
+            assert artifacts[0].content == updated_content
 
-    def test_upsert_run_artifact_insert_and_update(self, make_run, flask_app):
-        """Test inserting a new run artifact and updating it in-place."""
+    def test_upsert_artifact_missing_target_raises(self, flask_app):
+        """_upsert_artifact raises ValueError when neither result_id nor run_id is supplied."""
         client, _ = flask_app
-        with client.application.app_context():
-            run = make_run()
-            _upsert_run_artifact(run.id, "console.log", b"console output")
-            db.session.flush()
-
-            art = db.session.execute(
-                db.select(Artifact).where(
-                    Artifact.run_id == run.id, Artifact.filename == "console.log"
-                )
-            ).scalar_one()
-            assert art.content == b"console output"
-            assert art.data["runId"] == run.id
-
-            _upsert_run_artifact(run.id, "console.log", b"new console output")
-            db.session.flush()
-
-            artifacts = (
-                db.session.execute(
-                    db.select(Artifact).where(
-                        Artifact.run_id == run.id, Artifact.filename == "console.log"
-                    )
-                )
-                .scalars()
-                .all()
-            )
-            assert len(artifacts) == 1
-            assert artifacts[0].id == art.id
-            assert artifacts[0].content == b"new console output"
+        with (
+            client.application.app_context(),
+            pytest.raises(ValueError, match="Either result_id or run_id"),
+        ):
+            _upsert_artifact("test.txt", b"content")
 
     @pytest.mark.parametrize("target_type", ["result", "run"])
     def test_upsert_artifact_deduplicates_legacy_rows(
@@ -737,53 +755,50 @@ class TestRunJunitImport:
             </testsuite>
             """
 
-        import_record = make_import(filename="test.xml", format="junit", status="pending")
+            import_record = make_import(filename="test.xml", format="junit", status="pending")
+            import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            db.session.add(import_file)
+            db.session.commit()
 
-        # Create import file
-        import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
+            # Run the import - mock clear_import_file_content to avoid Redis dependency
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock:
+                run_junit_import({"id": str(import_record.id)})
 
-        session.add(import_file)
-        session.commit()
+            # Ensure cleanup task is invoked
+            clear_mock.delay.assert_called_once_with(import_record.id)
 
-        # Run the import - mock clear_import_file_content to avoid Redis dependency
-        with patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock:
-            run_junit_import({"id": str(import_record.id)})
+            # Verify run was created
+            runs = Run.query.all()
+            assert len(runs) > 0
+            run = runs[-1]  # Get the latest run
+            assert run.summary["tests"] == 2
+            assert run.summary["failures"] == 1
 
-        # Ensure cleanup task is invoked
-        clear_mock.delay.assert_called_once_with(import_record.id)
+            # Verify results were created
+            results = Result.query.filter_by(run_id=run.id).order_by(Result.id).all()
+            assert len(results) == 2
 
-        # Verify run was created
-        runs = Run.query.all()
-        assert len(runs) > 0
-        run = runs[-1]  # Get the latest run
-        assert run.summary["tests"] == 2
-        assert run.summary["failures"] == 1
+            # Verify per-test behavior: one passed and one failed result
+            statuses = {r.result for r in results}
+            assert statuses == {"passed", "failed"}
 
-        # Verify results were created
-        results = Result.query.filter_by(run_id=run.id).order_by(Result.id).all()
-        assert len(results) == 2
+            # Check that test identifiers/names were correctly mapped from the XML
+            test_ids = {r.test_id for r in results}
+            # Test IDs should contain both test case names
+            assert any("test_pass" in tid for tid in test_ids)
+            assert any("test_fail" in tid for tid in test_ids)
 
-        # Verify per-test behavior: one passed and one failed result
-        statuses = {r.result for r in results}
-        assert statuses == {"passed", "failed"}
+            # Verify the failed test has a traceback artifact attached
+            failed_result = next(r for r in results if r.result == "failed")
+            failed_artifacts = Artifact.query.filter_by(result_id=failed_result.id).all()
+            failed_filenames = {a.filename for a in failed_artifacts}
 
-        # Check that test identifiers/names were correctly mapped from the XML
-        test_ids = {r.test_id for r in results}
-        # Test IDs should contain both test case names
-        assert any("test_pass" in tid for tid in test_ids)
-        assert any("test_fail" in tid for tid in test_ids)
+            # We expect a traceback artifact for the failed test
+            assert "traceback.log" in failed_filenames
 
-        # Verify the failed test has a traceback artifact attached
-        failed_result = next(r for r in results if r.result == "failed")
-        failed_artifacts = Artifact.query.filter_by(result_id=failed_result.id).all()
-        failed_filenames = {a.filename for a in failed_artifacts}
-
-        # We expect a traceback artifact for the failed test
-        assert "traceback.log" in failed_filenames
-
-        # Verify import status updated
-        updated_import = db.session.get(Import, import_record.id)
-        assert updated_import.status == "done"
+            # Verify import status updated
+            updated_import = db.session.get(Import, import_record.id)
+            assert updated_import.status == "done"
 
     def test_run_junit_import_with_properties(self, make_import, make_project, flask_app):
         """Test JUnit import with properties"""
@@ -811,8 +826,8 @@ class TestRunJunitImport:
 
             import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
 
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             # Mock clear_import_file_content to avoid Redis dependency
             with patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock:
@@ -859,8 +874,8 @@ class TestRunJunitImport:
 
             import_record = make_import(filename="dup.xml", format="junit", status="pending")
             import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
                 run_junit_import({"id": str(import_record.id)})
@@ -898,8 +913,32 @@ class TestRunJunitImport:
                 filename=f"rollback-{run_uuid}.xml", format="junit", status="pending"
             )
             import_file = ImportFile(id=str(uuid4()), import_id=import_record.id, content=junit_xml)
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
+                patch(
+                    "ibutsu_server.tasks.importers._process_result",
+                    side_effect=RuntimeError("junit boom"),
+                ),
+                pytest.raises(RuntimeError, match="junit boom"),
+            ):
+                run_junit_import({"id": str(import_record.id)})
+
+            # The run and results must not have been committed
+            assert db.session.get(Run, run_uuid) is None
+            assert (
+                db.session.execute(db.select(Result).where(Result.run_id == run_uuid))
+                .scalars()
+                .all()
+                == []
+            )
+            # The import must be marked error, not left stuck in "running"
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "error"
+            # Cleanup must not run on a failed import
+            clear_mock.delay.assert_not_called()
 
             with (
                 patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
@@ -1068,8 +1107,8 @@ class TestRunJunitImport:
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=junit_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
                 run_junit_import({"id": str(import_record.id)})
@@ -1118,8 +1157,8 @@ class TestRunJunitImport:
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=junit_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
                 run_junit_import({"id": str(import_record.id)})
@@ -1155,8 +1194,8 @@ class TestRunJunitImport:
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=junit_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
                 run_junit_import({"id": str(import_record.id)})
@@ -1180,6 +1219,150 @@ class TestRunJunitImport:
             assert len(retry_results) == 2
             assert {r.id for r in results} == {r.id for r in retry_results}
 
+    def test_run_junit_import_malformed_xml_rolls_back_and_marks_error(
+        self, make_import, flask_app
+    ):
+        """Malformed XML syntax must roll back, mark import as error, and re-raise."""
+        client, _ = flask_app
+        with client.application.app_context():
+            import_record = make_import(filename="bad.xml", format="junit", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=b"<testsuite><unclosed>"
+            )
+            db.session.add(import_file)
+            db.session.commit()
+
+            with pytest.raises(etree.XMLSyntaxError):
+                run_junit_import({"id": str(import_record.id)})
+
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "error"
+
+    def test_run_junit_import_artifact_idempotency_on_retry(self, make_import, flask_app):
+        """Re-importing JUnit XML with logs updates artifacts without duplicating."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            xml_v1 = """
+            <testsuite name="suite" timestamp="2026-01-01T00:00:00" tests="1">
+                <testcase name="test_art_idemp" classname="pkg.test">
+                    <failure message="fail1">Traceback v1</failure>
+                    <system-out>stdout v1</system-out>
+                    <system-err>stderr v1</system-err>
+                </testcase>
+            </testsuite>
+            """
+            import_record = make_import(
+                filename=f"junit-{run_uuid}.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=xml_v1.encode()
+            )
+            db.session.add(import_file)
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            result = db.session.execute(
+                db.select(Result).where(Result.run_id == run_uuid)
+            ).scalar_one()
+            arts_v1 = (
+                db.session.execute(db.select(Artifact).where(Artifact.result_id == result.id))
+                .scalars()
+                .all()
+            )
+            assert len(arts_v1) == 3
+            art_map = {a.filename: a for a in arts_v1}
+            assert b"Traceback v1" in art_map["traceback.log"].content
+            assert b"stdout v1" in art_map["system-out.log"].content
+
+            # Second import with updated output
+            xml_v2 = """
+            <testsuite name="suite" timestamp="2026-01-01T00:00:00" tests="1">
+                <testcase name="test_art_idemp" classname="pkg.test">
+                    <failure message="fail2">Traceback v2</failure>
+                    <system-out>stdout v2</system-out>
+                    <system-err>stderr v2</system-err>
+                </testcase>
+            </testsuite>
+            """
+            import_file.content = xml_v2.encode()
+            import_record.status = "pending"
+            db.session.add_all([import_record, import_file])
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            arts_v2 = (
+                db.session.execute(db.select(Artifact).where(Artifact.result_id == result.id))
+                .scalars()
+                .all()
+            )
+            assert len(arts_v2) == 3
+            art_map2 = {a.filename: a for a in arts_v2}
+            assert b"Traceback v2" in art_map2["traceback.log"].content
+            assert b"stdout v2" in art_map2["system-out.log"].content
+
+    def test_run_junit_import_preserves_existing_env_and_component(self, make_import, flask_app):
+        """Re-importing JUnit XML without env/component preserves existing values."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run_uuid = str(uuid4())
+            xml_v1 = """
+            <testsuite name="suite" timestamp="2026-01-01T00:00:00" tests="1">
+                <properties>
+                    <property key="env" value="staging"/>
+                    <property key="component" value="backend"/>
+                </properties>
+                <testcase name="test_env" classname="pkg.test"/>
+            </testsuite>
+            """
+            import_record = make_import(
+                filename=f"junit-{run_uuid}.xml", format="junit", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=xml_v1.encode()
+            )
+            db.session.add(import_file)
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run = db.session.get(Run, run_uuid)
+            assert run.env == "staging"
+            assert run.component == "backend"
+            result = db.session.execute(
+                db.select(Result).where(Result.run_id == run_uuid)
+            ).scalar_one()
+            assert result.env == "staging"
+            assert result.component == "backend"
+
+            # Re-import without env and component
+            xml_v2 = """
+            <testsuite name="suite" timestamp="2026-01-01T00:00:00" tests="1">
+                <testcase name="test_env" classname="pkg.test"/>
+            </testsuite>
+            """
+            import_file.content = xml_v2.encode()
+            import_record.status = "pending"
+            db.session.add_all([import_record, import_file])
+            db.session.commit()
+
+            with patch("ibutsu_server.tasks.importers.clear_import_file_content"):
+                run_junit_import({"id": str(import_record.id)})
+
+            run_reloaded = db.session.get(Run, run_uuid)
+            assert run_reloaded.env == "staging"
+            assert run_reloaded.component == "backend"
+            result_reloaded = db.session.execute(
+                db.select(Result).where(Result.run_id == run_uuid)
+            ).scalar_one()
+            assert result_reloaded.env == "staging"
+            assert result_reloaded.component == "backend"
+
 
 class TestRunArchiveImport:
     """Integration tests for run_archive_import task"""
@@ -1189,7 +1372,6 @@ class TestRunArchiveImport:
         client, _ = flask_app
 
         with client.application.app_context():
-            # Create a simple tarball with run and result
             run_id = str(uuid4())
             result_id = str(uuid4())
 
@@ -1207,59 +1389,42 @@ class TestRunArchiveImport:
                 "start_time": datetime.now(UTC).isoformat(),
             }
 
-            # Create tarball
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                # Add run.json
-                run_json = json.dumps(run_data).encode()
-                run_info = tarfile.TarInfo(name=f"{run_id}/run.json")
-                run_info.size = len(run_json)
-                tar.addfile(run_info, BytesIO(run_json))
-
-                # Add result.json
-                result_json = json.dumps(result_data).encode()
-                result_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
-                result_info.size = len(result_json)
-                tar.addfile(result_info, BytesIO(result_json))
-
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
             import_record = make_import(
                 filename="archive.tar.gz", format="ibutsu", status="pending"
             )
 
-            # Create import file
             import_file = ImportFile(
                 id=str(uuid4()),
                 import_id=import_record.id,
                 content=tar_content,
             )
 
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
-            # Mock celery tasks to avoid Redis dependency
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
                 patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
             ):
                 run_archive_import({"id": str(import_record.id)})
 
-            # Ensure cleanup task is invoked
             clear_mock.delay.assert_called_once_with(import_record.id)
 
-            # Verify run was created or updated
             run = db.session.get(Run, run_id)
             assert run is not None
 
-            # Verify result was created and original UUID was preserved
             result = db.session.get(Result, result_id)
             assert result is not None
             assert result.test_id == "test.example"
             assert result.run_id == run.id
 
-            # Verify import status
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "done"
 
@@ -1286,26 +1451,13 @@ class TestRunArchiveImport:
                 "metadata": {"component": "backend", "env": "stage"},
             }
 
-            # Create tarball with artifact
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                run_json = json.dumps(run_data).encode()
-                run_info = tarfile.TarInfo(name=f"{run_id}/run.json")
-                run_info.size = len(run_json)
-                tar.addfile(run_info, BytesIO(run_json))
-
-                result_json = json.dumps(result_data).encode()
-                result_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
-                result_info.size = len(result_json)
-                tar.addfile(result_info, BytesIO(result_json))
-
-                artifact_content = b"log output line"
-                art_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/traceback.log")
-                art_info.size = len(artifact_content)
-                tar.addfile(art_info, BytesIO(artifact_content))
-
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                    f"{run_id}/{result_id}/traceback.log": b"log output line",
+                }
+            )
 
             # First import
             import_record1 = make_import(
@@ -1314,8 +1466,8 @@ class TestRunArchiveImport:
             import_file1 = ImportFile(
                 id=str(uuid4()), import_id=import_record1.id, content=tar_content
             )
-            session.add(import_file1)
-            session.commit()
+            db.session.add(import_file1)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1323,7 +1475,6 @@ class TestRunArchiveImport:
             ):
                 run_archive_import({"id": str(import_record1.id)})
 
-            # Verify initial counts
             all_results = (
                 db.session.execute(db.select(Result).where(Result.run_id == run_id)).scalars().all()
             )
@@ -1346,8 +1497,8 @@ class TestRunArchiveImport:
             import_file2 = ImportFile(
                 id=str(uuid4()), import_id=import_record2.id, content=tar_content
             )
-            session.add(import_file2)
-            session.commit()
+            db.session.add(import_file2)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1355,7 +1506,6 @@ class TestRunArchiveImport:
             ):
                 run_archive_import({"id": str(import_record2.id)})
 
-            # Verify no duplicates were created
             all_results_after = (
                 db.session.execute(db.select(Result).where(Result.run_id == run_id)).scalars().all()
             )
@@ -1378,12 +1528,69 @@ class TestRunArchiveImport:
                 filename="missing.tar.gz", format="ibutsu", status="pending"
             )
 
-            # Don't create import file
             run_archive_import({"id": str(import_record.id)})
 
-            # Verify status updated to error
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "error"
+
+    def test_run_archive_import_corrupt_archive_rolls_back_and_marks_error(
+        self, make_import, flask_app
+    ):
+        """A corrupt/non-tar archive must roll back, mark import error, and re-raise ReadError."""
+        client, _ = flask_app
+        with client.application.app_context():
+            import_record = make_import(
+                filename="corrupt.tar.gz", format="ibutsu", status="pending"
+            )
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=b"not a valid tar archive"
+            )
+            db.session.add(import_file)
+            db.session.commit()
+
+            with pytest.raises(tarfile.ReadError):
+                run_archive_import({"id": str(import_record.id)})
+
+            updated = db.session.get(Import, import_record.id)
+            assert updated.status == "error"
+
+    def test_run_archive_import_nested_artifact_paths(self, make_import, flask_app):
+        """Archive with nested artifact paths (e.g. subdir/nested.png) imports successfully."""
+        client, _ = flask_app
+        with client.application.app_context():
+            run_id = str(uuid4())
+            result_id = str(uuid4())
+
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": {"id": run_id, "summary": {"tests": 1}},
+                    f"{run_id}/{result_id}/result.json": {
+                        "id": result_id,
+                        "test_id": "test.nested_art",
+                        "result": "passed",
+                    },
+                    f"{run_id}/{result_id}/subfolder/screenshot.png": b"image-data",
+                }
+            )
+
+            import_record = make_import(filename="nested.tar.gz", format="ibutsu", status="pending")
+            import_file = ImportFile(
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
+            )
+            db.session.add(import_file)
+            db.session.commit()
+
+            with (
+                patch("ibutsu_server.tasks.importers.update_run"),
+                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
+            ):
+                run_archive_import({"id": str(import_record.id)})
+
+            art = db.session.execute(
+                db.select(Artifact).where(Artifact.result_id == result_id)
+            ).scalar_one()
+            assert art.filename == "screenshot.png"
+            assert art.content == b"image-data"
 
     def test_run_archive_import_error_rolls_back_and_marks_error(self, make_import, flask_app):
         """A failure during processing rolls back the run and marks the import errored"""
@@ -1401,27 +1608,20 @@ class TestRunArchiveImport:
                 "start_time": datetime.now(UTC).isoformat(),
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
             import_record = make_import(filename="boom.tar.gz", format="ibutsu", status="pending")
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
-            # Force a failure while creating results, after the run has been staged
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
                 patch("ibutsu_server.tasks.importers.clear_import_file_content") as clear_mock,
@@ -1433,12 +1633,9 @@ class TestRunArchiveImport:
             ):
                 run_archive_import({"id": str(import_record.id)})
 
-            # The run must not have been committed without its contents
             assert db.session.get(Run, run_id) is None
-            # The import must be marked error, not left stuck in "running"
             updated = db.session.get(Import, import_record.id)
             assert updated.status == "error"
-            # Cleanup must not run on a failed import
             clear_mock.delay.assert_not_called()
 
     def test_run_archive_import_with_none_data(self, make_import, flask_app):
@@ -1457,18 +1654,12 @@ class TestRunArchiveImport:
                 "start_time": datetime.now(UTC).isoformat(),
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
             import_record = make_import(
                 filename="none_data.tar.gz", format="ibutsu", status="pending"
@@ -1502,7 +1693,6 @@ class TestRunArchiveImport:
             run_id = str(uuid4())
             result_id = str(uuid4())
 
-            # Pre-existing run and result with metadata that the archive won't contain
             make_run(id=run_id, metadata={"build": "1"})
             make_result(
                 id=result_id,
@@ -1521,25 +1711,19 @@ class TestRunArchiveImport:
                 "metadata": {"component": "backend", "env": "stage"},
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
             import_record = make_import(filename="keep.tar.gz", format="ibutsu", status="pending")
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1548,19 +1732,16 @@ class TestRunArchiveImport:
                 run_archive_import({"id": str(import_record.id)})
 
             result = db.session.get(Result, result_id)
-            # Existing-only metadata key must survive the re-import
             assert result.data["classification"] == "product_failure"
-            # Incoming metadata key must be merged in
             assert result.data["env"] == "stage"
-            # Updated fields from the archive must be applied
             assert result.result == "failed"
 
-    def test_run_archive_import_with_null_result_metadata(
-        self, make_import, make_run, make_result, flask_app
+    @pytest.mark.parametrize("null_target", ["result", "run", "both"])
+    def test_run_archive_import_with_null_metadata(
+        self, make_import, make_run, make_result, flask_app, null_target
     ):
-        """Re-importing where result.json has metadata: null must not raise TypeError."""
+        """Archive where run.json or result.json has metadata: null must import gracefully."""
         client, _ = flask_app
-
         with client.application.app_context():
             run_id = str(uuid4())
             result_id = str(uuid4())
@@ -1574,27 +1755,25 @@ class TestRunArchiveImport:
                 metadata={"component": "backend"},
             )
 
-            run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
+            run_data = {
+                "id": run_id,
+                "metadata": None if null_target in ("run", "both") else {"build": "1"},
+                "summary": {"tests": 1},
+            }
             result_data = {
                 "id": result_id,
                 "test_id": "test.null_meta",
                 "result": "passed",
                 "start_time": datetime.now(UTC).isoformat(),
-                "metadata": None,
+                "metadata": None if null_target in ("result", "both") else {"component": "backend"},
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
             import_record = make_import(
                 filename="null_meta.tar.gz", format="ibutsu", status="pending"
@@ -1602,57 +1781,8 @@ class TestRunArchiveImport:
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
-
-            with (
-                patch("ibutsu_server.tasks.importers.update_run"),
-                patch("ibutsu_server.tasks.importers.clear_import_file_content"),
-            ):
-                run_archive_import({"id": str(import_record.id)})
-
-            result = db.session.get(Result, result_id)
-            assert result is not None
-            assert result.data["component"] == "backend"
-
-    def test_run_archive_import_with_null_run_metadata(self, make_import, make_run, flask_app):
-        """Archive where run.json has metadata: null must not raise AttributeError."""
-        client, _ = flask_app
-
-        with client.application.app_context():
-            run_id = str(uuid4())
-            result_id = str(uuid4())
-
-            run_data = {"id": run_id, "metadata": None, "summary": {"tests": 1}}
-            result_data = {
-                "id": result_id,
-                "test_id": "test.null_run_meta",
-                "result": "passed",
-                "start_time": datetime.now(UTC).isoformat(),
-                "metadata": {"component": "backend"},
-            }
-
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
-
-            import_record = make_import(
-                filename="null_run_meta.tar.gz", format="ibutsu", status="pending"
-            )
-            import_file = ImportFile(
-                id=str(uuid4()), import_id=import_record.id, content=tar_content
-            )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1661,8 +1791,9 @@ class TestRunArchiveImport:
                 run_archive_import({"id": str(import_record.id)})
 
             run = db.session.get(Run, run_id)
+            result = db.session.get(Result, result_id)
             assert run is not None
-            assert run.data == {}
+            assert result is not None
 
     def test_run_archive_import_preserves_existing_env_and_component(
         self, make_import, make_run, make_result, flask_app
@@ -1674,7 +1805,6 @@ class TestRunArchiveImport:
             run_id = str(uuid4())
             result_id = str(uuid4())
 
-            # Pre-existing run and result with env and component set on the database record
             make_run(id=run_id, metadata={"build": "1"})
             make_result(
                 id=result_id,
@@ -1685,7 +1815,6 @@ class TestRunArchiveImport:
                 component="backend",
             )
 
-            # Archive whose result.json does not specify env or component
             run_data = {"id": run_id, "metadata": {}, "summary": {"tests": 1}}
             result_data = {
                 "id": result_id,
@@ -1695,18 +1824,12 @@ class TestRunArchiveImport:
                 "metadata": {},
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
             import_record = make_import(
                 filename="preserve.tar.gz", format="ibutsu", status="pending"
@@ -1714,8 +1837,8 @@ class TestRunArchiveImport:
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1746,21 +1869,18 @@ class TestRunArchiveImport:
                 "metadata": {"env": "prod"},
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                data = json.dumps(result_data).encode()
-                info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
-                info.size = len(data)
-                tar.addfile(info, BytesIO(data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
             import_record = make_import(filename="no_run.tar.gz", format="ibutsu", status="pending")
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1779,8 +1899,8 @@ class TestRunArchiveImport:
             import_file_2 = ImportFile(
                 id=str(uuid4()), import_id=import_record_2.id, content=tar_content
             )
-            session.add(import_file_2)
-            session.commit()
+            db.session.add(import_file_2)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1803,7 +1923,6 @@ class TestRunArchiveImport:
             result_id = str(uuid4())
 
             run_data = {"id": run_id, "summary": {"tests": 1}}
-            # Omit or provide non-UUID 'id' from result.json payload
             result_data = {
                 "test_id": "test.missing_id_key",
                 "result": "passed",
@@ -1813,23 +1932,13 @@ class TestRunArchiveImport:
             if id_in_json:
                 result_data["id"] = id_in_json
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-                # Add an artifact for this result
-                artifact_data = b"artifact log"
-                art_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/log.txt")
-                art_info.size = len(artifact_data)
-                tar.addfile(art_info, BytesIO(artifact_data))
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                    f"{run_id}/{result_id}/log.txt": b"artifact log",
+                }
+            )
 
             import_record = make_import(
                 filename="missing_res_id.tar.gz", format="ibutsu", status="pending"
@@ -1837,8 +1946,8 @@ class TestRunArchiveImport:
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1877,25 +1986,13 @@ class TestRunArchiveImport:
                 "start_time": datetime.now(UTC).isoformat(),
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
-
-                # Add a run-level artifact
-                run_art_content = b"run-level log content"
-                run_art_info = tarfile.TarInfo(name=f"{run_id}/console.log")
-                run_art_info.size = len(run_art_content)
-                tar.addfile(run_art_info, BytesIO(run_art_content))
-
-            tar_buffer.seek(0)
-            tar_content = tar_buffer.read()
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                    f"{run_id}/console.log": b"run-level log content",
+                }
+            )
 
             import_record = make_import(
                 filename="run_art.tar.gz", format="ibutsu", status="pending"
@@ -1903,8 +2000,8 @@ class TestRunArchiveImport:
             import_file = ImportFile(
                 id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1912,7 +2009,6 @@ class TestRunArchiveImport:
             ):
                 run_archive_import({"id": str(import_record.id)})
 
-            # Check that run-level artifact was stored
             art = db.session.execute(
                 db.select(Artifact).where(
                     Artifact.run_id == run_id, Artifact.filename == "console.log"
@@ -1929,8 +2025,8 @@ class TestRunArchiveImport:
             import_file2 = ImportFile(
                 id=str(uuid4()), import_id=import_record2.id, content=tar_content
             )
-            session.add(import_file2)
-            session.commit()
+            db.session.add(import_file2)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -1957,7 +2053,6 @@ class TestRunArchiveImport:
             run_id = str(uuid4())
             result_id = str(uuid4())
 
-            # run.json without 'id' field
             run_data = {"summary": {"tests": 1}}
             result_data = {
                 "id": result_id,
@@ -1966,26 +2061,21 @@ class TestRunArchiveImport:
                 "start_time": datetime.now(UTC).isoformat(),
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
-            tar_buffer.seek(0)
             import_record = make_import(
                 filename="no_run_id_field.tar.gz", format="ibutsu", status="pending"
             )
             import_file = ImportFile(
-                id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read()
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -2018,18 +2108,13 @@ class TestRunArchiveImport:
                 },
             }
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                for name, payload in [
-                    (f"{run_id}/run.json", run_data),
-                    (f"{run_id}/{result_id}/result.json", result_data),
-                ]:
-                    data = json.dumps(payload).encode()
-                    info = tarfile.TarInfo(name=name)
-                    info.size = len(data)
-                    tar.addfile(info, BytesIO(data))
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/run.json": run_data,
+                    f"{run_id}/{result_id}/result.json": result_data,
+                }
+            )
 
-            tar_buffer.seek(0)
             import_record = make_import(
                 filename="user_props.tar.gz", format="ibutsu", status="pending"
             )
@@ -2037,12 +2122,12 @@ class TestRunArchiveImport:
                 "metadata": {"imported_by": "automation"},
                 "project_id": proj.id,
             }
-            session.add(import_record)
+            db.session.add(import_record)
             import_file = ImportFile(
-                id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read()
+                id=str(uuid4()), import_id=import_record.id, content=tar_content
             )
-            session.add(import_file)
-            session.commit()
+            db.session.add(import_file)
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -2065,29 +2150,23 @@ class TestRunArchiveImport:
             run_id = str(uuid4())
             result_id = str(uuid4())
 
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                dir_info = tarfile.TarInfo(name=f"{run_id}/")
-                dir_info.type = tarfile.DIRTYPE
-                tar.addfile(dir_info)
-
-                sub_dir_info = tarfile.TarInfo(name=f"{run_id}/{result_id}/")
-                sub_dir_info.type = tarfile.DIRTYPE
-                tar.addfile(sub_dir_info)
-
-                result_data = json.dumps(
-                    {"id": result_id, "test_id": "test.dir", "result": "passed"}
-                ).encode()
-                info = tarfile.TarInfo(name=f"{run_id}/{result_id}/result.json")
-                info.size = len(result_data)
-                tar.addfile(info, BytesIO(result_data))
-
-            tar_buffer.seek(0)
-            import_record = make_import(filename="dir.tar.gz", format="ibutsu", status="pending")
-            session.add(
-                ImportFile(id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read())
+            tar_content = make_archive_bytes(
+                {
+                    f"{run_id}/": "dir",
+                    f"{run_id}/{result_id}/": "dir",
+                    f"{run_id}/{result_id}/result.json": {
+                        "id": result_id,
+                        "test_id": "test.dir",
+                        "result": "passed",
+                    },
+                }
             )
-            session.commit()
+
+            import_record = make_import(filename="dir.tar.gz", format="ibutsu", status="pending")
+            db.session.add(
+                ImportFile(id=str(uuid4()), import_id=import_record.id, content=tar_content)
+            )
+            db.session.commit()
 
             with (
                 patch("ibutsu_server.tasks.importers.update_run"),
@@ -2113,23 +2192,57 @@ class TestRunArchiveImport:
         """Archive import raises ValueError and marks import as error on bad UUIDs."""
         client, _ = flask_app
         with client.application.app_context():
-            tar_buffer = BytesIO()
-            with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
-                payload = b"{}"
-                info = tarfile.TarInfo(name=bad_member_name)
-                info.size = len(payload)
-                tar.addfile(info, BytesIO(payload))
+            tar_content = make_archive_bytes({bad_member_name: b"{}"})
 
-            tar_buffer.seek(0)
             import_record = make_import(
                 filename="bad_uuid.tar.gz", format="ibutsu", status="pending"
             )
-            session.add(
-                ImportFile(id=str(uuid4()), import_id=import_record.id, content=tar_buffer.read())
+            db.session.add(
+                ImportFile(id=str(uuid4()), import_id=import_record.id, content=tar_content)
             )
-            session.commit()
+            db.session.commit()
 
             with pytest.raises(ValueError, match=error_match):
                 run_archive_import({"id": str(import_record.id)})
 
             assert db.session.get(Import, import_record.id).status == "error"
+
+
+class TestExtractRunId:
+    """Tests for _extract_run_id helper function"""
+
+    def test_extract_run_id_from_data_list(self):
+        rec = Import(data={"run_id": ["550e8400-e29b-41d4-a716-446655440000"]})
+        assert _extract_run_id(rec) == "550e8400-e29b-41d4-a716-446655440000"
+
+    def test_extract_run_id_from_data_str(self):
+        rec = Import(data={"run_id": "550e8400-e29b-41d4-a716-446655440000"})
+        assert _extract_run_id(rec) == "550e8400-e29b-41d4-a716-446655440000"
+
+    def test_extract_run_id_from_filename(self):
+        rec = Import(filename="junit-550e8400-e29b-41d4-a716-446655440000.xml")
+        assert _extract_run_id(rec) == "550e8400-e29b-41d4-a716-446655440000"
+
+    def test_extract_run_id_none(self):
+        rec = Import(filename="plain.xml")
+        assert _extract_run_id(rec) is None
+
+
+class TestUpdateRunSummary:
+    """Tests for _update_run_summary helper function"""
+
+    def test_update_run_summary_populates_empty(self):
+        run = Run(duration=0, summary={"errors": 0, "failures": 0})
+        run_data = {
+            "duration": 12.5,
+            "errors": 1,
+            "failures": 2,
+            "skips": 0,
+            "xfailures": 0,
+            "xpasses": 0,
+            "tests": 3,
+        }
+        _update_run_summary(run, run_data)
+        assert run.duration == 12.5
+        assert run.summary["errors"] == 1
+        assert run.summary["failures"] == 2


### PR DESCRIPTION
## Summary by Sourcery

Make backend JUnit and archive imports safe to retry by preventing duplicate records, preserving imported data, and rolling back failed transactions cleanly.

Bug Fixes:
- Make JUnit and archive imports idempotent by updating existing runs, results, and artifacts instead of creating duplicates on retries.
- Ensure failed imports roll back all staged data and are marked as errored rather than leaving partial or running imports.
- Preserve and normalize importer metadata, environment, component, project, and source values across re-imports and incomplete input data.
- Handle archive paths and missing identifiers more robustly, including nested artifacts and IDs inferred from archive structure.
- Allow negative Celery retry limits to represent unlimited retries.

Enhancements:
- Consolidate importer persistence into single-transaction workflows with shared upsert and failure-handling logic.

Tests:
- Add extensive coverage for importer idempotency, artifact deduplication, rollback behavior, metadata preservation, malformed inputs, and archive edge cases.
- Test Celery retry behavior when retries are unlimited.