### PR TITLE
Remove pymongo dependency

### DIFF
--- a/backend/ibutsu_server/controllers/admin/project_controller.py
+++ b/backend/ibutsu_server/controllers/admin/project_controller.py
@@ -9,7 +9,7 @@ from ibutsu_server.db.models import Group, Project, User
 from ibutsu_server.filters import convert_filter
 from ibutsu_server.util.admin import validate_admin
 from ibutsu_server.util.query import get_offset
-from ibutsu_server.util.uuid import convert_objectid_to_uuid, is_uuid, validate_uuid
+from ibutsu_server.util.uuid import validate_uuid
 
 
 @validate_admin
@@ -117,6 +117,7 @@ def admin_get_project_list(
     }
 
 
+@validate_uuid
 @validate_admin
 def admin_update_project(id_, project=None, body=None, token_info=None, user=None):
     """Update a project
@@ -130,8 +131,6 @@ def admin_update_project(id_, project=None, body=None, token_info=None, user=Non
     """
     if not request.is_json:
         return RESPONSE_JSON_REQ
-    if not is_uuid(id_):
-        id_ = convert_objectid_to_uuid(id_)
     project = db.session.get(Project, id_)
 
     if not project:
@@ -170,9 +169,6 @@ def admin_update_project(id_, project=None, body=None, token_info=None, user=Non
 @validate_admin
 def admin_delete_project(id_, token_info=None, user=None):
     """Delete a single project"""
-    # UUID validation (from incoming branch)
-    if not is_uuid(id_):
-        return f"Project ID {id_} is not in UUID format", HTTPStatus.BAD_REQUEST
     project = db.session.get(Project, id_)
     if not project:
         abort(HTTPStatus.NOT_FOUND)

--- a/backend/ibutsu_server/controllers/project_controller.py
+++ b/backend/ibutsu_server/controllers/project_controller.py
@@ -10,7 +10,7 @@ from ibutsu_server.filters import convert_filter
 from ibutsu_server.util import flat_dict_keys
 from ibutsu_server.util.projects import add_user_filter, project_has_user
 from ibutsu_server.util.query import get_offset
-from ibutsu_server.util.uuid import convert_objectid_to_uuid, is_uuid, validate_uuid
+from ibutsu_server.util.uuid import validate_uuid
 
 
 def add_project(body=None, token_info=None, user=None):
@@ -47,8 +47,6 @@ def get_project(id_, token_info=None, user=None):
 
     :rtype: Project
     """
-    if not is_uuid(id_):
-        id_ = convert_objectid_to_uuid(id_)
     project = db.session.execute(db.select(Project).where(Project.name == id_)).scalar_one_or_none()
     if not project:
         project = db.session.get(Project, id_)
@@ -124,8 +122,6 @@ def update_project(id_, body=None, token_info=None, user=None, **_kwargs):
     """
     if not request.is_json:
         return RESPONSE_JSON_REQ
-    if not is_uuid(id_):
-        id_ = convert_objectid_to_uuid(id_)
     project = db.session.get(Project, id_)
 
     if not project:

--- a/backend/ibutsu_server/util/__init__.py
+++ b/backend/ibutsu_server/util/__init__.py
@@ -13,7 +13,6 @@ __all__ = [
     "json_response",
     "merge_dicts",
     "safe_string",
-    "serialize",
     "serialize_error",
 ]
 
@@ -209,19 +208,6 @@ def merge_dicts(old_dict, new_dict):
             new_dict[key] = value
         elif isinstance(value, dict) and isinstance(new_dict[key], dict):
             merge_dicts(value, new_dict[key])
-
-
-def serialize(mongo_dict):
-    """Serialize just converts the MongoDB "_id" ObjectId into a string "id" in a dictionary
-
-    :param mongo_dict: The dict from MongoDB
-    :type: mongo_dict: dict
-
-    :rtype: dict
-    """
-    if mongo_dict and "_id" in mongo_dict:
-        mongo_dict["id"] = str(mongo_dict.pop("_id"))
-    return mongo_dict
 
 
 def json_response(obj, status_code=200):

--- a/backend/ibutsu_server/util/uuid.py
+++ b/backend/ibutsu_server/util/uuid.py
@@ -1,12 +1,5 @@
-from datetime import UTC, datetime
 from http import HTTPStatus
 from uuid import UUID
-
-from bson import ObjectId
-
-UUID_1_EPOCH = datetime(1582, 10, 15, tzinfo=UTC)
-UUID_TICKS = 10000000
-UUID_VARIANT_1 = 0b1000000000000000
 
 
 def is_uuid(candidate):
@@ -28,21 +21,3 @@ def validate_uuid(function):
         return function(**kwargs)
 
     return validate
-
-
-def convert_objectid_to_uuid(object_id):
-    """Convert an ObjectId to a UUID"""
-    if isinstance(object_id, str) and not is_uuid(object_id) and ObjectId.is_valid(object_id):
-        object_id = ObjectId(object_id)
-    if not isinstance(object_id, ObjectId):
-        return object_id
-    unix_time = object_id.generation_time.astimezone(UTC)
-    hex_string = str(object_id)
-    counter = int(hex_string[18:], 16)
-
-    uuid_time = f"1{int((unix_time + (unix_time - UUID_1_EPOCH)).timestamp() * UUID_TICKS):015x}"
-    uuid_clock = f"{UUID_VARIANT_1 | (counter & 0x3FFF):04x}"
-    uuid_node = "1" + hex_string[8:18].rjust(11, "0")
-    string_uuid = f"{uuid_time[-8:]}-{uuid_time[4:8]}-{uuid_time[:4]}-{uuid_clock}-{uuid_node}"
-    converted_uuid = UUID(string_uuid)
-    return str(converted_uuid)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
     "lxml",
     "psycopg2-binary",
     "pyjwt",
-    "pymongo",
     "python-magic",
     "python_dateutil",
     "PyYAML",

--- a/backend/requirements-pinned.txt
+++ b/backend/requirements-pinned.txt
@@ -56,8 +56,6 @@ connexion==3.3.0
     # via ibutsu-server (pyproject.toml)
 cryptography==50.0.1
     # via google-auth
-dnspython==2.8.0
-    # via pymongo
 flask==3.1.3
     # via
     #   ibutsu-server (pyproject.toml)
@@ -161,8 +159,6 @@ pyasn1-modules==0.4.2
 pycparser==3.0
     # via cffi
 pyjwt==2.13.0
-    # via ibutsu-server (pyproject.toml)
-pymongo==4.17.0
     # via ibutsu-server (pyproject.toml)
 pyparsing==3.3.2
     # via httplib2

--- a/backend/tests/controllers/test_admin_project_controller.py
+++ b/backend/tests/controllers/test_admin_project_controller.py
@@ -270,42 +270,37 @@ def test_admin_update_project_success(flask_app, make_project, make_user, auth_h
         assert str(new_user.id) in user_ids
 
 
-def test_admin_update_project_not_found(flask_app, auth_headers):
-    """Test case for admin_update_project - project not found"""
+@pytest.mark.validation
+@pytest.mark.parametrize(
+    ("project_id", "expected_status", "description"),
+    [
+        ("not-a-uuid", HTTPStatus.BAD_REQUEST, "Invalid UUID format triggers validation error"),
+        (
+            "507f1f77bcf86cd799439011",
+            HTTPStatus.BAD_REQUEST,
+            "ObjectId format triggers validation error",
+        ),
+        (
+            "00000000-0000-0000-0000-000000000000",
+            HTTPStatus.NOT_FOUND,
+            "Valid UUID format but project not found",
+        ),
+    ],
+)
+def test_admin_update_project_validation_errors(
+    flask_app, project_id, expected_status, description, auth_headers
+):
+    """Test case for admin_update_project validation errors - parametrized"""
     client, jwt_token = flask_app
 
     update_data = {"title": "Updated Project Title"}
     headers = auth_headers(jwt_token)
-
     response = client.put(
-        "/api/admin/project/00000000-0000-0000-0000-000000000000",
+        f"/api/admin/project/{project_id}",
         headers=headers,
         json=update_data,
     )
-
-    assert response.status_code == HTTPStatus.NOT_FOUND
-
-
-def test_admin_update_project_converts_objectid(flask_app, make_project, auth_headers):
-    """Test case for admin_update_project - converts ObjectId to UUID"""
-    client, jwt_token = flask_app
-
-    # Create project
-    make_project(name="test-project", title="Original Title")
-
-    # Use ObjectId format
-    object_id = "507f1f77bcf86cd799439011"
-
-    update_data = {"title": "Updated Project Title"}
-    headers = auth_headers(jwt_token)
-    response = client.put(
-        f"/api/admin/project/{object_id}",
-        headers=headers,
-        json=update_data,
-    )
-
-    # ObjectId conversion should happen and fail gracefully if no project found
-    assert response.status_code in [200, 400, 404]
+    assert response.status_code == expected_status, description
 
 
 def test_admin_delete_project_success(flask_app, make_project, auth_headers):

--- a/backend/tests/test_util.py
+++ b/backend/tests/test_util.py
@@ -2,13 +2,11 @@
 
 import contextlib
 import datetime
-import uuid
 from collections import OrderedDict
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
 
 import pytest
-from bson import ObjectId
 from werkzeug.exceptions import BadRequest, Forbidden, InternalServerError, NotFound, Unauthorized
 
 from ibutsu_server.db import db
@@ -40,7 +38,6 @@ from ibutsu_server.util import (
     json_response,
     merge_dicts,
     safe_string,
-    serialize,
     serialize_error,
 )
 from ibutsu_server.util.admin import validate_admin
@@ -55,7 +52,7 @@ from ibutsu_server.util.projects import (
 from ibutsu_server.util.query import query_as_task
 from ibutsu_server.util.redis_lock import get_redis_client, is_locked
 from ibutsu_server.util.urls import build_url
-from ibutsu_server.util.uuid import convert_objectid_to_uuid, is_uuid, validate_uuid
+from ibutsu_server.util.uuid import is_uuid, validate_uuid
 from ibutsu_server.util.widget import (
     create_basic_summary_columns,
     create_jenkins_columns,
@@ -382,27 +379,6 @@ def test_merge_dicts_with_none_values():
     new_dict = {"a": None, "c": 3}
     merge_dicts(old_dict, new_dict)
     assert new_dict == {"a": 1, "b": 2, "c": 3}
-
-
-@pytest.mark.parametrize(
-    ("input_data", "expected_output", "check_id"),
-    [
-        (
-            {"_id": ObjectId("507f1f77bcf86cd799439011"), "name": "test"},
-            {"id": "507f1f77bcf86cd799439011", "name": "test"},
-            True,
-        ),
-        ({"name": "test", "value": 123}, {"name": "test", "value": 123}, False),
-        (None, None, False),
-    ],
-)
-def test_serialize(input_data, expected_output, check_id):
-    """Test serialize with various input types."""
-    result = serialize(input_data)
-    if check_id:
-        assert "_id" not in result
-        assert "id" in result
-    assert result == expected_output
 
 
 def test_json_response_default():
@@ -827,49 +803,6 @@ class TestRedisLock:
 
 
 # Tests for util/uuid.py
-
-
-class TestConvertObjectIdToUuid:
-    """Tests for convert_objectid_to_uuid function."""
-
-    def test_convert_objectid_to_uuid_string(self):
-        """Test convert_objectid_to_uuid with ObjectId string."""
-        # Valid ObjectId string
-        object_id_str = "507f1f77bcf86cd799439011"
-        result = convert_objectid_to_uuid(object_id_str)
-
-        # Should return a valid UUID string - verify by parsing with uuid.UUID
-        assert result is not None
-        parsed_uuid = uuid.UUID(result)  # Raises ValueError if not a valid UUID
-        assert str(parsed_uuid) == result, "Result should be a properly formatted UUID string"
-
-    def test_convert_objectid_to_uuid_object(self):
-        """Test convert_objectid_to_uuid with ObjectId object."""
-        object_id = ObjectId("507f1f77bcf86cd799439011")
-        result = convert_objectid_to_uuid(object_id)
-
-        # Should return a valid UUID string - verify by parsing with uuid.UUID
-        assert result is not None
-        parsed_uuid = uuid.UUID(result)  # Raises ValueError if not a valid UUID
-        assert str(parsed_uuid) == result, "Result should be a properly formatted UUID string"
-
-    def test_convert_objectid_to_uuid_with_uuid_string(self):
-        """Test convert_objectid_to_uuid with UUID string (no conversion)."""
-        uuid_str = "507f1f77-bcf8-6cd7-9943-901100000000"
-        result = convert_objectid_to_uuid(uuid_str)
-
-        # Should return original UUID string unchanged
-        assert result == uuid_str
-        # Verify it's still a valid UUID
-        parsed_uuid = uuid.UUID(result)
-        assert str(parsed_uuid) == result
-
-    def test_convert_objectid_to_uuid_with_invalid_input(self):
-        """Test convert_objectid_to_uuid with non-ObjectId input."""
-
-        # Should return input unchanged if not ObjectId
-        result = convert_objectid_to_uuid(12345)
-        assert result == 12345
 
 
 class TestIsUuid:


### PR DESCRIPTION
replace bson ObjectId with pure python parsing
remove convert_objectid_to_uuid from the controller

Reviewing data on production DB backups for any lingering objectID data. It should have all been migrated years ago.

FIXES #1109 

## Summary by Sourcery

Remove the remaining MongoDB ObjectId compatibility code and dependency in favor of UUID-only project identifiers.

Enhancements:
- Remove legacy MongoDB ObjectId compatibility and require UUID-formatted project identifiers for project updates.
- Delete obsolete MongoDB serialization and ObjectId-to-UUID utility functionality.

Build:
- Remove pymongo from the backend dependencies and pinned requirements.

Tests:
- Update project controller tests to verify invalid and legacy ObjectId identifiers are rejected while valid UUIDs continue to return not-found responses when absent.